### PR TITLE
Draft: Fix sort order of VoDs within a given month

### DIFF
--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -19,7 +19,7 @@
         <!-- VoD -->
         <div {{if .IndexData.TUMLiveContext}}x-init="watchedTracker.init({{.WatchedData}})"
              x-data="watchedTracker = new global.WatchedTracker" {{end}}class="w-full md:row-span-6 md:col-span-3">
-            <div x-data="{asc: false{{if .IndexData.TUMLiveContext.User}}, filterWatched: true, watchedAll: watchedTracker.userWatchedAll(){{end}}}"
+            <div x-data="{asc: false, vodList: $el.querySelector('.vod-list') {{if .IndexData.TUMLiveContext.User}}, filterWatched: true, watchedAll: watchedTracker.userWatchedAll(){{end}}}"
                  class="bg-white h-full border dark:bg-secondary dark:border-gray-800 rounded-lg
                     shadow-sm flex flex-col">
                 <div class="flex justify-between h-16 px-3 border-b dark:border-gray-800">
@@ -27,8 +27,7 @@
                     <div class="my-auto">
                         {{if .Course.HasRecordings}}
                             <button class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded px-2"
-                                    x-init="global.reorderVodList()"
-                                    @click="asc = !asc; global.reorderVodList()">
+                                    @click="asc = !asc; global.mirror(vodList, ['.vod-list-month', '.vod-list-video'])">
                             <span class="text-sm font-semibold uppercase dark:text-white"
                                   x-text="asc ? '&#x25B2; asc' : '&#x25BC; desc'">desc &#x25BC;</span>
                             </button>
@@ -45,7 +44,7 @@
                         {{end}}
                     </div>
                 </div>
-                <ul id="vod-list" class="flex flex-col flex-1 px-5 py-3 overflow-y-scroll">
+                <ul class="vod-list flex flex-col flex-1 px-5 py-3 overflow-y-scroll">
                     {{template "vod_course_list" . }}
                 </ul>
             </div>

--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -19,7 +19,7 @@
         <!-- VoD -->
         <div {{if .IndexData.TUMLiveContext}}x-init="watchedTracker.init({{.WatchedData}})"
              x-data="watchedTracker = new global.WatchedTracker" {{end}}class="w-full md:row-span-6 md:col-span-3">
-            <div x-data="{asc: false, mirror: global.mirror($el.querySelector('.vod-list'), ['.vod-list-month', '.vod-list-video'])
+            <div x-data="{asc: false, mirror: () => { global.mirror($el.querySelector('.vod-list'), ['.vod-list-month', '.vod-list-video']); }
                     {{if .IndexData.TUMLiveContext.User}}, filterWatched: true, watchedAll: watchedTracker.userWatchedAll(){{end}}}"
                  class="bg-white h-full border dark:bg-secondary dark:border-gray-800 rounded-lg
                     shadow-sm flex flex-col">

--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -19,7 +19,8 @@
         <!-- VoD -->
         <div {{if .IndexData.TUMLiveContext}}x-init="watchedTracker.init({{.WatchedData}})"
              x-data="watchedTracker = new global.WatchedTracker" {{end}}class="w-full md:row-span-6 md:col-span-3">
-            <div x-data="{asc: false, vodList: $el.querySelector('.vod-list') {{if .IndexData.TUMLiveContext.User}}, filterWatched: true, watchedAll: watchedTracker.userWatchedAll(){{end}}}"
+            <div x-data="{asc: false, mirror: global.mirror($el.querySelector('.vod-list'), ['.vod-list-month', '.vod-list-video'])
+                    {{if .IndexData.TUMLiveContext.User}}, filterWatched: true, watchedAll: watchedTracker.userWatchedAll(){{end}}}"
                  class="bg-white h-full border dark:bg-secondary dark:border-gray-800 rounded-lg
                     shadow-sm flex flex-col">
                 <div class="flex justify-between h-16 px-3 border-b dark:border-gray-800">
@@ -27,7 +28,8 @@
                     <div class="my-auto">
                         {{if .Course.HasRecordings}}
                             <button class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded px-2"
-                                    @click="asc = !asc; global.mirror(vodList, ['.vod-list-month', '.vod-list-video'])">
+                                    x-init="mirror()"
+                                    @click="asc = !asc; mirror();">
                             <span class="text-sm font-semibold uppercase dark:text-white"
                                   x-text="asc ? '&#x25B2; asc' : '&#x25BC; desc'">desc &#x25BC;</span>
                             </button>

--- a/web/template/vod_course_list.gohtml
+++ b/web/template/vod_course_list.gohtml
@@ -9,10 +9,10 @@
             {{if ne $lecture.Start.Month $lastMonth}}
                 {{if ne $lastMonth -1}} </div> {{end}}
                 {{$lastMonth = $lecture.Start.Month}}
