### PR TITLE
make livestream link more visible

### DIFF
--- a/model/course.go
+++ b/model/course.go
@@ -116,6 +116,16 @@ func (c Course) GetNextLecture() Stream {
 	return earliestLecture
 }
 
+// GetLiveStream returns the current live stream of the course (if any)
+func (c Course) GetLiveStream() *Stream {
+	for _, s := range c.Streams {
+		if s.LiveNow {
+			return &s
+		}
+	}
+	return nil
+}
+
 // GetNextLectureDate returns the next lecture date of the course
 func (c Course) GetNextLectureDate() time.Time {
 	// TODO: Refactor this with IsNextLectureSelfStream when the sorting error fixed

--- a/web/template/course.gohtml
+++ b/web/template/course.gohtml
@@ -41,14 +41,17 @@
         <div class="flex w-full relative bg-white border dark:bg-secondary-lighter dark:border-gray-900 rounded-lg
                     shadow-sm py-3 px-5 my-3 order-first md:my-0 md:row-span-1 md:w-auto md:order-none">
             {{$lecture := $course.GetNextLecture}}
-            {{if $lecture.LiveNow}}
+            {{if $course.IsLive}}
+                {{$lecture = $course.GetLiveStream}}
                 <span class="absolute -top-1 -right-1 flex h-5 w-5">
                   <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-700 opacity-75"></span>
                   <span class="relative inline-flex rounded-full h-5 w-5 bg-danger"></span>
                 </span>
                 <div class="my-auto">
-                    <a href="/w/{{$course.Slug}}/{{$lecture.Model.ID}}">
-                        <h1 class="text-3xl font-bold text-3"><i class="fas fa-angle-right"></i> Live Now!</h1>
+                    <h1 class="text-3xl font-bold text-3">Live Now!</h1>
+                    <a class="font-light text-sm dark:text-white" href="/w/{{$course.Slug}}/{{$lecture.Model.ID}}">
+                        <i class="fas fa-angle-right"></i>
+                        <span>Open stream</span>
                     </a>
                 </div>
             {{else if $lecture.IsComingUp}}


### PR DESCRIPTION
This PR aligns the UI of the link to live streams to the UI of the link to waiting rooms.

Also, this fixes an issue where the course page doesn't display live streams that are still live but with their end date in the past.

![image](https://user-images.githubusercontent.com/44805696/150994227-4fb3d359-4bd2-41e9-9509-42eee578da66.png)
