### PR TITLE
Optimize lecture schedule loading time

### DIFF
--- a/api/sexy.go
+++ b/api/sexy.go
@@ -12,7 +12,7 @@ func configGinSexyApiRouter(router gin.IRoutes) {
 }
 
 func getStreamInfo(context *gin.Context) {
-	courses, err := dao.GetAllCourses(false)
+	courses, err := dao.GetAllCourses()
 	if err != nil {
 		context.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"status": "something went wrong"})
 		return

--- a/api/template/ical.gotemplate
+++ b/api/template/ical.gotemplate
@@ -15,14 +15,14 @@ TZOFFSETFROM:+0100
 TZOFFSETTO:+0200
 RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=-1SU;BYMONTH=3
 END:DAYLIGHT
-END:VTIMEZONE{{- /*gotype: TUM-Live/api.ICALData*/ -}}{{$lectureHalls := .LectureHalls}}{{$courses := .Courses}}
-{{range $stream := .Streams}}BEGIN:VEVENT
-UID:sdfg9438wpwoskegt{{$stream.Model.ID}}
-DTSTART;TZID=W. Europe Standard Time:{{$stream.IsoStart}}
-DTEND;TZID=W. Europe Standard Time:{{$stream.IsoEnd}}
-DTSTAMP:{{$stream.IsoCreated}}
-LOCATION:{{if $stream.LectureHallID}}{{range $hall := $lectureHalls}}{{if eq $hall.Model.ID $stream.LectureHallID}}{{$hall.Name}}{{end}}{{end}}{{else}}Selfstream{{end}}
-SUMMARY:{{range $course := $courses}}{{if eq $course.Model.ID $stream.CourseID}}{{$course.Name}}{{end}}{{end}}
-DESCRIPTION:{{$stream.Model.ID}}
+END:VTIMEZONE
+{{range $event := .}}BEGIN:VEVENT
+UID:sdfg9438wpwoskegt{{$event.StreamID}}
+DTSTART;TZID=W. Europe Standard Time:{{$event.IsoStart}}
+DTEND;TZID=W. Europe Standard Time:{{$event.IsoEnd}}
+DTSTAMP:{{$event.IsoCreated}}
+LOCATION:{{if $event.LectureHallName}}{{$event.LectureHallName}}{{else}}Selfstream{{end}}
+SUMMARY:{{$event.CourseName}}
+DESCRIPTION:{{$event.StreamID}}
 END:VEVENT
 {{end}}END:VCALENDAR

--- a/dao/courses.go
+++ b/dao/courses.go
@@ -18,20 +18,13 @@ func GetCurrentOrNextLectureForCourse(ctx context.Context, courseID uint) (model
 }
 
 // GetAllCourses retrieves all courses from the database
