### PR TITLE
Don't use target blank for external links

### DIFF
--- a/web/template/header.gohtml
+++ b/web/template/header.gohtml
@@ -36,7 +36,7 @@
                 </a>
             </div>
             <div>
-                <a class="mr-3" target="_blank" rel="noopener" href="https://github.com/joschahenningsen/TUM-Live"><i
+                <a class="mr-3" rel="noopener" href="https://github.com/joschahenningsen/TUM-Live"><i
                             class="text-white fab fa-github"></i></a>
             </div>
         </div>


### PR DESCRIPTION
Its annoying by breaking navigating back/forward and people should usually use their middle mouse to open a new tab.