### PR TITLE
web/template/watch.gohtml: Remove player padding-top.

### DIFF
--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -16,7 +16,7 @@
 </head>
 <body class="bg-primary h-full overflow-hidden">
 {{template "header" .IndexData.TUMLiveContext}}
-<div class="flex h-full md:flex-row w-full flex-wrap pt-20">
+<div class="flex h-full md:flex-row w-full flex-wrap">
     <input type="hidden" id="streamID" value="{{$stream.Model.ID}}">
     <div id="watchWrapper"
          class="watchContent w-full pt-3 px-2 md:px-8 {{if $course.ChatEnabled}}md:w-4/6{{end}} lg:w-8/12 2xl:max-w-screen-xl mx-auto mx:h-full overflow-scroll overflow-x-hidden">


### PR DESCRIPTION
Hi :)

The `pt-20` class adds a rather huge padding-top (5rem) above the player
which is especially inconvenient when using the "big picture mode".
This commit removes the `pt-20` class from the enclosing div.

Feedback would be greatly appreciated, thank you for your work! :heart: 