### PR TITLE
Allow disabling anonymous messages

### DIFF
--- a/api/chat.go
+++ b/api/chat.go
@@ -60,7 +60,7 @@ func configGinChatRouter(router *gin.RouterGroup) {
 			return
 		}
 		uname := tumLiveContext.User.Name
-		if chat.Anonymous {
+		if chat.Anonymous && tumLiveContext.Course.AnonymousChatEnabled {
 			uname = "Anonymous"
 		}
 		dao.AddMessage(model.Chat{

--- a/api/wsHub.go
+++ b/api/wsHub.go
@@ -34,6 +34,14 @@ var connHandler = func(s *melody.Session) {
 	if err != nil {
 		log.WithError(err).Error("can't write initial stats to session")
 	}
+	if tumLiveContext.Course.ChatEnabled {
+		// todo: edit this message through the admin interface
+		msg, _ := json.Marshal(gin.H{"server": "Welcome to the chatroom! If you want this feature to stay active, please be nice to each other and stay on topic."})
+		err := s.Write(msg)
+		if err != nil {
+			return
+		}
+	}
 }
 
 func BroadcastStats() {

--- a/api/wsHub.go
+++ b/api/wsHub.go
@@ -34,14 +34,6 @@ var connHandler = func(s *melody.Session) {
 	if err != nil {
 		log.WithError(err).Error("can't write initial stats to session")
 	}
-	if tumLiveContext.Course.ChatEnabled {
-		// todo: edit this message through the admin interface
-		msg, _ := json.Marshal(gin.H{"server": "Welcome to the chatroom! If you want this feature to stay active, please be nice to each other and stay on topic."})
-		err := s.Write(msg)
-		if err != nil {
-			return
-		}
-	}
 }
 
 func BroadcastStats() {

--- a/model/course.go
+++ b/model/course.go
@@ -20,6 +20,7 @@ type Course struct {
 	VODEnabled              bool
 	DownloadsEnabled        bool
 	ChatEnabled             bool
+	AnonymousChatEnabled    bool `gorm:"not null;default:true"`
 	VodChatEnabled          bool
 	Visibility              string // public, loggedin or enrolled
 	Streams                 []Stream

--- a/web/admin.go
+++ b/web/admin.go
@@ -219,10 +219,12 @@ func UpdateCourse(c *gin.Context) {
 	enVOD := c.PostForm("enVOD") == "on"
 	enDL := c.PostForm("enDL") == "on"
 	enChat := c.PostForm("enChat") == "on"
+	enChatAnon := c.PostForm("enChatAnon") == "on"
 	tumLiveContext.Course.Visibility = access
 	tumLiveContext.Course.VODEnabled = enVOD
 	tumLiveContext.Course.DownloadsEnabled = enDL
 	tumLiveContext.Course.ChatEnabled = enChat
+	tumLiveContext.Course.AnonymousChatEnabled = enChatAnon
 	dao.UpdateCourseMetadata(context.Background(), *tumLiveContext.Course)
 	c.Redirect(http.StatusFound, fmt.Sprintf("/admin/course/%v", tumLiveContext.Course.ID))
 }

--- a/web/template/admin/course_settings.gohtml
+++ b/web/template/admin/course_settings.gohtml
@@ -24,7 +24,7 @@
                    value="hidden"
                     {{if .}} {{if eq .Visibility "hidden"}}checked{{end}}{{end}}>
             <span>Hidden: only visible for users with this link: <br><a class="underline"
-                        href="https://live.rbg.tum.de/course/{{.Year}}/{{.TeachingTerm}}/{{.Slug}}">https://live.rbg.tum.de/course/{{.Year}}/{{.TeachingTerm}}/{{.Slug}}</a>
+                                                                        href="https://live.rbg.tum.de/course/{{.Year}}/{{.TeachingTerm}}/{{.Slug}}">https://live.rbg.tum.de/course/{{.Year}}/{{.TeachingTerm}}/{{.Slug}}</a>
             </span>
         </label>
     </div>
@@ -46,12 +46,24 @@
                 <span class="ml-2">Enable Downloads</span>
             </label>
         </div>
-        <div>
+        <div x-data="{enChat:{{.ChatEnabled}}}">
             <label class="inline-flex items-center" for="enChat">
-                <input class="w-auto form-checkbox" id="enChat" name="enChat" type="checkbox"
+                <input x-model="enChat"
+                       class="w-auto form-checkbox"
+                       id="enChat" name="enChat"
+                       type="checkbox"
                        {{if and . .ChatEnabled}}checked{{end}}
                         {{if not .}}checked{{end}}>
                 <span class="ml-2">Enable Live Chat</span>
+            </label>
+            <label class="inline-flex items-center pl-2" for="enChatAnon">
+                <input :disabled="!enChat"
+                       class="w-auto form-checkbox"
+                       id="enChatAnon" name="enChatAnon"
+                       type="checkbox"
+                       {{if and . .AnonymousChatEnabled}}checked{{end}}
+                        {{if not .}}checked{{end}}>
+                <span class="ml-2">Allow Anonymous Messages</span>
             </label>
         </div>
     </div>

--- a/web/template/partial/stream/chat.gohtml
+++ b/web/template/partial/stream/chat.gohtml
@@ -1,0 +1,40 @@
+{{define "chat"}}
+    {{- /*gotype: TUM-Live/web.WatchPageData*/ -}}
+    {{$stream := .IndexData.TUMLiveContext.Stream}}
+    <div id="chatWrapper"
+         class="hidden md:flex flex-col w-full md:h-full border-t-2 mt-2 md:mt-0 md:border-t-0 md:dark:border-l dark:border-secondary dark:bg-secondary-lighter bg-gray-100 md:w-2/6 lg:w-1/6 text-1 pt-3">
+        <div id="chatBox" class="overflow-scroll overflow-x-hidden overflow-y-scroll" style="flex: 2;">
+            {{range $chat := $stream.Chats}}
+                <div class="rounded p-2 mx-2">
+                    <div class="flex flex-row">
+                        <p class="flex-grow font-semibold {{if $chat.Admin}}text-warn{{end}}">{{$chat.UserName}}</p>
+                        <p class="text-4">
+                            {{printf "%02d:%02d" $chat.CreatedAt.Hour $chat.CreatedAt.Minute}}
+                        </p>
+                    </div>
+                    <p class="text-3 break-words">
+                        {{$chat.Message}}
+                    </p>
+                </div>
+            {{end}}
+        </div>
+        <form id="chatForm"
+              class="border-b-2 focus-within:border-gray-300 dark:border-secondary dark:bg-secondary-lighter inset-x-0 flex px-3"
+              style="">
+            {{if .IndexData.TUMLiveContext.Course.AnonymousChatEnabled}}
+                <input type="checkbox" name="anonymous" id="anonymous" class="hidden">
+                <label for="anonymous" class="flex items-center cursor-pointer text-4 hover:text-1"
+                       title="Don't show my name.">
+                    <i class="fas fa-ghost"></i>
+                </label>
+            {{end}}
+            <label for="chatInput" class="hidden">Chat input</label><input
+                    maxlength="200"
+                    {{if not (.IndexData.TUMLiveContext.User)}}disabled
+                    placeholder="Log in to chat" {{else}}
+                    placeholder="Send a message" {{end}}autocomplete="off" id="chatInput" type="text"
+                    class="border-none">
+            <button class="fas fa-paper-plane text-4 hover:text-1 focus:outline-none"></button>
+        </form>
+    </div>
+{{end}}

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -82,7 +82,8 @@
                                     class="fas fa-camera text-4 hover:text-1"></i></a>
                     {{end}}
                     {{if $stream.PlaylistUrl}}
-                        <a class="flex m-auto mr-2" title="Combined view" href="/w/{{$course.Slug}}/{{$stream.Model.ID}}"><i
+                        <a class="flex m-auto mr-2" title="Combined view"
+                           href="/w/{{$course.Slug}}/{{$stream.Model.ID}}"><i
                                     class="fas fa-object-group text-4 hover:text-1"></i></a>
                     {{end}}
                     <i title="Copy HLS URL"
@@ -132,40 +133,7 @@
         </div>
     </div>
     {{if $course.ChatEnabled}}
-        <div id="chatWrapper"
-             class="hidden md:flex flex-col w-full md:h-full border-t-2 mt-2 md:mt-0 md:border-t-0 md:dark:border-l dark:border-secondary dark:bg-secondary-lighter bg-gray-100 md:w-2/6 lg:w-1/6 text-1 pt-3">
-            <div id="chatBox" class="overflow-scroll overflow-x-hidden overflow-y-scroll" style="flex: 2;">
-                {{range $chat := $stream.Chats}}
-                    <div class="rounded p-2 mx-2">
-                        <div class="flex flex-row">
-                            <p class="flex-grow font-semibold {{if $chat.Admin}}text-warn{{end}}">{{$chat.UserName}}</p>
-                            <p class="text-4">
-                                {{printf "%02d:%02d" $chat.CreatedAt.Hour $chat.CreatedAt.Minute}}
-                            </p>
-                        </div>
-                        <p class="text-3 break-words">
-                            {{$chat.Message}}
-                        </p>
-                    </div>
-                {{end}}
-            </div>
-            <form id="chatForm"
-                  class="border-b-2 focus-within:border-gray-300 dark:border-secondary dark:bg-secondary-lighter inset-x-0 flex px-3"
-                  style="">
-                <input type="checkbox" name="anonymous" id="anonymous" class="hidden">
-                <label for="anonymous" class="flex items-center cursor-pointer text-4 hover:text-1"
-                       title="Don't show my name.">
-                    <i class="fas fa-ghost"></i>
-                </label>
-                <label for="chatInput" class="hidden">Chat input</label><input
-                        maxlength="200"
-                        {{if not (.IndexData.TUMLiveContext.User)}}disabled
-                        placeholder="Log in to chat" {{else}}
-                        placeholder="Send a message" {{end}}autocomplete="off" id="chatInput" type="text"
-                        class="border-none">
-                <button class="fas fa-paper-plane text-4 hover:text-1 focus:outline-none"></button>
-            </form>
-        </div>
+        {{template "chat" .}}
     {{end}}
 </div>
 
@@ -239,7 +207,7 @@
     });
 
     {{if and $stream.Recording .IndexData.TUMLiveContext.User}}
-        player.watchProgress({{$stream.Model.ID}}, {{.Progress.Progress}});
+    player.watchProgress({{$stream.Model.ID}}, {{.Progress.Progress}});
     {{end}}
 
     {{if $stream.Silences}}

--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -16,9 +16,10 @@ class Watch {
 
     submitChat(e: Event) {
         e.preventDefault();
+        const anonymousCheckBox: HTMLInputElement = document.getElementById("anonymous") as HTMLInputElement;
         ws.send(JSON.stringify({
             "msg": this.chatInput.value,
-            "anonymous": (document.getElementById("anonymous") as HTMLInputElement).checked
+            "anonymous": anonymousCheckBox ? anonymousCheckBox.checked : false,
         }))
         this.chatInput.value = "";
         return false;//prevent form submission

--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -13,17 +13,6 @@ class Watch {
             this.chatInput = document.getElementById("chatInput") as HTMLInputElement
         }
     }
-
-    submitChat(e: Event) {
-        e.preventDefault();
-        const anonymousCheckBox: HTMLInputElement = document.getElementById("anonymous") as HTMLInputElement;
-        ws.send(JSON.stringify({
-            "msg": this.chatInput.value,
-            "anonymous": anonymousCheckBox ? anonymousCheckBox.checked : false,
-        }))
-        this.chatInput.value = "";
-        return false;//prevent form submission
-    }
 }
 
 let ws: WebSocket;
@@ -106,9 +95,10 @@ function createMessageElement(m): HTMLDivElement {
 
 function submitChat(e: Event) {
     e.preventDefault();
+    const anonCheckbox: HTMLInputElement = document.getElementById("anonymous") as HTMLInputElement;
     ws.send(JSON.stringify({
         "msg": this.chatInput.value,
-        "anonymous": (document.getElementById("anonymous") as HTMLInputElement).checked
+        "anonymous": anonCheckbox ? anonCheckbox.checked : false,
     }))
     this.chatInput.value = "";
     return false;//prevent form submission


### PR DESCRIPTION
Some students tend to shitpost using the "anonymous" chat feature. Lecturers requested an option to disable anonymous messages. 