### PR TITLE
Enhancement: follow system theme

### DIFF
--- a/web/template/headImports.gohtml
+++ b/web/template/headImports.gohtml
@@ -11,11 +11,6 @@
         <script defer src="/static/node_modules/alpinejs/dist/cdn.min.js"></script>
     {{end}}
     <script src="/static/assets/ts-dist/global.bundle.js?v={{if .}}{{.}}{{else}}development{{end}}"></script>
-    <script> // init in dom to prevent screen flickering
-        let darkTheme = localStorage.getItem("darkTheme") ? JSON.parse(localStorage.getItem("darkTheme")) : true;
-        if (!darkTheme) {
-            document.documentElement.classList.remove("dark");
-        }
-    </script>
+    {{template "theme-selector-head"}}
     <style>[x-cloak] { display: none !important; }</style>
 {{end}}

--- a/web/template/header.gohtml
+++ b/web/template/header.gohtml
@@ -87,25 +87,16 @@
                 <i class="fas fa-info-circle w-8"></i>
                 <span class="ml-2 text-sm">About</span>
             </a>
-            {{/* TODO: color scheme for mobile */}}
-            <div class="flex justify-end px-5 py-2 border-b dark:border-gray-600">
-                <span class="text-sm text-gray-500 uppercase mr-2 my-auto">Dark Mode</span>
-                <button class="flex my-auto w-12 justify-end" title="Toggle color scheme"
-                        onclick="global.toggleColorScheme()"
-                        @click="dark = !dark">
-                    <i class="text-3 text-2xl fas "
-                       :class="dark ? 'fa-toggle-on' :  'fa-toggle-off'"></i>
-                </button>
-            </div>
-            <div class="flex justify-end px-5 py-2 border-b dark:border-gray-600">
-                <span class="text-sm text-gray-500 uppercase mr-2 my-auto">GitHub</span>
-                <div class="w-12 flex justify-end">
-                    <a class="my-auto" rel="noopener" href="https://github.com/joschahenningsen/TUM-Live"
-                       aria-label="GitHub">
-                        <i class="text-3 vjs-icon-github"></i>
-                    </a>
+            {{template "theme-selector-mobile"}}
+            <a class="my-auto" rel="noopener" href="https://github.com/joschahenningsen/TUM-Live" aria-label="GitHub">
+                <div class="flex justify-end px-5 py-2 border-b dark:border-gray-600
+                            text-sm transition-colors duration-200 text-5 hover:text-1">
+                    <span class="uppercase mr-2 my-auto">GitHub</span>
+                    <div class="w-12 flex justify-end">
+                        <i class="vjs-icon-github"></i>
+                    </div>
                 </div>
-            </div>
+            </a>
         </div>
     </div>
     <div id="alertBox" class="fixed top-24 z-50 left-0 right-0 hidden text-center">

--- a/web/template/header.gohtml
+++ b/web/template/header.gohtml
@@ -1,5 +1,5 @@
 {{define "header"}} {{- /*gotype: github.com/joschahenningsen/TUM-Live/tools.TUMLiveContext*/ -}}
-<div x-cloak x-data="{showMobNav: false, dark: false}" x-init="dark = global.isDark()" class="inline">
+<div x-cloak x-data="{showMobNav: false, dark: false}" class="inline">
     <nav class="flex z-40 lg:z-50 sticky top-0 w-full items-center justify-between dark:bg-secondary bg-white
                     shadow border-b dark:border-0 p-3 h-20 z-40">
         <a title="Start" href="/" class="flex items-center flex-no-shrink text-white mr-6">
@@ -37,11 +37,7 @@
                 </a>
             </div>
             <div class="flex">
-                <button class="flex my-auto text-xl mr-6" title="Toggle color scheme"
-                        onclick="global.toggleColorScheme()"
-                        @click="dark = !dark">
-                    <i class="text-gray-400 text-xl fas" :class="dark ? 'fa-toggle-on' :  'fa-toggle-off'"></i>
-                </button>
+                {{template "theme-selector"}}
                 {{template "notifications"}}
                 <a class="mr-3" rel="noopener" href="https://github.com/joschahenningsen/TUM-Live"
                    aria-label="GitHub"><i
