### PR TITLE
Fix height of ICS export button

### DIFF
--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -114,7 +114,7 @@
                             <span class="text-sm font-semibold uppercase dark:text-white"
                                   x-text="showPlanned ? '&#x25B2; hide' : '&#x25BC; show'">&#x25B2; hide</span>
                         </button>
-                        <a class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded px-2"
+                        <a class="hover:bg-gray-200 dark:hover:bg-gray-600 inline-block rounded px-2"
                            href="/api/download_ics/{{$course.Year}}/{{$course.TeachingTerm}}/{{$course.Slug}}/events.ics"
                            :title="'Export lecture dates'"
                            x-show="lectures">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/17551908/169247400-405f4044-ca93-44af-88d5-c071bb031c7f.png)

After:
![image](https://user-images.githubusercontent.com/17551908/169247451-3c3ca2c9-d160-424e-b5e4-960aaf2b1310.png)

Peace at last.
