### PR TITLE
Show hidden streams to admins

### DIFF
--- a/dao/streams.go
+++ b/dao/streams.go
@@ -179,19 +179,6 @@ func GetCurrentLive(ctx context.Context) (currentLive []model.Stream, err error)
 	return streams, err
 }
 
-func GetCurrentLiveNonHidden(ctx context.Context) (currentLive []model.Stream, err error) {
-	if streams, found := Cache.Get("NonHiddenCurrentlyLiveStreams"); found {
-		return streams.([]model.Stream), nil
-	}
-	var streams []model.Stream
-	if err := DB.Joins("JOIN courses ON courses.id = streams.course_id").Find(&streams,
-		"live_now = ? AND visibility != ?", true, "hidden").Error; err != nil {
-		return nil, err
-	}
-	Cache.SetWithTTL("NonHiddenCurrentlyLiveStreams", streams, 1, time.Minute)
-	return streams, err
-}
-
 func DeleteStream(streamID string) {
 	DB.Where("id = ?", streamID).Delete(&model.Stream{})
 	Cache.Clear()

--- a/web/index.go
+++ b/web/index.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"errors"
 	"github.com/RBG-TUM/commons"
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-gonic/gin"
@@ -142,8 +143,9 @@ func (d *IndexData) LoadSemesters(spanMain *sentry.Span) {
 // LoggedIn streams can only be seen by logged-in users.
 // Enrolled streams can only be seen by users which are allowed to.
 func (d *IndexData) LoadLivestreams(c *gin.Context) {
-	streams, err := dao.GetCurrentLiveNonHidden(context.Background())
-	if err != nil {
+	streams, err := dao.GetCurrentLive(context.Background())
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		log.WithError(err).Error("could not get current live streams")
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"message": "Could not load current livestream from database."})
 	}
 
@@ -154,13 +156,19 @@ func (d *IndexData) LoadLivestreams(c *gin.Context) {
 	for _, stream := range streams {
 		courseForLiveStream, _ := dao.GetCourseById(context.Background(), stream.CourseID)
 
+		// only show streams for logged in users if they are logged in
 		if courseForLiveStream.Visibility == "loggedin" && tumLiveContext.User == nil {
 			continue
 		}
+		// only show "enrolled" streams to users which are enrolled or admins
 		if courseForLiveStream.Visibility == "enrolled" {
 			if !isUserAllowedToWatchPrivateCourse(courseForLiveStream, tumLiveContext.User) {
 				continue
 			}
+		}
+		// Only show hidden streams to admins
+		if courseForLiveStream.Visibility == "hidden" && (tumLiveContext.User == nil || tumLiveContext.User.Role != model.AdminType) {
+			continue
 		}
 		livestreams = append(livestreams, CourseStream{
 			Course: courseForLiveStream,

--- a/web/template/index.gohtml
+++ b/web/template/index.gohtml
@@ -10,7 +10,7 @@
 <body>
 {{template "header" .TUMLiveContext}}
 
-{{- /*gotype: TUM-Live/web.IndexData*/ -}}
+{{- /*gotype: github.com/joschahenningsen/TUM-Live/web.IndexData*/ -}}
 <div class="container flex flex-col pb-16">
     {{if .ServerNotifications}}
         {{range $notification := .ServerNotifications}}
@@ -32,6 +32,9 @@
                 <h3 class="text-lg text-2 inline">{{$liveStream.Course.Name}}{{if $liveStream.Stream.Name}}: {{$liveStream.Stream.Name}}{{end}}</h3>
             </a>
             <p class="font-sans font-light text-sm">
+                {{if $liveStream.Course.IsHidden}} {{- /* only admins have hidden courses here */ -}}
+                <span class="bg-blue-800 text-blue-100 px-2 mr-1 capitalize rounded-full font-semibold">Hidden</span>
+                {{end}}
                 <span class="bg-red-800 text-red-100 px-2 mr-1 capitalize rounded-full font-semibold">Live</span>
                 <span class="font-light text-3">{{printf "until %2d:%02d" $liveStream.Stream.End.Hour $liveStream.Stream.End.Minute}}</span>
             </p>


### PR DESCRIPTION
Admins (not course admins) now see hidden streams on the start page: 

![image](https://user-images.githubusercontent.com/44805696/165711567-96a43613-2144-4e7a-9f9e-ad0065be5526.png)

fixes #392