### PR TITLE
make chat colorful

### DIFF
--- a/model/chat.go
+++ b/model/chat.go
@@ -4,9 +4,12 @@ import (
 	"database/sql"
 	"errors"
 	"gorm.io/gorm"
+	"strconv"
 	"strings"
 	"time"
 )
+
+var chatColors = []string{"#368bd6", "#ac3ba8", "#0dbd8b", "#e64f7a", "#ff812d", "#2dc2c5", "#5c56f5", "#74d12c"}
 
 var (
 	ErrReplyToReply       = errors.New("reply to reply not allowed")
@@ -32,6 +35,7 @@ type Chat struct {
 	Message  string `gorm:"not null" json:"message"`
 	StreamID uint   `gorm:"not null" json:"-"`
 	Admin    bool   `gorm:"not null;default:false" json:"admin"`
+	Color    string `gorm:"not null;default:'#368bd6'" json:"color"`
 
 	Replies []Chat        `gorm:"foreignkey:ReplyTo" json:"replies"`
 	ReplyTo sql.NullInt64 `json:"replyTo"`
@@ -64,6 +68,16 @@ func (c *Chat) BeforeCreate(tx *gorm.DB) (err error) {
 	if recentMessages >= coolDownMessages {
 		return ErrCooledDown
 	}
+
+	// set chat color:
+	userIdInt, err := strconv.Atoi(c.UserID)
+	if err != nil {
+		c.Color = chatColors[0]
+	} else {
+		c.Color = chatColors[userIdInt%len(chatColors)]
+	}
+
+	// not a reply, no need for more checks
 	if !c.ReplyTo.Valid {
 		return nil
 	}

--- a/model/chat.go
+++ b/model/chat.go
@@ -9,8 +9,6 @@ import (
 	"time"
 )
 
-var chatColors = []string{"#368bd6", "#ac3ba8", "#0dbd8b", "#e64f7a", "#ff812d", "#2dc2c5", "#5c56f5", "#74d12c"}
-
 var (
 	ErrReplyToReply       = errors.New("reply to reply not allowed")
 	ErrReplyToWrongStream = errors.New("reply to message from different stream not allowed")
@@ -39,6 +37,11 @@ type Chat struct {
 
 	Replies []Chat        `gorm:"foreignkey:ReplyTo" json:"replies"`
 	ReplyTo sql.NullInt64 `json:"replyTo"`
+}
+
+// getColors returns all colors chat names are mapped to
+func (c Chat) getColors() []string {
+	return []string{"#368bd6", "#ac3ba8", "#0dbd8b", "#e64f7a", "#ff812d", "#2dc2c5", "#5c56f5", "#74d12c"}
 }
 
 // BeforeCreate is a GORM hook that is called before a new chat is created.
@@ -70,11 +73,12 @@ func (c *Chat) BeforeCreate(tx *gorm.DB) (err error) {
 	}
 
 	// set chat color:
+	colors := c.getColors()
 	userIdInt, err := strconv.Atoi(c.UserID)
 	if err != nil {
-		c.Color = chatColors[0]
+		c.Color = colors[0]
 	} else {
-		c.Color = chatColors[userIdInt%len(chatColors)]
+		c.Color = colors[userIdInt%len(colors)]
 	}
 
 	// not a reply, no need for more checks

--- a/web/template/headImports.gohtml
+++ b/web/template/headImports.gohtml
@@ -5,7 +5,7 @@
     <link href="/static/assets/css-dist/main.css?v={{if .}}{{.}}{{else}}development{{end}}" rel="stylesheet">
     <link href="/static/node_modules/@fortawesome/fontawesome-free/css/all.min.css" rel="stylesheet">
     <link href="/static/assets/css/icons.css?v={{if .}}{{.}}{{else}}development{{end}}" rel="stylesheet">
-    <script defer src="/static/node_modules/alpinejs/dist/cdn.min.js"></script>
+    <script defer src="/static/node_modules/alpinejs/dist/cdn.js"></script>
     <script> // init in dom to prevent screen flickering
         let darkTheme = localStorage.getItem("darkTheme") ? JSON.parse(localStorage.getItem("darkTheme")) : true;
         if (!darkTheme) {

--- a/web/template/headImports.gohtml
+++ b/web/template/headImports.gohtml
@@ -5,7 +5,7 @@
     <link href="/static/assets/css-dist/main.css?v={{if .}}{{.}}{{else}}development{{end}}" rel="stylesheet">
     <link href="/static/node_modules/@fortawesome/fontawesome-free/css/all.min.css" rel="stylesheet">
     <link href="/static/assets/css/icons.css?v={{if .}}{{.}}{{else}}development{{end}}" rel="stylesheet">
-    <script defer src="/static/node_modules/alpinejs/dist/cdn.js"></script>
+    <script defer src="/static/node_modules/alpinejs/dist/cdn.min.js"></script>
     <script> // init in dom to prevent screen flickering
         let darkTheme = localStorage.getItem("darkTheme") ? JSON.parse(localStorage.getItem("darkTheme")) : true;
         if (!darkTheme) {

--- a/web/template/partial/stream/chat_message.gohtml
+++ b/web/template/partial/stream/chat_message.gohtml
@@ -3,7 +3,7 @@
         <div class="last:mb-1 rounded py-2 px-2" :class="replyTo === m.ID && 'ring ring-blue-500/50'"
              x-data="{ showReplies: false, m: m }" x-show="m.replyTo && !m.replyTo.Valid">
             <p class="text-4 text-sm">
-                <span class="text-2 font-semibold" :class="m.admin && 'text-warn'" x-text="m.name"></span>
+                <span class="text-2 font-semibold" :class="m.admin && 'text-warn'" x-text="m.name" :style="'color:'+m.color"></span>
                 <span x-text="m.message"></span>
             </p>
             <p class="flex flex-row text-sm font-semibold gap-3 text-5 mt-1">
@@ -26,7 +26,8 @@
                         <div>
                             <p class="text-4 text-sm">
                                 <span class="text-2 font-semibold" :class="reply.admin && 'text-warn'"
-                                      x-text="reply.name"></span>
+                                      x-text="reply.name"
+                                      :style="'color:'+reply.color"></span>
                                 <span x-text="reply.message"></span>
                             </p>
                             <p class="flex flex-row text-sm font-semibold gap-3 text-5">

--- a/web/template/partial/stream/chat_message.gohtml
+++ b/web/template/partial/stream/chat_message.gohtml
@@ -27,9 +27,7 @@
                         <div>
                             <p class="text-4 text-sm">
                                 <span x-show="reply.admin" class="text-white rounded-full bg-danger px-2 fas fa-video"></span>
-                                <span class="text-2 font-semibold" :class="reply.admin && 'text-warn'"
-                                      x-text="reply.name"
-                                      :style="'color:'+reply.color"></span>
+                                <span class="text-2 font-semibold" x-text="reply.name":style="'color:'+reply.color"></span>
                                 <span x-text="reply.message"></span>
                             </p>
                             <p class="flex flex-row text-sm font-semibold gap-3 text-5">

--- a/web/template/partial/stream/chat_message.gohtml
+++ b/web/template/partial/stream/chat_message.gohtml
@@ -3,7 +3,8 @@
         <div class="last:mb-1 rounded py-2 px-2" :class="replyTo === m.ID && 'ring ring-blue-500/50'"
              x-data="{ showReplies: false, m: m }" x-show="m.replyTo && !m.replyTo.Valid">
             <p class="text-4 text-sm">
-                <span class="text-2 font-semibold" :class="m.admin && 'text-warn'" x-text="m.name" :style="'color:'+m.color"></span>
+                <span x-show="m.admin" class="text-white rounded-full bg-danger px-2 fas fa-video"></span>
+                <span class="text-2 font-semibold" x-text="m.name" :style="'color:'+m.color"></span>
                 <span x-text="m.message"></span>
             </p>
             <p class="flex flex-row text-sm font-semibold gap-3 text-5 mt-1">

--- a/web/template/partial/stream/chat_message.gohtml
+++ b/web/template/partial/stream/chat_message.gohtml
@@ -26,6 +26,7 @@
                     <template x-for="reply in m.replies">
                         <div>
                             <p class="text-4 text-sm">
+                                <span x-show="reply.admin" class="text-white rounded-full bg-danger px-2 fas fa-video"></span>
                                 <span class="text-2 font-semibold" :class="reply.admin && 'text-warn'"
                                       x-text="reply.name"
                                       :style="'color:'+reply.color"></span>


### PR DESCRIPTION
Fixes #256 

This adds one of 8 colors to every username (unfortunately only for future messages but hey...)

IMO the colors look great in both, light and dark mode:

light | dark 
--- | ---
![image](https://user-images.githubusercontent.com/44805696/150976884-8f295361-6558-4837-aa2c-fdb7401da82e.png) | ![image](https://user-images.githubusercontent.com/44805696/150976828-78fa82e3-a3cf-4036-a4f4-56c66d44623f.png)

