### PR TITLE
Updated playbackRates

### DIFF
--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -29,7 +29,7 @@ export const initPlayer = function (
         {
             liveui: true,
             fluid: fluid,
-            playbackRates: [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
+            playbackRates: [0.5, 1, 1.25, 1.5, 1.75, 2, 2.5, 3],
             html5: {
                 reloadSourceOnError: true,
                 vhs: {


### PR DESCRIPTION
I widedned the upper range for playbackRates and removed one in the lower rate

The reasoning for this Stepsize: 
  - between 1..2 0.25 is a sane stepsize, as I would assume that most users watch in this range
  - 0.5..1 and 2..3: This is a range, I would assume to be uncommon, so we dont need to offer such a granular stepsize.