### PR TITLE
Set fixed go hook revision

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/Bahjat/pre-commit-golang
-    rev: master
+    rev: c3086ee
     hooks:
       - id: go-fmt-import
       - id: go-vet

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/Bahjat/pre-commit-golang
-    rev: c3086ee
+    rev: c3086eea8af86847dbdff2e46b85a5fe3c9d9656
     hooks:
       - id: go-fmt-import
       - id: go-vet


### PR DESCRIPTION
Fixes a warning for `pre-commit` regarding use of a moving branch. The author of the go hook scripts, see https://github.com/Bahjat/pre-commit-golang, set the revision to master in the template, but setting to a fixed revision should be more stable and remove the associated warning.