@@ -91,6 +87,7 @@
                 <i class="fas fa-info-circle w-8"></i>
                 <span class="ml-2 text-sm">About</span>
             </a>
+            {{/* TODO: color scheme for mobile */}}
             <div class="flex justify-end px-5 py-2 border-b dark:border-gray-600">
                 <span class="text-sm text-gray-500 uppercase mr-2 my-auto">Dark Mode</span>
                 <button class="flex my-auto w-12 justify-end" title="Toggle color scheme"

--- a/web/template/partial/notifications.gohtml
+++ b/web/template/partial/notifications.gohtml
@@ -1,6 +1,6 @@
 {{define "notifications"}}
     {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.User*/ -}}
-    <div class="relative" x-data="{ n: new global.Notifications(), show: false}" x-init="n.fetchNotifications(); console.log(n);"
+    <div class="relative" x-data="{ n: new global.Notifications(), show: false}" x-init="n.fetchNotifications();"
          @keyup.escape="show=false; n.writeToStorage(true)">
         <button class="transition-colors duration-200 hover:text-gray-600 dark:hover:text-white text-gray-400 mr-6 relative h-4 w-4"
                 type="button" @click="show=!show; show===false && n.writeToStorage(true)">

--- a/web/template/partial/notifications.gohtml
+++ b/web/template/partial/notifications.gohtml
@@ -1,6 +1,6 @@
 {{define "notifications"}}
     {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.User*/ -}}
-    <div class="relative" x-data="{ n: new global.Notifications(), show: false}" x-init="n.fetchNotifications()"
+    <div class="relative" x-data="{ n: new global.Notifications(), show: false}" x-init="n.fetchNotifications(); console.log(n);"
          @keyup.escape="show=false; n.writeToStorage(true)">
         <button class="transition-colors duration-200 hover:text-gray-600 dark:hover:text-white text-gray-400 mr-6 relative h-4 w-4"
                 type="button" @click="show=!show; show===false && n.writeToStorage(true)">

--- a/web/template/partial/notifications.gohtml
+++ b/web/template/partial/notifications.gohtml
@@ -8,7 +8,7 @@
                   class="bg-gradient-to-r from-cyan-500 to-blue-500 rounded-full absolute -top-1 -right-1 h-3 w-3 border-2 border-white dark:border-secondary"> </span>
             <i class="fa-solid fa-bell"></i>
         </button>
-        <div x-cloak x-show="show" @click.outside="show=false; n.writeToStorage(true)" class="origin-top-right absolute right-0 mt-4 lg:shadow-sm lg:rounded-lg h-fit bg-white border rounded-t-lg w-96
+        <div x-cloak x-show="show" @click.outside="show=false; n.writeToStorage(true)" class="origin-top-right absolute right-0 mt-4 shadow-sm rounded-lg h-fit bg-white border w-96
                         dark:bg-secondary dark:border-gray-800">
             <div class="my-auto w-full min-h-30 max-h-60 overflow-y-scroll">
                 <div class="py-4 relative text-3 text-center" x-cloak x-show="n.notifications.length === 0">

--- a/web/template/partial/theme-selector-head.gohtml
+++ b/web/template/partial/theme-selector-head.gohtml
@@ -13,7 +13,7 @@
         const getThemeMode = () => localStorage.themeMode;
 
         // transition from old dark theme system
