### PR TITLE
Changed "Moin" to "Servus" on the Start Page

### DIFF
--- a/web/template/index.gohtml
+++ b/web/template/index.gohtml
@@ -21,7 +21,7 @@
     {{if not .TUMLiveContext.User}}
         <p class="text-2"><a href="/login" class="underline">Log in</a> to see your courses</p>
     {{else if .TUMLiveContext.User.Name}}
-        <p class="text-2">Moin {{.TUMLiveContext.User.Name}}, nice to see you!</p>
+        <p class="text-2">Servus {{.TUMLiveContext.User.Name}}, nice to see you!</p>
     {{end}}
     {{if .LiveStreams}}
         <h2 class="text-2xl text-1">Active Livestreams</h2>


### PR DESCRIPTION
Why? Because the TUM is located in Bavaria, not in Hamburg. Regarding the fact that most people here say "Servus" and not "Moin" for "Hello", I think this would be an appropriate change to make.

To be clear, this was not my idea:
![Unbenannt](https://user-images.githubusercontent.com/22636066/165990101-a34b17c5-3b13-4cbf-a4b4-630b12b5cdbb.png)
