### PR TITLE
don't  scroll down chat when scrolled up

### DIFF
--- a/web/template/partial/stream/chat.gohtml
+++ b/web/template/partial/stream/chat.gohtml
@@ -18,7 +18,8 @@
             <span x-show="show" class="font-semibold text-sm my-auto">Chat</span>
         </div>
         <div x-show="show">
-            <div id="disconnectMsg" class="text-white shadow-lg py-1 px-3 bg-red-500 border-2 border-red-600 rounded-b-lg hidden">
+            <div id="disconnectMsg"
+                 class="text-white shadow-lg py-1 px-3 bg-red-500 border-2 border-red-600 rounded-b-lg hidden">
                 <span class="text-sm font-semibold">Connection to chat lost! Reconnecting...</span>
             </div>
         </div>
@@ -38,9 +39,18 @@
                 </div>
             {{end}}
         </div>
+        <div x-cloak x-show="show"
+             x-on:messageindicator.window="e => {showNewMsgIndicator = e.detail.show}"
+             class="relative -top-8 h-0 w-full text-center"
+             x-data="{showNewMsgIndicator:true}">
+                <span @click="scrollToLatestMessage()"
+                      x-show="showNewMsgIndicator"
+                      class="bg-blue-600 rounded-full px-4 py-1 text-white shadow cursor-pointer hover:bg-blue-700">
+                    <i class="fas fa-arrow-down"></i> New messages
+                </span>
+        </div>
         <form x-show="show" id="chatForm"
-              class="2xl:flex 2xl:justify-between inset-x-0 px-2 pb-4 pt-5 bg-white dark:bg-secondary-lighter"
-              style="">
+              class="2xl:flex 2xl:justify-between inset-x-0 px-2 pb-4 pt-5 bg-white dark:bg-secondary-lighter">
             <div class="bg-gray-200 dark:bg-gray-600 focus-within:border-sky-600 dark:focus-within:border-sky-700
                         rounded-lg flex border-2 border-transparent w-full my-auto lg:mr-2">
                 {{if .IndexData.TUMLiveContext.Course.AnonymousChatEnabled}}

--- a/web/template/partial/stream/chat.gohtml
+++ b/web/template/partial/stream/chat.gohtml
@@ -42,10 +42,10 @@
         <div x-cloak x-show="show"
              x-on:messageindicator.window="e => {showNewMsgIndicator = e.detail.show}"
              class="relative -top-8 h-0 w-full text-center"
-             x-data="{showNewMsgIndicator:true}">
+             x-data="{showNewMsgIndicator:false}">
                 <span @click="scrollToLatestMessage()"
                       x-show="showNewMsgIndicator"
-                      class="bg-blue-600 rounded-full px-4 py-1 text-white shadow cursor-pointer hover:bg-blue-700">
+                      class="bg-blue-600 rounded-full px-4 py-1 text-white shadow cursor-pointer hover:bg-blue-700 whitespace-nowrap">
                     <i class="fas fa-arrow-down"></i> New messages
                 </span>
         </div>

--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -18,6 +18,16 @@ let ws: WebSocket;
 let retryInt = 5000; //retry connecting to websocket after this timeout
 const pageloaded = new Date();
 
+function scrollChat() {
+    const c = document.getElementById("chatBox");
+    if (c.scrollHeight - c.scrollTop <= c.offsetHeight + 150) {
+        c.scrollTop = c.scrollHeight;
+    } else {
+        console.log("not at bottom, skipping scroll");
+        // todo: add some visual indicator that the chat is not at the bottom and there are new messages
+    }
+}
+
 function startWebsocket() {
     const wsProto = window.location.protocol === "https:" ? `wss://` : `ws://`;
     const streamid = (document.getElementById("streamID") as HTMLInputElement).value;
@@ -46,11 +56,11 @@ function startWebsocket() {
         } else if ("server" in data) {
             const serverElem = createServerMessage(data);
             document.getElementById("chatBox").appendChild(serverElem);
-            document.getElementById("chatBox").scrollTop = document.getElementById("chatBox").scrollHeight;
+            scrollChat();
         } else if ("msg" in data) {
             const chatElem = createMessageElement(data);
             document.getElementById("chatBox").appendChild(chatElem);
-            document.getElementById("chatBox").scrollTop = document.getElementById("chatBox").scrollHeight;
+            scrollChat();
         }
     };
 