-        if ("darkTheme" in localStorage) { // TODO: send notification? }
+        if ("darkTheme" in localStorage) { /* TODO: send notification? */ }
         localStorage.removeItem("darkTheme");
         // first visit or transition
         if (!("themeMode" in localStorage)) { setThemeMode("system"); }

--- a/web/template/partial/theme-selector-head.gohtml
+++ b/web/template/partial/theme-selector-head.gohtml
@@ -1,0 +1,41 @@
+{{define "theme-selector-head"}}
+    <script>
+        /* put this in document head to avoid FOUC */
+        const mediaQueryPrefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)");
+        function updateTheme() {
+            const shouldBeDark = localStorage.themeMode === "dark"
+                || localStorage.themeMode === "system" && mediaQueryPrefersDarkScheme.matches;
+            if (document.documentElement.classList.contains("dark") !== shouldBeDark) {
+                document.documentElement.classList.toggle("dark");
+            }
+        }
+        const setThemeMode = mode => { localStorage.themeMode = mode; };
+        const getThemeMode = () => localStorage.themeMode;
+
+        // transition from old dark theme system
+        if ("darkTheme" in localStorage) { // TODO: send notification? }
+        localStorage.removeItem("darkTheme");
+        // first visit or transition
+        if (!("themeMode" in localStorage)) { setThemeMode("system"); }
+
+        updateTheme();
+        mediaQueryPrefersDarkScheme.addEventListener("change", () => updateTheme());
+
+        document.addEventListener("alpine:init", () => {
+            Alpine.store("theme", {
+                init() { this.activeMode = getThemeMode(); },
+                setMode(mode) {
+                    this.activeMode = mode;
+                    setThemeMode(mode);
+                    updateTheme();
+                },
+                modes: {
+                    light: { name: "Light", faIconId: "sun" },
+                    dark: { name: "Dark", faIconId: "moon" },
+                    system: { name: "System", faIconId: "desktop" }
+                },
+                activeMode: "system"
+            });
+        });
+    </script>
+{{end}}

--- a/web/template/partial/theme-selector-head.gohtml
+++ b/web/template/partial/theme-selector-head.gohtml
@@ -23,7 +23,14 @@
 
         document.addEventListener("alpine:init", () => {
             Alpine.store("theme", {
-                init() { this.activeMode = getThemeMode(); },
+                init() {
+                    this.activeMode = getThemeMode();
+                    // show the currently active theme (light/dark) on the switcher when system theme mode is active
+                    const updateSystemModeSwitcherIconId = () =>
+                        this.modes.system.faSwitcherIconId = mediaQueryPrefersDarkScheme.matches ? "moon" : "sun";
+                    mediaQueryPrefersDarkScheme.addEventListener("change", () => updateSystemModeSwitcherIconId())
+                    updateSystemModeSwitcherIconId();
+                },
                 setMode(mode) {
                     this.activeMode = mode;
                     setThemeMode(mode);
@@ -32,9 +39,9 @@
                 modes: {
                     light: { name: "Light", faIconId: "sun" },
                     dark: { name: "Dark", faIconId: "moon" },
-                    system: { name: "System", faIconId: "desktop" }
+                    system: { name: "System", faIconId: "desktop", faSwitcherIconId: "" }
                 },
-                activeMode: "system"
+                activeMode: ""
             });
         });
     </script>

--- a/web/template/partial/theme-selector.gohtml
+++ b/web/template/partial/theme-selector.gohtml
@@ -17,11 +17,16 @@
     </div>
 {{end}}
 
+{{define "theme-switcher-icon"}}
+<i class="fa-solid" :class="'fa-' + (mode => mode.faSwitcherIconId ?? mode.faIconId)($store.theme.modes[$store.theme.activeMode])"></i>
+{{end}}
+
 {{define "theme-selector"}}
     <div class="relative" x-data="{ show: false, mobile: false }">
-        <button class="transition-colors duration-200 text-5 hover:text-1 mr-6 relative h-4 w-4"
+        <button class="transition-colors duration-200 hover:text-gray-600
+                       dark:hover:text-white text-gray-400 mr-6 relative h-4 w-4"
                 type="button" @click="show=!show">
-            <i class="fa-solid" :class="'fa-' + $store.theme.modes[$store.theme.activeMode].faIconId"></i>
+            {{template "theme-switcher-icon"}}
         </button>
         <div x-cloak x-show="show"
              @click.outside="show=false"
@@ -35,12 +40,12 @@
 {{define "theme-selector-mobile"}}
     <div class="border-b dark:border-gray-600 text-sm" x-data="{ show: false, mobile: true }">
         <div role="button" tabindex="0"
-             class="px-5 py-2 flex justify-end transition-colors duration-200 hover:text-gray-600 dark:hover:text-white text-gray-400"
+             class="px-5 py-2 flex justify-end transition-colors duration-200 text-5 hover:text-1"
              @click="show=!show">
             <span class="uppercase mr-2 my-auto">Theme</span>
             <div class="w-12 flex justify-end">
                 <div class="my-auto" aria-label="Theme">
-                    <i class="fa-solid" :class="'fa-' + $store.theme.modes[$store.theme.activeMode].faIconId"></i>
+                    {{template "theme-switcher-icon"}}
                 </div>
             </div>
         </div>

--- a/web/template/partial/theme-selector.gohtml
+++ b/web/template/partial/theme-selector.gohtml
@@ -30,7 +30,7 @@
         </button>
         <div x-cloak x-show="show"
              @click.outside="show=false"
-             class="origin-top-right absolute right-0 mt-4 lg:shadow-sm lg:rounded-lg h-fit bg-white border rounded-t-lg w-36
+             class="origin-top-right absolute right-0 mt-4 shadow-sm rounded-lg h-fit bg-white border w-36
                     dark:bg-secondary dark:border-gray-800 overflow-hidden">
             {{template "theme-selector-content"}}
         </div>

--- a/web/template/partial/theme-selector.gohtml
+++ b/web/template/partial/theme-selector.gohtml
@@ -1,30 +1,53 @@
+{{define "theme-selector-content"}}
+    <div class="my-auto w-full min-h-30 max-h-60 overflow-y-auto">
+        <template x-for="[modeId, mode] of Object.entries($store.theme.modes)" :key="modeId">
+            <div role="button" tabindex="0"
+                 x-data="{ active: () => modeId == $store.theme.activeMode }"
+                 class="p-2 w-full border-b dark:border-gray-800 relative last:border-0
+                               transition-colors duration-200 text-5 hover:text-1"
+                 :class="(active() ? ['bg-gray-100', 'dark:bg-secondary-lighter'] : []).concat(mobile ? ['px-5'] : [])"
+                 type="button"
+                 @click="$store.theme.setMode(modeId); show=false;">
+                <div class="flex items-center" :class="mobile ? 'flex-row-reverse' : ''">
+                    <i class="fa-solid" :class="['fa-' + mode.faIconId, mobile ? 'ml-8' : 'mr-2']"></i>
+                    <p x-text="mode.name" :class="mobile ? 'mr-2' : ''"></p>
+                </div>
+            </div>
+        </template>
+    </div>
+{{end}}
+
 {{define "theme-selector"}}
-    {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.User*/ -}}
-    <div class="relative" x-data="{ show: false }">
-        <button class="transition-colors duration-200 hover:text-gray-600 dark:hover:text-white text-gray-400 mr-6 relative h-4 w-4"
+    <div class="relative" x-data="{ show: false, mobile: false }">
+        <button class="transition-colors duration-200 text-5 hover:text-1 mr-6 relative h-4 w-4"
                 type="button" @click="show=!show">
-        <i class="fa-solid" :class="'fa-' + $store.theme.modes[$store.theme.activeMode].faIconId"></i>
+            <i class="fa-solid" :class="'fa-' + $store.theme.modes[$store.theme.activeMode].faIconId"></i>
         </button>
         <div x-cloak x-show="show"
              @click.outside="show=false"
              class="origin-top-right absolute right-0 mt-4 lg:shadow-sm lg:rounded-lg h-fit bg-white border rounded-t-lg w-36
                     dark:bg-secondary dark:border-gray-800 overflow-hidden">
-            <div class="my-auto w-full min-h-30 max-h-60 overflow-y-auto">
-                <template x-for="([modeId, mode], i) of Object.entries($store.theme.modes)" :key="modeId">
-                    <div role="button" tabindex="0"
-                            x-data="{ active: () => modeId == $store.theme.activeMode }"
-                            class="p-2 w-full border-b dark:border-gray-800 relative last:border-0
-                               transition-colors duration-200 text-5 hover:text-1"
-                            :class="active() ? 'bg-gray-100 dark:bg-secondary-lighter' : ''"
-                            type="button"
-                            @click="$store.theme.setMode(modeId); show=false;">
-                        <div class="flex items-center">
-                            <i class="fa-solid mr-2" :class="'fa-' + mode.faIconId"></i>
-                            <p x-text="mode.name"></p>
-                        </div>
-                    </div>
-                </template>
+            {{template "theme-selector-content"}}
+        </div>
+    </div>
+{{end}}
+
+{{define "theme-selector-mobile"}}
+    <div class="border-b dark:border-gray-600 text-sm" x-data="{ show: false, mobile: true }">
+        <div role="button" tabindex="0"
+             class="px-5 py-2 flex justify-end transition-colors duration-200 hover:text-gray-600 dark:hover:text-white text-gray-400"
+             @click="show=!show">
+            <span class="uppercase mr-2 my-auto">Theme</span>
+            <div class="w-12 flex justify-end">
+                <div class="my-auto" aria-label="Theme">
+                    <i class="fa-solid" :class="'fa-' + $store.theme.modes[$store.theme.activeMode].faIconId"></i>
+                </div>
             </div>
+        </div>
+        <div x-cloak x-show="show"
+             @click.outside="show=false"
+            class="bg-white border-t dark:bg-secondary dark:border-gray-800 overflow-hidden">
+            {{template "theme-selector-content"}}
         </div>
     </div>
 {{end}}

--- a/web/template/partial/theme-selector.gohtml
+++ b/web/template/partial/theme-selector.gohtml
@@ -1,0 +1,30 @@
+{{define "theme-selector"}}
+    {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.User*/ -}}
+    <div class="relative" x-data="{ show: false }">
+        <button class="transition-colors duration-200 hover:text-gray-600 dark:hover:text-white text-gray-400 mr-6 relative h-4 w-4"
+                type="button" @click="show=!show">
+        <i class="fa-solid" :class="'fa-' + $store.theme.modes[$store.theme.activeMode].faIconId"></i>
+        </button>
+        <div x-cloak x-show="show"
+             @click.outside="show=false"
+             class="origin-top-right absolute right-0 mt-4 lg:shadow-sm lg:rounded-lg h-fit bg-white border rounded-t-lg w-36
+                    dark:bg-secondary dark:border-gray-800 overflow-hidden">
+            <div class="my-auto w-full min-h-30 max-h-60 overflow-y-auto">
+                <template x-for="([modeId, mode], i) of Object.entries($store.theme.modes)" :key="modeId">
+                    <div role="button" tabindex="0"
+                            x-data="{ active: () => modeId == $store.theme.activeMode }"
+                            class="p-2 w-full border-b dark:border-gray-800 relative last:border-0
+                               transition-colors duration-200 text-5 hover:text-1"
+                            :class="active() ? 'bg-gray-100 dark:bg-secondary-lighter' : ''"
+                            type="button"
+                            @click="$store.theme.setMode(modeId); show=false;">
+                        <div class="flex items-center">
+                            <i class="fa-solid mr-2" :class="'fa-' + mode.faIconId"></i>
+                            <p x-text="mode.name"></p>
+                        </div>
+                    </div>
+                </template>
+            </div>
+        </div>
+    </div>
+{{end}}

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -61,23 +61,6 @@ export function unhideCourse(id: string) {
     document.location.reload();
 }
 
