### PR TITLE
Improve filtering watched videos

### DIFF
--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -35,64 +35,70 @@
                             </button>
                         {{end}}
                         {{if and .IndexData.TUMLiveContext.User .Course.HasRecordings }}
-                            <button class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded px-2"
-                                    @click="filterWatched=!filterWatched"
-                                    :title="filterWatched ? 'Show watched streams' : 'Hide watched streams'">
-                            <span class="text-sm font-semibold uppercase dark:text-white">
-                                <i class="fa-solid w-5 mr-1"
-                                   :class="filterWatched ? 'fa-eye' : 'fa-eye-slash'"></i>watched
-                            </span>
-                            </button>
+                            <template x-if="watchedCount > 0">
+                                <button class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded px-2"
+                                        @click="filterWatched=!filterWatched"
+                                        :title="filterWatched ? 'Show watched streams' : 'Hide watched streams'">
+                                        <span class="text-sm font-semibold uppercase dark:text-white">
+                                            <i class="fa-solid w-5 mr-1"
+                                               :class="filterWatched ? 'fa-eye-slash' : 'fa-eye'"></i>watched
+                                           (<span class="tabular-nums" x-text="watchedCount"></span>)
+                                        </span>
+                                </button>
+                            </template>
                         {{end}}
                     </div>
                 </div>
-                <ul class="vod-list flex flex-col flex-1 px-5 py-3 overflow-y-scroll">
+                <ul class=" vod-list flex flex-col flex-1 px-5 py-3 overflow-y-scroll">
                     {{template "vod_course_list" . }}
                 </ul>
             </div>
         </div>
         <!-- Next Lecture -->
         {{if or $course.HasNextLecture $course.IsLive}}
-        <div class="flex w-full relative bg-white border dark:bg-secondary dark:border-gray-800 rounded-lg
+            <div class="flex w-full relative bg-white border dark:bg-secondary dark:border-gray-800 rounded-lg
                     shadow-sm py-3 px-5 my-3 order-first md:my-0 md:row-span-1 md:col-span-2 md:order-none ">
-            {{$lecture := $course.GetNextLecture}}
-            {{if $course.IsLive}}
-                {{$liveLectures := $course.GetLiveStreams}}
-                <span class="absolute -top-1 -right-1 flex h-5 w-5">
+                {{$lecture := $course.GetNextLecture}}
+                {{if $course.IsLive}}
+                    {{$liveLectures := $course.GetLiveStreams}}
+                    <span class="absolute -top-1 -right-1 flex h-5 w-5">
                   <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-700 opacity-75"></span>
                   <span class="relative inline-flex rounded-full h-5 w-5 bg-danger"></span>
                 </span>
-                <div class="my-auto">
-                    <h1 class="text-2xl font-bold text-3">Live Now!</h1>
-                    {{range $liveLectures}}
-                        <a class="font-light block text-sm dark:text-white" href="/w/{{$course.Slug}}/{{.Model.ID}}">
-                            <i class="fas fa-angle-right"></i>
-                            <span class="hover:underline">Open stream{{if gt (len $liveLectures) 1}} <span class="font-semibold">{{.GetName}}</span>{{end}}</span>
-                        </a>
-                    {{end}}
-                </div>
-            {{else if $lecture.IsComingUp}}
-                <span class="absolute -top-1 -right-1 flex h-5 w-5">
+                    <div class="my-auto">
+                        <h1 class="text-2xl font-bold text-3">Live Now!</h1>
+                        {{range $liveLectures}}
+                            <a class="font-light block text-sm dark:text-white"
+                               href="/w/{{$course.Slug}}/{{.Model.ID}}">
+                                <i class="fas fa-angle-right"></i>
+                                <span class="hover:underline">Open stream{{if gt (len $liveLectures) 1}} <span
+                                        class="font-semibold">{{.GetName}}</span>{{end}}</span>
+                            </a>
+                        {{end}}
+                    </div>
+                {{else if $lecture.IsComingUp}}
+                    <span class="absolute -top-1 -right-1 flex h-5 w-5">
                   <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-500 opacity-75"></span>
                   <span class="relative inline-flex rounded-full h-5 w-5 bg-wait"></span>
                 </span>
