### PR TITLE
Don't send private or unnecessary data in chat user search

### DIFF
--- a/api/chat.go
+++ b/api/chat.go
@@ -411,12 +411,12 @@ func getUsers(c *gin.Context) {
 		return
 	}
 	type chatUserSearchDto struct {
-		Id   uint   `json:"id"`
+		ID   uint   `json:"id"`
 		Name string `json:"name"`
 	}
 	resp := make([]chatUserSearchDto, len(users))
 	for i, user := range users {
-		resp[i].Id = user.ID
+		resp[i].ID = user.ID
 		resp[i].Name = user.Name
 	}
 	c.JSON(http.StatusOK, resp)

--- a/api/chat.go
+++ b/api/chat.go
@@ -410,7 +410,16 @@ func getUsers(c *gin.Context) {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
-	c.JSON(http.StatusOK, users)
+	type chatUserSearchDto struct {
+		Id   uint   `json:"id"`
+		Name string `json:"name"`
+	}
+	resp := make([]chatUserSearchDto, len(users))
+	for i, user := range users {
+		resp[i].Id = user.ID
+		resp[i].Name = user.Name
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 func getActivePoll(c *gin.Context) {


### PR DESCRIPTION
This PR adds a dto that just contains the user id and name for the chat user search.
This prevents sending data like `createdAt`, `administeredCourses` or similar as they are not needed here. 