-export function isDark() {
-    return localStorage.getItem("darkTheme") ? JSON.parse(localStorage.getItem("darkTheme")) : true;
-}
-
-export function toggleColorScheme() {
-    //initial theme preference:
-    const darkTheme: boolean = isDark();
-    //store opposite
-    localStorage.setItem("darkTheme", JSON.stringify(!darkTheme));
-    //set opposite class
-    if (!darkTheme) {
-        document.documentElement.classList.add("dark");
-    } else {
-        document.documentElement.classList.remove("dark");
-    }
-}
-
 export function initHiddenCourses() {
     const el = document.getElementById("hiddenCoursesText");
     if (!el) {


### PR DESCRIPTION
More or less like in #134 .

**All** of the code is still in the header because I wasn't sure how to get access to the Alpine.js object from the webpack.

Naming convention: "theme mode": whether the theme is set manually to light/dark or to automatic (that's what github calls it).

Visually I tried to follow the rest of the header's design language: hovering increases contrast (text-5 to text-1), the dropdown is basically the same as the one for notifications and the selected mode is marked with a darker background as on the semester selection widget.

Outstanding:
- is there a way to notify users? or should they just notice by themselves :)

Next steps?
- GitHub has a nice smooth transition between light and dark modes. Just setting `transition-colors duration-200` on the body doesn't really do it (not everything transitions smoothly, and it conflicts with the use of transitions for hovering).

resolves #134, resolves #133 