-                <div class="my-2" {{if $user}}x-show="!filterWatched || (filterWatched && !monthHidden)" x-data="{ monthHidden: watchedTracker.userWatchedMonth(`{{$lecture.Start.Month.String}}`) }"{{end}}> <!-- div with monthname <p> and all <li> elements -->
+                <div class="vod-list-month my-2" {{if $user}}x-show="!filterWatched || (filterWatched && !monthHidden)" x-data="{ monthHidden: watchedTracker.userWatchedMonth(`{{$lecture.Start.Month.String}}`) }"{{end}}> <!-- div with monthname <p> and all <li> elements -->
                 <p class="text-gray-500 text-sm uppercase">{{printf "%v %v" $lastMonth $lecture.Start.Year}}</p>
             {{end}}
-            <li class="p-2 w-full" {{if $user}}x-show="!filterWatched || (filterWatched && !watched)" x-data="{ watched: {{$lecture.Watched}} }"{{end}}>
+            <li class="vod-list-video p-2 w-full" {{if $user}}x-show="!filterWatched || (filterWatched && !watched)" x-data="{ watched: {{$lecture.Watched}} }"{{end}}>
                 <div class="flex justify-between">
                     <div>
                         <div>

--- a/web/ts/course-overview.ts
+++ b/web/ts/course-overview.ts
@@ -43,12 +43,3 @@ export class WatchedTracker {
         return this.streams.findIndex((s) => !s.watched) === -1;
     }
 }
-
-export function reorderVodList() {
-    const vodList = document.getElementById("vod-list");
-    const months = vodList.children;
-
-    for (let i = months.length - 1; i >= 0; i--) {
-        vodList.appendChild(months[i]);
-    }
-}

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -75,7 +75,6 @@ export function unhideCourse(id: string) {
  * Mirrors a tree (reverses the order of its "leaves") in the DOM.
  */
 export function mirror(parent: Element, levelSelectors: string[], levelIndex = 0) {
-    console.log(parent, levelSelectors, levelIndex);
     const children = parent.querySelectorAll(levelSelectors[levelIndex]); // querySelectorAll returns static node list
 
     // if this is not a leaf, recurse

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -71,6 +71,27 @@ export function unhideCourse(id: string) {
     document.location.reload();
 }
 
+/**
+ * Mirrors a tree (reverses the order of its "leaves") in the DOM.
+ */
+export function mirror(parent: Element, levelSelectors: string[], levelIndex=0) {
+    console.log(parent, levelSelectors, levelIndex);
+    const children = parent.querySelectorAll(levelSelectors[levelIndex]); // querySelectorAll returns static node list
+
+    // if this is not a leaf, recurse
+    if (levelIndex + 1 < levelSelectors.length)
+        children.forEach(child => mirror(child, levelSelectors, levelIndex + 1));
+
+    // mirror the direct children
+    const placeholder = document.createElement("div");
+    for (let childI = 0; childI * 2 + 1 < children.length; childI++) {
+        const a = children[childI], b = children[children.length - childI - 1];
+        a.replaceWith(placeholder);
+        b.replaceWith(a);
+        placeholder.replaceWith(b);
+    }
+}
+
 export function initHiddenCourses() {
     const el = document.getElementById("hiddenCoursesText");
     if (!el) {

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -74,18 +74,19 @@ export function unhideCourse(id: string) {
 /**
  * Mirrors a tree (reverses the order of its "leaves") in the DOM.
  */
-export function mirror(parent: Element, levelSelectors: string[], levelIndex=0) {
+export function mirror(parent: Element, levelSelectors: string[], levelIndex = 0) {
     console.log(parent, levelSelectors, levelIndex);
     const children = parent.querySelectorAll(levelSelectors[levelIndex]); // querySelectorAll returns static node list
 
     // if this is not a leaf, recurse
     if (levelIndex + 1 < levelSelectors.length)
-        children.forEach(child => mirror(child, levelSelectors, levelIndex + 1));
+        children.forEach((child) => mirror(child, levelSelectors, levelIndex + 1));
 
     // mirror the direct children
     const placeholder = document.createElement("div");
     for (let childI = 0; childI * 2 + 1 < children.length; childI++) {
-        const a = children[childI], b = children[children.length - childI - 1];
+        const a = children[childI];
+        const b = children[children.length - childI - 1];
         a.replaceWith(placeholder);
         b.replaceWith(a);
         placeholder.replaceWith(b);


### PR DESCRIPTION
Currently, changing between the ascending and descending sort order on the VoD overview only changes the order of the months, which I think is not the expected behaviour (and I've heard from at least one other person who found it confusing). Instead, the lectures should all be sorted by date (either ascending or descending) within a month AND the months should be sorted. This PR fixes that.

Before (order of lectures is 2, 3, 1):
![image](https://user-images.githubusercontent.com/17551908/167889404-3f06e6f8-840b-4a2d-ac16-58f7ad661418.png)

After (order 3, 2, 1):
![image](https://user-images.githubusercontent.com/17551908/167890834-88f13c4a-55b5-4880-a087-1d3acdef842a.png)

Resolves #448