### PR TITLE
use absolute link for chat popout

### DIFF
--- a/web/template/partial/stream/chat/chat.gohtml
+++ b/web/template/partial/stream/chat/chat.gohtml
@@ -91,7 +91,8 @@
                     <div class="flex mt-2">
                         {{if not .IsPopUp}}
                             <button class="flex bg-transparent border-0 font-semibold h-8 w-8 rounded hover:dark:bg-gray-600 hover:bg-gray-200"
-                                    @click="watch.openChatPopUp()" title="Popout Chat">
+                                    @click="watch.openChatPopUp('{{.IndexData.TUMLiveContext.Course.Slug}}', {{.IndexData.TUMLiveContext.Stream.Model.ID}})"
+                                    title="Popout Chat">
                                 <i class="fas fa-external-link-alt text-3 m-auto"></i>
                             </button>
                         {{end}}

--- a/web/ts/chat.ts
+++ b/web/ts/chat.ts
@@ -114,10 +114,10 @@ export function hideDisconnectedMsg() {
     }
 }
 
-export function openChatPopUp() {
+export function openChatPopUp(courseSlug: string, streamID: number) {
     const height = window.innerHeight * 0.8;
     window.open(
-        "chat/popup", // relative path to caller url
+        `/w/${courseSlug}/${streamID}/chat/popup`,
         "_blank",
         `popup=yes,width=420,innerWidth=420,height=${height},innerHeight=${height}`,
     );


### PR DESCRIPTION
For me, opening the chat popout only works on a specific version of a stream (e.g. http://localhost:8081/w/test/26/COMB) but not the general version (http://localhost:8081/w/test/26). This fixes the issue by using the absolute path of the chat popout.