### PR TITLE
Increment go version

### DIFF
--- a/.idea/TUM-Live-Backend.iml
+++ b/.idea/TUM-Live-Backend.iml
@@ -2,7 +2,7 @@
 <module type="WEB_MODULE" version="4">
   <component name="Go" enabled="true">
     <buildTags>
-      <option name="goVersion" value="go1.16" />
+      <option name="goVersion" value="go1.17" />
     </buildTags>
   </component>
   <component name="NewModuleRootManager">


### PR DESCRIPTION
I saw that the GoLand configuration still used 1.16 instead of the current 1.17, so I updated it real quick. :relaxed: 