-                <div class="my-auto">
-                    <h1 class="text-2xl font-bold text-3">Live Soon!</h1>
-                    <a class="font-light text-sm dark:text-white" href="/w/{{$course.Slug}}/{{$lecture.Model.ID}}">
-                        <i class="fas fa-angle-right"></i>
-                        <span>Join waiting room</span>
-                    </a>
-                </div>
-            {{else}}
-                <div class="my-auto">
-                    <h1 class="text-2xl font-bold text-3">
-                        {{$next := $lecture.Start}}
-                        {{$lecture.FriendlyNextDate}}
-                    </h1>
-                    <span class="font-light text-sm text-3">Next Livestream</span>
-                </div>
-            {{end}}
-        </div>
+                    <div class="my-auto">
+                        <h1 class="text-2xl font-bold text-3">Live Soon!</h1>
+                        <a class="font-light text-sm dark:text-white"
+                           href="/w/{{$course.Slug}}/{{$lecture.Model.ID}}">
+                            <i class="fas fa-angle-right"></i>
+                            <span>Join waiting room</span>
+                        </a>
+                    </div>
+                {{else}}
+                    <div class="my-auto">
+                        <h1 class="text-2xl font-bold text-3">
+                            {{$next := $lecture.Start}}
+                            {{$lecture.FriendlyNextDate}}
+                        </h1>
+                        <span class="font-light text-sm text-3">Next Livestream</span>
+                    </div>
+                {{end}}
+            </div>
         {{end}}
         <!-- Planned -->
         <div class="w-full {{if $course.HasNextLecture}}md:row-span-5{{else}}md:row-span-6{{end}} md:col-span-2">
@@ -109,9 +115,9 @@
                                   x-text="showPlanned ? '&#x25B2; hide' : '&#x25BC; show'">&#x25B2; hide</span>
                         </button>
                         <a class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded px-2"
-                                href="/api/download_ics/{{$course.Year}}/{{$course.TeachingTerm}}/{{$course.Slug}}/events.ics"
-                                :title="'Export lecture dates'"
-                                x-show="lectures">
+                           href="/api/download_ics/{{$course.Year}}/{{$course.TeachingTerm}}/{{$course.Slug}}/events.ics"
+                           :title="'Export lecture dates'"
+                           x-show="lectures">
                                 <span class="text-sm font-semibold uppercase dark:text-white">
                                     <i class="fa-solid w-5 mr-1 fa-calendar"></i>ics
                                 </span>

--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -19,7 +19,7 @@
         <!-- VoD -->
         <div {{if .IndexData.TUMLiveContext}}x-init="watchedTracker.init({{.WatchedData}})"
              x-data="watchedTracker = new global.WatchedTracker" {{end}}class="w-full md:row-span-6 md:col-span-3">
-            <div x-data="{asc: false, mirror: () => { global.mirror($el.querySelector('.vod-list'), ['.vod-list-month', '.vod-list-video']); }
+            <div x-data="{asc: $persist(false), mirror: () => { global.mirror($el.querySelector('.vod-list'), ['.vod-list-month', '.vod-list-video']); }
                     {{if .IndexData.TUMLiveContext.User}}, filterWatched: $persist(false), watchedAll: watchedTracker.userWatchedAll(), watchedCount: watchedTracker.countWatched(){{end}}}"
                  class="bg-white h-full border dark:bg-secondary dark:border-gray-800 rounded-lg
                     shadow-sm flex flex-col">

--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -20,7 +20,7 @@
         <div {{if .IndexData.TUMLiveContext}}x-init="watchedTracker.init({{.WatchedData}})"
              x-data="watchedTracker = new global.WatchedTracker" {{end}}class="w-full md:row-span-6 md:col-span-3">
             <div x-data="{asc: false, mirror: () => { global.mirror($el.querySelector('.vod-list'), ['.vod-list-month', '.vod-list-video']); }