--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -18,14 +18,32 @@ let ws: WebSocket;
 let retryInt = 5000; //retry connecting to websocket after this timeout
 const pageloaded = new Date();
 
+function initChatScrollListener() {
+    const chatBox = document.getElementById("chatBox") as HTMLDivElement;
+    if (chatBox === undefined || chatBox === null) {
+        return;
+    }
+    chatBox.addEventListener("scroll", function (e) {
+        if (chatBox.scrollHeight - chatBox.scrollTop === chatBox.offsetHeight) {
+            window.dispatchEvent(new CustomEvent("messageindicator", { detail: { show: false } }));
+        }
+    });
+}
+
 function scrollChat() {
     const c = document.getElementById("chatBox");
+    // 150px grace offset to avoid showing message when close to bottom
     if (c.scrollHeight - c.scrollTop <= c.offsetHeight + 150) {
         c.scrollTop = c.scrollHeight;
     } else {
-        console.log("not at bottom, skipping scroll");
-        // todo: add some visual indicator that the chat is not at the bottom and there are new messages
+        window.dispatchEvent(new CustomEvent("messageindicator", { detail: { show: true } }));
     }
+}
+
+function scrollToLatestMessage() {
+    const c = document.getElementById("chatBox");
+    c.scrollTo({ top: c.scrollHeight, behavior: "smooth" });
+    window.dispatchEvent(new CustomEvent("messageindicator", { detail: { show: false } }));
 }
 
 function startWebsocket() {
@@ -36,6 +54,7 @@ function startWebsocket() {
     if (cf !== null && cf != undefined) {
         (document.getElementById("chatForm") as HTMLFormElement).addEventListener("submit", (e) => submitChat(e));
     }
+    initChatScrollListener();
     ws.onopen = function (e) {
         hideDisconnectedMsg();
     };

--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -30,7 +30,7 @@ function initChatScrollListener() {
     });
 }
 
-function scrollChat() {
+function scrollChatIfNeeded() {
     const c = document.getElementById("chatBox");
     // 150px grace offset to avoid showing message when close to bottom
     if (c.scrollHeight - c.scrollTop <= c.offsetHeight + 150) {
@@ -75,11 +75,11 @@ function startWebsocket() {
         } else if ("server" in data) {
             const serverElem = createServerMessage(data);
             document.getElementById("chatBox").appendChild(serverElem);
-            scrollChat();
+            scrollChatIfNeeded();
         } else if ("msg" in data) {
             const chatElem = createMessageElement(data);
             document.getElementById("chatBox").appendChild(chatElem);
-            scrollChat();
+            scrollChatIfNeeded();
         }
     };
 

--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -20,7 +20,7 @@ const pageloaded = new Date();
 
 function initChatScrollListener() {
     const chatBox = document.getElementById("chatBox") as HTMLDivElement;
-    if (chatBox === undefined || chatBox === null) {
+    if (chatBox) {
         return;
     }
     chatBox.addEventListener("scroll", function (e) {


### PR DESCRIPTION
fixes #241 


Desired behaviour: 

On New message:
- If the chat has not been scrolled up (or only a few pixels), the chat scrolls down like before
- if the chat has been scrolled up, a blue indicator is shown and the chat does not scroll down. 

When the indicator is shown:
- clicking the indicator scrolls down the chat and the indicator hides
- scrolling down manually also hides the indicator


https://user-images.githubusercontent.com/44805696/150636383-6371f2c9-02fd-4f2a-b172-86fa0c8bd9c6.mp4

 