### PR TITLE
Reorder planned courses

### DIFF
--- a/dao/courses.go
+++ b/dao/courses.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
-  
+
 	"github.com/RBG-TUM/commons"
 	"github.com/getsentry/sentry-go"
 	log "github.com/sirupsen/logrus"

--- a/dao/streams.go
+++ b/dao/streams.go
@@ -4,10 +4,11 @@ import (
 	"TUM-Live/model"
 	"context"
 	"fmt"
-	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 	"strconv"
 	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GetDueStreamsForWorkers retrieves all streams that due to be streamed in a lecture hall.
@@ -284,7 +285,7 @@ func GetStreamsWithWatchState(courseID uint, userID uint) (streams []model.Strea
 	queriedStreams := DB.Table("streams").Where("course_id = ? and deleted_at is NULL", courseID)
 	result := queriedStreams.
 		Joins("left join (select watched, stream_id from stream_progresses where user_id = ?) as sp on sp.stream_id = streams.id", userID).
-		Order("start").          // Order by start time, this is also the order that is used in the course page.
+		Order("start asc").      // Order by start time, this is also the order that is used in the course page.
 		Session(&gorm.Session{}) // Session is required to scan multiple times
 
 	if err = result.Scan(&streams).Error; err != nil {

--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -26,6 +26,7 @@
                     <div class="my-auto">
                         {{if .Course.HasRecordings}}
                         <button class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded px-2"
+                                x-init="global.reorderVodList()"
                                 @click="asc = !asc; global.reorderVodList()">
                             <span class="text-sm font-semibold uppercase dark:text-white"
                           x-text="asc ? '&#x25B2; asc' : '&#x25BC; desc'">desc &#x25BC;</span>


### PR DESCRIPTION
Fixes https://github.com/joschahenningsen/TUM-Live/issues/370

This seems the most simple way to fix this.  Reording once in the beginning does not have any impact on loading as far as I could tell.

Alternatively, we could implement a method for a course that sorts the the VoDs or do another data base query and attach the result to the CoursePageContext.