### PR TITLE
Make "Log in" in "Log in to see your courses" clickable

### DIFF
--- a/web/template/index.gohtml
+++ b/web/template/index.gohtml
@@ -24,7 +24,7 @@
         <p class="text-yellow-400"><i class="fas fa-exclamation-triangle mr-2"></i><span>The previous version of this website is still available at <a href="https://oldlive.mm.rbg.tum.de" class="underline">https://oldlive.mm.rbg.tum.de</a>, if you miss anything on this website let us know! <a class="underline" href="mailto:live@rbg.tum.de">live@rbg.tum.de</a> :)</span></p>
     {{end}}
     {{if not .TUMLiveContext.User}}
-        <p class="text-2">Log in to see your courses</p>
+        <p class="text-2"><a href="/login">Log in</a> to see your courses</p>
     {{else if .TUMLiveContext.User.Name}}
         <p class="text-2">Moin {{.TUMLiveContext.User.Name}}, nice to see you!</p>
     {{end}}

--- a/web/template/index.gohtml
+++ b/web/template/index.gohtml
@@ -24,7 +24,7 @@
         <p class="text-yellow-400"><i class="fas fa-exclamation-triangle mr-2"></i><span>The previous version of this website is still available at <a href="https://oldlive.mm.rbg.tum.de" class="underline">https://oldlive.mm.rbg.tum.de</a>, if you miss anything on this website let us know! <a class="underline" href="mailto:live@rbg.tum.de">live@rbg.tum.de</a> :)</span></p>
     {{end}}
     {{if not .TUMLiveContext.User}}
-        <p class="text-2"><a href="/login">Log in</a> to see your courses</p>
+        <p class="text-2"><a href="/login" class="underline">Log in</a> to see your courses</p>
     {{else if .TUMLiveContext.User.Name}}
         <p class="text-2">Moin {{.TUMLiveContext.User.Name}}, nice to see you!</p>
     {{end}}


### PR DESCRIPTION
I have heard from a few people (and experienced myself) that it is unintutive that the text telling you to log in does not itself contain a link to the login page.
Feel free to delete if you disagree, but in my opinion this should be a minor usability improvement.