### PR TITLE
Re add automatic camera preset switch on stream start

### DIFF
--- a/api/worker_grpc.go
+++ b/api/worker_grpc.go
@@ -3,6 +3,7 @@ package api
 // worker_grpc.go handles communication with workers via grpc
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	go_anel_pwrctrl "github.com/RBG-TUM/go-anel-pwrctrl"
@@ -10,6 +11,7 @@ import (
 	"github.com/joschahenningsen/TUM-Live/dao"
 	"github.com/joschahenningsen/TUM-Live/model"
 	"github.com/joschahenningsen/TUM-Live/tools"
+	"github.com/joschahenningsen/TUM-Live/tools/camera"
 	"github.com/joschahenningsen/TUM-Live/worker/pb"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
@@ -241,6 +243,40 @@ func (s server) NotifyStreamFinished(ctx context.Context, request *pb.StreamFini
 	return &pb.Status{Ok: true}, nil
 }
 
+func handleCameraPositionSwitch(stream model.Stream) error {
+	if stream.LectureHallID == 0 {
+		return nil
+	}
+	course, err := dao.GetCourseById(context.Background(), stream.CourseID)
+	if err != nil {
+		return err
+	}
+	lectureHall, err := dao.GetLectureHallByID(stream.LectureHallID)
+	if err != nil {
+		return err
+	}
+	var preferences []model.CameraPresetPreference
+	// make sure there is an empty list if no preferences are found (null or empty string in db)
+	if course.CameraPresetPreferences == "" {
+		course.CameraPresetPreferences = "[]"
+	}
+	err = json.Unmarshal([]byte(course.CameraPresetPreferences), &preferences)
+	if err != nil {
+		return err
+	}
+	for _, preference := range preferences {
+		if preference.LectureHallID == stream.LectureHallID {
+			return camera.NewCamera(lectureHall.CameraIP, tools.Cfg.Auths.CamAuth).SetPreset(preference.PresetID)
+		}
+	}
+	// no preset found for this lecture hall, use default
+	defaultPreset, err := dao.GetDefaultCameraPreset(lectureHall.ID)
+	if err != nil {
+		return err
+	}
+	return camera.NewCamera(lectureHall.CameraIP, tools.Cfg.Auths.CamAuth).SetPreset(defaultPreset.PresetID)
+}
+
 func handleLightOnSwitch(stream model.Stream) error {
 	if stream.LectureHallID == 0 {
 		return nil // no light to switch
@@ -398,6 +434,10 @@ func (s server) NotifyStreamStarted(ctx context.Context, request *pb.StreamStart
 		err := handleLightOnSwitch(stream)
 		if err != nil {
 			log.WithError(err).Error("Can't handle light on switch")
+		}
+		err = handleCameraPositionSwitch(stream)
+		if err != nil {
+			log.WithError(err).Error("Can't handle camera position switch")
 		}
 	}()
 	go func() {

--- a/dao/lecture_halls.go
+++ b/dao/lecture_halls.go
@@ -13,6 +13,11 @@ func FindPreset(lectureHallID string, presetID string) (model.CameraPreset, erro
 	return preset, err
 }
 
+// UnsetDefaults makes all camera presets not default
+func UnsetDefaults(lectureHallID string) error {
+	return DB.Model(&model.CameraPreset{}).Where("lecture_hall_id = ?", lectureHallID).Update("default", nil).Error
+}
+
 func SavePreset(preset model.CameraPreset) error {
 	return DB.Clauses(clause.OnConflict{UpdateAll: true}).Save(&preset).Error
 }

--- a/web/template/admin/admin_tabs/lecture_halls.gohtml
+++ b/web/template/admin/admin_tabs/lecture_halls.gohtml
@@ -87,10 +87,16 @@
                             <div class="w-full overflow-x-scroll scrollbarThin">
                                 <div class="flex flex-row gap-x-2">
                                     {{range $preset := $lectureHall.CameraPresets}}
-                                        <div style="min-width: 150px" class="text-center relative group">
+                                        <div x-data="{defaultPreset: {{$preset.Default}}, lectureHallID: {{$preset.LectureHallId}}}"
+                                             @resetdefaults.window="e => {if(e.detail === lectureHallID){defaultPreset = false}}"
+                                             style="min-width: 150px" class="text-center relative group">
                                             <img id="presetImage{{$preset.LectureHallId}}-{{$preset.PresetID}}"
                                                  src="/public/{{if $preset.Image}}{{$preset.Image}}{{else}}noPreset.jpg{{end}}"
                                                  alt="prev" width="150px">
+                                            <i @click="admin.setDefaultPreset({{$preset.LectureHallId}}, {{$preset.PresetID}}).then((r) => {if(r){$dispatch('resetdefaults', lectureHallID);defaultPreset=true}})"
+                                               title="Set default"
+                                               :class="!defaultPreset && 'opacity-0'"
+                                               class="group-hover:opacity-100 absolute top-1 left-1 p-1 rounded text-white bg-amber-800 fas fa-check"></i>
                                             <i onclick="admin.takeSnapshot({{$preset.LectureHallId}}, {{$preset.PresetID}})"
                                                title="Take new snapshot"
                                                class="opacity-0 group-hover:opacity-100 absolute top-1 right-1 p-1 rounded text-white bg-sky-800 fas fa-sync"></i>

--- a/web/ts/lecture-hall-management.ts
+++ b/web/ts/lecture-hall-management.ts
@@ -1,4 +1,4 @@
-import { postData } from "./global";
+import {postData} from "./global";
 
 export function takeSnapshot(lectureHallID: number, presetID: number) {
     if (confirm("Do you want to take a snapshot? Make sure no lecture is live in this lecture hall.")) {
@@ -17,4 +17,18 @@ export function takeSnapshot(lectureHallID: number, presetID: number) {
             }
         });
     }
+}
+
+export function setDefaultPreset(lectureHallID: number, presetID: number): Promise<boolean> {
+    return fetch(`/api/lectureHall/${lectureHallID}/defaultPreset`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            presetID: presetID,
+        }),
+    }).then(function (res) {
+        return res.ok;
+    });
 }

--- a/web/ts/lecture-hall-management.ts
+++ b/web/ts/lecture-hall-management.ts
@@ -1,4 +1,4 @@
-import {postData} from "./global";
+import { postData } from "./global";
 
 export function takeSnapshot(lectureHallID: number, presetID: number) {
     if (confirm("Do you want to take a snapshot? Make sure no lecture is live in this lecture hall.")) {


### PR DESCRIPTION
This was previously part of the worker which didn't really make sense. 

I also added an option to select the default preset for a lecture hall to fall back to in case no preference is set:

https://user-images.githubusercontent.com/44805696/164199789-21d4ad46-0de0-45f4-9b2f-4643d5a16313.mp4


