### PR TITLE
added Links to the rooms in the about section

### DIFF
--- a/web/template/about.gohtml
+++ b/web/template/about.gohtml
@@ -24,7 +24,18 @@
     </p>
     <p><b>1. Die Veranstaltung findet in einem von uns ausgestatteten Raum statt:</b><br>
         Ihre Veranstaltung läuft in einen dieser Räume:
-        <i><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5602.EG.001">MI HS 1</a>, <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5604.EG.011">MI HS 2</a>, <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5606.EG.011">MI HS 3</a>, <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5608.EG.038">00.08.038</a> (Seminarraum), <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5613.EG.009A">00.13.009A</a> (Seminarraum), <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5620.01.101">Interims I (101)</a>, <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5620.01.102">Interims I(102)</a></i>.<br>
+        <ul class="ml-3 pl-3 list-disc">
+            <li><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5510.EG.001">MW0001</a>,</li>
+            <li><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5510.02.001">MW2001</a>,</li>
+            <li><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5602.EG.001">MI HS 1</a>,</li>
+            <li><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5604.EG.011">MI HS 2</a>,</li>
+            <li><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5606.EG.011">MI HS 3</a>,</li>
+            <li><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5608.EG.038">00.08.038</a> (Seminarraum),</li>
+            <li><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5613.EG.009A">00.13.009A</a> (Seminarraum),</li>
+            <li><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5607.EG.014">00.07.014</a> (Seminarraum),</li>
+            <li><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5620.01.101">Interims I (101)</a>,</li>
+            <li><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5620.01.102">Interims I(102)</a></li>
+        </ul>
         In diesem Fall wird die Veranstaltung automatisch übertragen und aufgezeichnet.
         Sie bekommen vor Semesterbeginn eine Benachrichtigung von uns und können einstellen, ob die
         Veranstaltung übertragen werden soll, welche Features aktiviert werden und wer sie sehen darf.<br>

--- a/web/template/about.gohtml
+++ b/web/template/about.gohtml
@@ -24,7 +24,7 @@
     </p>
     <p><b>1. Die Veranstaltung findet in einem von uns ausgestatteten Raum statt:</b><br>
         Ihre Veranstaltung läuft in einen dieser Räume:
-        <i>MI HS 1, MI HS 2, MI HS 3, 00.08.038 (Seminarraum), 00.13.009A (Seminarraum), Interims I (101), Interims I(102)</i>.<br>
+        <i><a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5602.EG.001">MI HS 1</a>, <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5604.EG.011">MI HS 2</a>, <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5606.EG.011">MI HS 3</a>, <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5608.EG.038">00.08.038</a> (Seminarraum), <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5613.EG.009A">00.13.009A</a> (Seminarraum), <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5620.01.101">Interims I (101)</a>, <a class="underline" target="_blank" rel="noopener" href="https://nav.tum.sexy/room/5620.01.102">Interims I(102)</a></i>.<br>
         In diesem Fall wird die Veranstaltung automatisch übertragen und aufgezeichnet.
         Sie bekommen vor Semesterbeginn eine Benachrichtigung von uns und können einstellen, ob die
         Veranstaltung übertragen werden soll, welche Features aktiviert werden und wer sie sehen darf.<br>


### PR DESCRIPTION
This PR adds links to the room listed in the about us section.
Possibly sourounding this with a ul/li elements would have been nicer for code-readability, but that would have been a layout change and I wanted to keep my change as minmal as possible to increase the change of this being merged.