### PR TITLE
Make database host configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,7 @@ Features include:
 
 ## Getting Started
 
-To get this running locally follow these steps:
-
-### Setup IPs
-
-In `/etc/hosts` add this: 
-```
-127.0.0.1  db
-```
+To get TUM-Live running locally follow these steps:
 
 ### Setup Database
 - Follow the steps [here](https://mariadb.com/kb/en/installing-and-using-mariadb-via-docker/) to install mariadb via docker.

--- a/cmd/tumlive/tumlive.go
+++ b/cmd/tumlive/tumlive.go
@@ -93,9 +93,10 @@ func main() {
 		defer sentry.Recover()
 	}
 	db, err := gorm.Open(mysql.Open(fmt.Sprintf(
-		"%v:%v@tcp(db:3306)/%v?parseTime=true&loc=Local",
+		"%s:%s@tcp(%s:3306)/%s?parseTime=true&loc=Local",
 		tools.Cfg.Db.User,
 		tools.Cfg.Db.Password,
+		tools.Cfg.Db.Host,
 		tools.Cfg.Db.Database),
 	), &gorm.Config{
 		PrepareStmt: true,

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,7 @@ campus:
   - secret1
   - secret2
 db:
+  host: localhost
   database: tumlive
   password: example
   user: root

--- a/tools/config.go
+++ b/tools/config.go
@@ -103,6 +103,7 @@ type Config struct {
 		User     string `yaml:"user"`
 		Password string `yaml:"password"`
 		Database string `yaml:"database"`
+		Host     string `yaml:"host"`
 	} `yaml:"db"`
 	Campus struct {
 		Base   string   `yaml:"base"`


### PR DESCRIPTION
This PR adds a config field for the database host.

Please note, that you might need to add this to your config if you copied it to ~/.TUM-Live or /etc/TUM-Live