-                    {{if .IndexData.TUMLiveContext.User}}, filterWatched: true, watchedAll: watchedTracker.userWatchedAll(){{end}}}"
+                    {{if .IndexData.TUMLiveContext.User}}, filterWatched: $persist(false), watchedAll: watchedTracker.userWatchedAll(), watchedCount: watchedTracker.countWatched(){{end}}}"
                  class="bg-white h-full border dark:bg-secondary dark:border-gray-800 rounded-lg
                     shadow-sm flex flex-col">
                 <div class="flex justify-between h-16 px-3 border-b dark:border-gray-800">

--- a/web/template/vod_course_list.gohtml
+++ b/web/template/vod_course_list.gohtml
@@ -12,7 +12,8 @@
                 <div class="vod-list-month my-2" {{if $user}}x-show="!filterWatched || (filterWatched && !monthHidden)" x-data="{ monthHidden: watchedTracker.userWatchedMonth(`{{$lecture.Start.Month.String}}`) }"{{end}}> <!-- div with monthname <p> and all <li> elements -->
                 <p class="text-gray-500 text-sm uppercase">{{printf "%v %v" $lastMonth $lecture.Start.Year}}</p>
             {{end}}
-            <li class="vod-list-video p-2 w-full" {{if $user}}x-show="!filterWatched || (filterWatched && !watched)" x-data="{ watched: {{$lecture.Watched}} }"{{end}}>
+            <li class="vod-list-video p-2 w-full" {{if $user}}x-show="!filterWatched || (filterWatched && !watched)"
+                x-data="{ watched: {{$lecture.Watched}} }"{{end}}>
                 <div class="flex justify-between">
                     <div>
                         <div>
@@ -26,9 +27,12 @@
                                         @click="
                                         watched = !watched;
                                         watchedTracker.setWatched({{$lecture.Model.ID}}, watched);
+                                        watchedCount = watchedTracker.countWatched();
                                         monthHidden = watchedTracker.userWatchedMonth(`{{$lecture.Start.Month.String}}`); {{/* Updates state in the client and in the database */}}
                                         watchedAll = watchedTracker.userWatchedAll();">
-                                    <i :title="watched ? 'Mark as unwatched' : 'Mark as watched'" class="fa-solid text-l text-3 font-semibold" :class="watched ? 'fa-clock-rotate-left' : 'fa-check'"></i>
+                                    <i :title="watched ? 'Mark as unwatched' : 'Mark as watched'"
+                                       class="fa-solid text-l text-3 font-semibold"
+                                       :class="watched ? 'fa-clock-rotate-left' : 'fa-check'"></i>
                                 </button>
                             {{end}}
                         </div>
@@ -94,7 +98,8 @@
     {{end}}
     {{if and .User $course.HasRecordings}}
         </div>
-        <p x-show="watchedAll && filterWatched" class="font-semibold m-auto dark:text-white border-b-2 border-black dark:border-white">All VoDs watched</p>
+        <p x-show="watchedAll && filterWatched"
+           class="font-semibold m-auto dark:text-white border-b-2 border-black dark:border-white">All VoDs watched</p>
     {{end}}
     {{if eq $lastMonth -1}}
         <p class="font-semibold m-auto dark:text-white border-b-2 border-black dark:border-white">No VoDs yet</p>

--- a/web/ts/course-overview.ts
+++ b/web/ts/course-overview.ts
@@ -39,6 +39,10 @@ export class WatchedTracker {
         return unwatchedStreamIndex === -1;
     }
 
+    countWatched(): number {
+        return this.streams.filter((s) => s.watched).length;
+    }
+
     userWatchedAll(): boolean {
         return this.streams.findIndex((s) => !s.watched) === -1;
     }


### PR DESCRIPTION
**Description**:

- Makes setting the VoD order and "filter watched" persistent
- Adds a counter behind "filter watched", so there is a visual indicator that there is something that is/can be filtered
- Only show the filter option, when watched lectures exist

If you have any other ideas for this feature, please tell me!

**Demo**:

![Peek 2022-05-17 13-59](https://user-images.githubusercontent.com/30267166/168805902-00748c8f-90f9-45a1-85bb-8fbce435b613.gif)