### PR TITLE
live-update title and description for viewers on update

### DIFF
--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -61,7 +61,7 @@
         </div>
         <div id="streamInfo" class="mx-5 m-auto">
             <div class="flex justify-between align-middle mt-4">
-                <h1 class="text-4 text-xl grow">
+                <h1 class="text-4 text-xl grow" @titleupdate.window="$el.innerText=$event.detail.title">
                     {{if $stream.Name}}
                         {{$stream.Name}}
                     {{else}}
@@ -200,18 +200,17 @@
             <div class="flex justify-between align-middle mt-2 md:hidden">
                 {{template "actions" . }}
             </div>
-            {{if $stream.Description}}
-                {{$isMinLen := gt (len $stream.Description) 128}}
-                <div x-data="{less: {{$isMinLen}}}" class="text-3 p-4 border-t-2 my-3 border-secondary video-description">
-                    <span class="font-semibold">Video Description:</span>
-                    <div :class="less && 'truncate-children'">{{.Description}}</div>
-                    <template x-if="{{$isMinLen}}">
-                        <button class='text-xs text-gray-500 dark:text-gray-400 uppercase mt-2'
+                <div x-data="{description: `{{.Description}}`, less:true}"
+                     @descriptionupdate.window="description=$event.detail.description"
+                     class="text-3 p-4 border-t-2 my-3 border-secondary video-description">
+                    <span class="font-semibold" x-show="description.length>0">{{if .Description}}Video Description:{{end}}</span>
+                    <div :class="less && 'truncate-children'" x-html="description">
+                        {{if .Description}}{{.Description}}{{end}}
+                    </div>
+                        <button x-show="description.length>128" class='text-xs text-gray-500 dark:text-gray-400 uppercase mt-2'
                                 @click="less = !less" x-text="less ? 'show more' : 'show less'">show less
                         </button>
-                    </template>
                 </div>
-            {{end}}
             {{if .IsHighlightPage}}
                 <ul class="w-full m-auto mb-4">
                     {{template "course_list" .IndexData.TUMLiveContext}}

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -200,10 +200,9 @@
             <div class="flex justify-between align-middle mt-2 md:hidden">
                 {{template "actions" . }}
             </div>
-            <div x-data="{descriptionlen: `{{len .Description}}`, less:true}"
-                 class="text-3 p-4 border-t-2 my-3 border-secondary video-description">
-                <span class="font-semibold"
-                      x-show="description.length>0">{{if .Description}}Video Description:{{end}}</span>
+            <div x-data="{descriptionlen: {{len .Description}}, less:true}"
+                 class="text-3 p-4 border-t-2 my-3 border-secondary video-description" x-show="descriptionlen > 0">
+                <span class="font-semibold">Video Description:</span>
                 <div :class="less && 'truncate-children'"
                      @descriptionupdate.window="$el.innerHTML=$event.detail.description; descriptionlen=$event.detail.description.length">
                     {{if .Description}}{{.Description}}{{end}}

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -200,17 +200,18 @@
             <div class="flex justify-between align-middle mt-2 md:hidden">
                 {{template "actions" . }}
             </div>
-                <div x-data="{description: `{{.Description}}`, less:true}"
-                     @descriptionupdate.window="description=$event.detail.description"
-                     class="text-3 p-4 border-t-2 my-3 border-secondary video-description">
-                    <span class="font-semibold" x-show="description.length>0">{{if .Description}}Video Description:{{end}}</span>
-                    <div :class="less && 'truncate-children'" x-html="description">
-                        {{if .Description}}{{.Description}}{{end}}
-                    </div>
-                        <button x-show="description.length>128" class='text-xs text-gray-500 dark:text-gray-400 uppercase mt-2'
-                                @click="less = !less" x-text="less ? 'show more' : 'show less'">show less
-                        </button>
+            <div x-data="{descriptionlen: `{{len .Description}}`, less:true}"
+                 class="text-3 p-4 border-t-2 my-3 border-secondary video-description">
+                <span class="font-semibold"
+                      x-show="description.length>0">{{if .Description}}Video Description:{{end}}</span>
+                <div :class="less && 'truncate-children'"
+                     @descriptionupdate.window="$el.innerHTML=$event.detail.description; descriptionlen=$event.detail.description.length">
+                    {{if .Description}}{{.Description}}{{end}}
                 </div>
+                <button x-show="descriptionlen>128" class='text-xs text-gray-500 dark:text-gray-400 uppercase mt-2'
+                        @click="less = !less" x-text="less ? 'show more' : 'show less'">show less
+                </button>
+            </div>
             {{if .IsHighlightPage}}
                 <ul class="w-full m-auto mb-4">
                     {{template "course_list" .IndexData.TUMLiveContext}}

--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -1,6 +1,5 @@
 import { scrollChat, shouldScroll, showNewMessageIndicator } from "./chat";
 import { NewChatMessage } from "./chat/NewChatMessage";
-import { List } from "postcss/lib/list";
 
 let chatInput: HTMLInputElement;
 
@@ -125,6 +124,12 @@ export function startWebsocket() {
             window.dispatchEvent(event);
         } else if ("approve" in data) {
             const event = new CustomEvent("chatapprove", { detail: data });
+            window.dispatchEvent(event);
+        } else if ("title" in data) {
+            const event = new CustomEvent("titleupdate", { detail: data });
+            window.dispatchEvent(event);
+        } else if ("description" in data) {
+            const event = new CustomEvent("descriptionupdate", { detail: data });
             window.dispatchEvent(event);
         }
     };


### PR DESCRIPTION
I noticed lecturers adding the tweedback link when the stream was already running. Users had to reload the page to see the link. This PR addresses this issue.

https://user-images.githubusercontent.com/44805696/161003720-bef59d62-ffd6-4e33-a99c-403670661f1e.mp4

I'm duplicating some logic in alpine and in gohtml here to support people with js turned off.