### PR TITLE
Bundle version revision into executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,6 @@ web/assets/css-dist
 
 # secrets
 variables-backend.env
-hash.env
 rebuild.sh
 
 tumlive.service

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 all: npm_dependencies go_dependencies bundle
 
+VERSION := $(shell git rev-parse --short HEAD)
+
 npm_dependencies:
 	cd web; \
 	npm i --no-dev;
@@ -8,13 +10,10 @@ go_dependencies:
 	go get ./...
 
 bundle:
-	go build app/server/main.go
+	go build -ldflags="-X 'main.VersionTag=$(VERSION)'" app/server/main.go
 
 clean:
 	rm -fr web/node_modules
 
-version:
-	echo "hash=$$(git rev-parse --short origin/HEAD)\c" > hash.env
-
-install: version
+install:
 	mv main /bin/tum-live

--- a/app/server/main.go
+++ b/app/server/main.go
@@ -28,6 +28,8 @@ import (
 	"time"
 )
 
+var VersionTag = "development"
+
 const UserKey = "RBG-Default-User" // UserKey key used for storing User struct in context
 
 // GinServer launch gin server
@@ -67,6 +69,7 @@ func (u *User) String() string {
 }
 
 func main() {
+	web.VersionTag = VersionTag
 	OsSignal = make(chan os.Signal, 1)
 
 	goopt.Parse(nil)
@@ -75,7 +78,7 @@ func main() {
 	}
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:              os.Getenv("SentryDSN"),
-		Release:          os.Getenv("hash"),
+		Release:          VersionTag,
 		TracesSampleRate: 0.1,
 		Debug:            true,
 		AttachStacktrace: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
         target: /recordings
     env_file:
       - variables-backend.env
-      - hash.env
     restart: always
 
   db:

--- a/tumlive.example.service
+++ b/tumlive.example.service
@@ -6,7 +6,6 @@ Requires=mariadb.service
 [Service]
 LimitNOFILE=1048576:2097152
 EnvironmentFile=/path/to/your/variables-backend.env
-EnvironmentFile=/path/to/your/hash.env
 Type=simple
 ExecStart=/bin/tum-live
 TimeoutStopSec=5

--- a/web/index.go
+++ b/web/index.go
@@ -9,9 +9,10 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-gonic/gin"
 	"net/http"
-	"os"
 	"strconv"
 )
+
+var VersionTag string
 
 func MainPage(c *gin.Context) {
 	tName := sentry.TransactionName("GET /")
@@ -106,7 +107,7 @@ func MainPage(c *gin.Context) {
 
 func AboutPage(c *gin.Context) {
 	var indexData IndexData
-	indexData.VersionTag = os.Getenv("hash")
+	indexData.VersionTag = VersionTag
 	u, userErr := tools.GetUser(c)
 	_, studentErr := tools.GetStudent(c)
 	if userErr == nil {
@@ -135,7 +136,7 @@ type IndexData struct {
 
 func NewIndexData() IndexData {
 	return IndexData{
-		VersionTag: os.Getenv("hash"),
+		VersionTag: VersionTag,
 	}
 }
 

--- a/web/router.go
+++ b/web/router.go
@@ -5,7 +5,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"html/template"
 	"net/http"
-	"os"
 )
 
 var templ *template.Template
@@ -57,7 +56,7 @@ func configCourseRoute(router gin.IRoutes) {
 }
 
 func HealthCheck(context *gin.Context) {
-	context.JSON(http.StatusOK, gin.H{"version": os.Getenv("hash")})
+	context.JSON(http.StatusOK, gin.H{"version": VersionTag})
 }
 
 type ErrorPageData struct {


### PR DESCRIPTION
Followup to #74 

This PR makes changes to bake the revision at build right into the executable instead of using an env-file that could very well change at runtime. 

One question remains: does the server merge local env commits into the local repository before or after the `make bundle` target? If before, `HEAD` in the Makefile again needs to be changed to `origin/HEAD`, otherwise fine as-is.