### PR TITLE
Only show the download button for recordings

### DIFF
--- a/web/template/partial/stream/actions.gohtml
+++ b/web/template/partial/stream/actions.gohtml
@@ -7,7 +7,7 @@
     {{/* Icons for different actions student can do for a stream */}}
     <span class="flex space-x-2 content-center">
         {{/* Download button */}}
-        {{if (and $course.DownloadsEnabled $user)}}
+        {{if and (and $course.DownloadsEnabled $user) $stream.Recording}}
             {{template "downloadBtn" $stream.Files}}
         {{end}}
         {{/* Switch video to presentation */}}


### PR DESCRIPTION
I think we should not show the download button, if the stream is still running.