### PR TITLE
Add specific type and size to unique columns

### DIFF
--- a/model/shortlink.go
+++ b/model/shortlink.go
@@ -6,6 +6,6 @@ import "gorm.io/gorm"
 type ShortLink struct {
 	gorm.Model
 
-	Link     string `gorm:"not null unique"`
+	Link     string `gorm:"type:varchar(256); unique; not null"`
 	CourseId uint   `gorm:"not null"`
 }

--- a/model/stream-name.go
+++ b/model/stream-name.go
@@ -6,7 +6,7 @@ import "gorm.io/gorm"
 type StreamName struct {
 	gorm.Model
 
-	StreamName     string `gorm:"type:varchar(64); unique; default:null"`
+	StreamName     string `gorm:"type:varchar(64); unique; not null"`
 	IsTranscoding  bool   `gorm:"not null;default:false"`
 	IngestServerID uint   `gorm:"not null"`
 	StreamID       uint   // Is null when the slot is not used

--- a/model/stream-name.go
+++ b/model/stream-name.go
@@ -6,7 +6,7 @@ import "gorm.io/gorm"
 type StreamName struct {
 	gorm.Model
 
-	StreamName     string `gorm:"unique;not null"`
+	StreamName     string `gorm:"type:varchar(64); unique; default:null"`
 	IsTranscoding  bool   `gorm:"not null;default:false"`
 	IngestServerID uint   `gorm:"not null"`
 	StreamID       uint   // Is null when the slot is not used

--- a/model/user.go
+++ b/model/user.go
@@ -25,8 +25,8 @@ type User struct {
 	gorm.Model
 
 	Name                string         `gorm:"not null"`
-	Email               sql.NullString `gorm:"unique;default:null"`
-	MatriculationNumber string         `gorm:"unique;default:null"`
+	Email               sql.NullString `gorm:"type:varchar(256); unique; default:null"`
+	MatriculationNumber string         `gorm:"type:varchar(256); unique; default:null"`
 	LrzID               string
 	Role                uint     `gorm:"default:4"` // AdminType = 1, LecturerType = 2, GenericType = 3, StudentType  = 4
 	Password            string   `gorm:"default:null"`


### PR DESCRIPTION
I (painfully) found out that some database systems don't play well with unique constraints when the size of a column is not set. In our case GORM decided to convert some fields to `longtext` which can not have a unique constraint. This killed prod when I tried to restart it (: :tada: 