-// @limit bool true if streams should be limited to -1 month, +3 months
-func GetAllCourses(limit bool) ([]model.Course, error) {
+func GetAllCourses() ([]model.Course, error) {
 	cachedCourses, found := Cache.Get("allCourses")
 	if found {
 		return cachedCourses.([]model.Course), nil
 	}
 	var courses []model.Course
-	var err error
-	if !limit {
-		err = DB.Preload("Streams").Find(&courses).Error
-	} else {
-		// limit 3 months in the future and one month in the past
-		err = DB.Preload("Streams", "start BETWEEN DATE_SUB(NOW(), INTERVAL 1 MONTH) and DATE_ADD(NOW(), INTERVAL 3 MONTH)").Find(&courses).Error
-	}
+	err := DB.Preload("Streams").Find(&courses).Error
 	if err == nil {
 		Cache.SetWithTTL("allCourses", courses, 1, time.Minute)
 	}

--- a/dao/lecture_halls.go
+++ b/dao/lecture_halls.go
@@ -63,15 +63,17 @@ func UnsetLectureHall(lectureID uint) {
 
 // GetStreamsForLectureHallIcal returns an instance of []calendarResult for the ical export.
 // if a user id is given, only streams of the user are returned. All streams are returned otherwise.
+// streams that happened more than on month ago and streams that are more than 3 months in the future are omitted.
 func GetStreamsForLectureHallIcal(userId uint) ([]CalendarResult, error) {
 	var res []CalendarResult
 	err := DB.Model(&model.Stream{}).
 		Joins("LEFT JOIN lecture_halls ON lecture_halls.id = streams.lecture_hall_id").
 		Joins("JOIN courses ON courses.id = streams.course_id").
 		Select("streams.id as stream_id, streams.created_at as created, "+
-			" lecture_halls.name as lecture_hall_name, "+
-			" streams.start, streams.end, courses.name as course_name").
-		Where("courses.user_id = ? OR 0 = ?", userId, userId).
+			"lecture_halls.name as lecture_hall_name, "+
+			"streams.start, streams.end, courses.name as course_name").
+		Where("(streams.start BETWEEN DATE_SUB(NOW(), INTERVAL 1 MONTH) and DATE_ADD(NOW(), INTERVAL 3 MONTH)) "+
+			"AND (courses.user_id = ? OR 0 = ?)", userId, userId).
 		Scan(&res).Error
 	return res, err
 }

--- a/dao/lecture_halls.go
+++ b/dao/lecture_halls.go
@@ -4,6 +4,7 @@ import (
 	"TUM-Live/model"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+	"time"
 )
 
 func FindPreset(lectureHallID string, presetID string) (model.CameraPreset, error) {
@@ -58,4 +59,40 @@ func UnsetLectureHall(lectureID uint) {
 		Where("id = ?", lectureID).
 		Select("lecture_hall_id").
 		Updates(map[string]interface{}{"lecture_hall_id": nil})
+}
+
+// GetStreamsForLectureHallIcal returns an instance of []calendarResult for the ical export.
+// if a user id is given, only streams of the user are returned. All streams are returned otherwise.
+func GetStreamsForLectureHallIcal(userId uint) ([]CalendarResult, error) {
+	var res []CalendarResult
+	err := DB.Model(&model.Stream{}).
+		Joins("LEFT JOIN lecture_halls ON lecture_halls.id = streams.lecture_hall_id").
+		Joins("JOIN courses ON courses.id = streams.course_id").
+		Select("streams.id as stream_id, streams.created_at as created, "+
+			" lecture_halls.name as lecture_hall_name, "+
+			" streams.start, streams.end, courses.name as course_name").
+		Where("courses.user_id = ? OR 0 = ?", userId, userId).
+		Scan(&res).Error
+	return res, err
+}
+
+type CalendarResult struct {
+	StreamID        uint
+	Created         time.Time
+	Start           time.Time
+	End             time.Time
+	CourseName      string
+	LectureHallName string
+}
+
+func (r CalendarResult) IsoStart() string {
+	return r.Start.Format("20060102T150405")
+}
+
+func (r CalendarResult) IsoEnd() string {
+	return r.End.Format("20060102T150405")
+}
+
+func (r CalendarResult) IsoCreated() string {
+	return r.Created.Format("20060102T150405")
 }

--- a/model/stream.go
+++ b/model/stream.go
@@ -73,22 +73,10 @@ func (s Stream) GetDescriptionHTML() string {
 	return string(html)
 }
 
-func (s Stream) IsoStart() string {
-	return s.Start.Format("20060102T150405")
-}
-
 func (s Stream) FriendlyDate() string {
 	return s.Start.Format("Mon 02.01.2006")
 }
 
-func (s Stream) IsoEnd() string {
-	return s.End.Format("20060102T150405")
-}
-
 func (s Stream) FriendlyTime() string {
 	return s.Start.Format("02.01.2006 15:04") + " - " + s.End.Format("15:04")
-}
-
-func (s Stream) IsoCreated() string {
-	return s.Model.CreatedAt.Format("20060102T150405")
 }


### PR DESCRIPTION
There is a `.ical` file used for the calendar on the admin page as well as for recording schedules on lecture hall hardware. Loading this takes ages because I iterated over all lecture halls and courses for each stream to get their data in. This was fine with just a handful of courses but now with > 1000 streams, this is getting ugly. 

I decided to just load all data we need in one SQL query. This reduces the request time from ~ 213 ms to ~ 11 ms on my machine.