### PR TITLE
[Draft] Highlight current video section on watch page

### DIFF
--- a/web/template/partial/stream/video-sections.gohtml
+++ b/web/template/partial/stream/video-sections.gohtml
@@ -1,4 +1,5 @@
 {{define "videosections"}}
+    {{/* todo */}}
     <div class="w-full">
         <h6 class="font-bold text-3 pb-3">Sections</h6>
         <div class="overflow-auto flex">


### PR DESCRIPTION
Todos: 
- [ ] Add class `outline` to currently active video section
- [ ] (Maybe, if possible) display `section.description` in the player itself

<img width="433" alt="image" src="https://user-images.githubusercontent.com/29633518/168534734-3c80f10b-029b-4c34-806d-8f1a2aabdd8f.png">
