### PR TITLE
Add Hotkeys for Video Player

### DIFF
--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -266,6 +266,73 @@ button.vjs-skip-silence-control {
     line-height: 1.5em !important;
 }
 
+/* Overlay icons that show up when various hotkeys are activated */
+
+.video-js .vjs-overlay-icon-container {
+    width: 100%;
+    height: 100%;
+
+    position: absolute;
+    pointer-events: none;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    font-size: 2rem;
+}
+
+.video-js .vjs-overlay-icon-container .vjs-overlay-icon-wrapper {
+    background: rgba(0, 0, 0, 0.5);
+    color: white;
+
+    width: 2em;
+    height: 2em;
+    border-radius: 1000px;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    opacity: 0;
+}
+
+@keyframes vjs-overlay-icon-frames {
+    from {
+        opacity: 0;
+        transform: scale(1);
+    }
+    10% {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+        transform: scale(2);
+    }
+}
+
+@keyframes vjs-overlay-icon-frames-reduced-motion {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+.video-js .vjs-overlay-icon-container.vjs-overlay-icon-animate .vjs-overlay-icon-wrapper {
+    animation: ease-in 0.6s vjs-overlay-icon-frames 0s /*infinite*/ 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .video-js .vjs-overlay-icon-container.vjs-overlay-icon-animate .vjs-overlay-icon-wrapper {
+        animation-name: vjs-overlay-icon-frames-reduced-motion;
+    }
+}
+
+.video-js .vjs-overlay-icon-container.vjs-overlay-icon-visible {
+    display: flex;
+}
+
 a.fc-event, a.fc-event:hover {
     cursor: pointer;
 }

--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -31,27 +31,24 @@ export const initPlayer = function (
     courseUrl?: string,
     streamStartIn?: number, // in seconds
 ) {
-    player = videojs(
-        "my-video",
-        {
-            liveui: true,
-            fluid: fluid,
-            playbackRates: playbackSpeeds,
-            html5: {
-                reloadSourceOnError: true,
-                vhs: {
-                    overrideNative: !videojs.browser.IS_SAFARI,
-                },
-                nativeVideoTracks: false,
-                nativeAudioTracks: false,
-                nativeTextTracks: false,
+    player = videojs("my-video", {
+        liveui: true,
+        fluid: fluid,
+        playbackRates: playbackSpeeds,
+        html5: {
+            reloadSourceOnError: true,
+            vhs: {
+                overrideNative: !videojs.browser.IS_SAFARI,
             },
-            userActions: {
-                hotkeys: handleHotkeys(),
-            },
-            autoplay: autoplay,
+            nativeVideoTracks: false,
+            nativeAudioTracks: false,
+            nativeTextTracks: false,
         },
-    );
+        userActions: {
+            hotkeys: handleHotkeys(),
+        },
+        autoplay: autoplay,
+    });
     player.hlsQualitySelector();
     player.seekButtons({
         // TODO user preferences, e.g. change to 5s
@@ -97,8 +94,7 @@ export const initPlayer = function (
         }
         player.addChild("OverlayIcon", {});
     });
-    // handle hotkeys from anywhere on page
-    // TODO is this safe
+    // handle hotkeys from anywhere on the page
     document.addEventListener("keydown", (event) => player.handleKeyDown(event));
 };
 

--- a/web/ts/hotkeys.ts
+++ b/web/ts/hotkeys.ts
@@ -33,10 +33,6 @@ const handleWithClick = (name) => (player, event) => {
     ButtonComponent.prototype.handleClick.call(player, event);
 };
 
-function handleMute(player, event) {
-    handleWithClick("MuteToggle")(player, event);
-}
-
 const handleSeek = (forward: boolean) => (player, event) => {
     const controlBar = player.controlBar;
     (forward ? controlBar.seekForward : controlBar.seekBack).handleClick(event);
@@ -84,17 +80,17 @@ interface Hotkeys {
 /**
  * See {@link handleHotkeys}.
  */
-// TODO: is there any value to additional media key handling (MediaPause, MediaFastForward, ...)
 // see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values for documentation
 export const defaultOptions = {
     hotkeys: {
         fullscreen: {
             match: ["f", "F"],
             handle: handleWithClick("FullscreenToggle"),
+            icon: (player) => vjsIcon(player.isFullscreen() ? "fullscreen-exit" : "fullscreen-enter"),
         },
         mute: {
             match: ["m", "M", "AudioVolumeMute", "VolumeMute"],
-            handle: handleMute,
+            handle: handleWithClick("MuteToggle"),
             icon: volumeIcon(true),
         },
         // "Spacebar" is for IE+old Firefox

--- a/web/ts/hotkeys.ts
+++ b/web/ts/hotkeys.ts
@@ -1,0 +1,180 @@
+import videojs from "video.js";
+
+// VideoJS uses `import * as keycode from "keycode";`
+// However, keycode uses deprecated event.keyCode https://github.com/timoxley/keycode/issues/52
+// The code used below avoids the mentioned IE issue (see link) by matching old key names too.
+
+// TODO: disable some actions for live streams (forward/backwards, seek to percentage, ...)
+
+// helpers
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+const optional = (value) => ({
+    value,
+    map: (ifPresent) => optional(value === undefined ? undefined : ifPresent(value)),
+});
+const fa = (icon) => `fa-solid fa-${icon}`;
+const vjsIcon = (icon) => `vjs-icon-${icon}`;
+
+/**
+ * Checks whether the event matches one of the given key codes.
+ * @param keys An iterable of strings, each naming a key code as per {@link KeyboardEvent#key}.
+ * @param event The event to match.
+ */
+const matchKeys = (keys: Iterable<string>, event: videojs.KeyboardEvent) =>
+    Array.from(keys).includes(event.key) ? event.key : undefined;
+
+const matches = (match, player, event) =>
+    typeof match === "function" ? match(player, event) : matchKeys(match, event);
+
+const getIcon = (icon, player, event) => (typeof icon === "function" ? icon(player, event) : icon);
+
+const handleWithClick = (name) => (player, event) => {
+    const ButtonComponent = videojs.getComponent(name);
+    ButtonComponent.prototype.handleClick.call(player, event);
+};
+
+function handleMute(player, event) {
+    handleWithClick("MuteToggle")(player, event);
+}
+
+const handleSeek = (forward: boolean) => (player, event) => {
+    const controlBar = player.controlBar;
+    (forward ? controlBar.seekForward : controlBar.seekBack).handleClick(event);
+};
+
+const handleVolume = (up: boolean, step = 0.05) =>
+    function (player) {
+        player.volume(clamp(player.volume() + (up ? step : -step), 0, 1));
+        player.muted(false);
+    };
+
+const volumeIcon = (up: boolean) => (player) =>
+    vjsIcon(`volume-${player.muted() || player.volume() == 0 ? "mute" : up ? "high" : "mid"}`);
+
+const handlePlaybackRate = (increase: boolean) => (player) => {
+    const playbackRates = player.playbackRates();
+    if (playbackRates) {
+        const currIndex = playbackRates.indexOf(player.playbackRate());
+        const newIndex = increase ? currIndex + 1 : currIndex - 1;
+        if (newIndex < 0 || newIndex >= playbackRates.length) return;
+        player.playbackRate(playbackRates[newIndex]);
+    }
+};
+
+const numberKeys = Array.from({ length: 10 }, (_, i) => i.toString());
+function matchSeekPercentage(player, event) {
+    return optional(matchKeys(numberKeys, event)).map((key) => key / 10).value;
+}
+
+const handleSeekPercentage = (player, _, percentage) => {
+    // TODO: what does player.duration() return for a live stream? Presumably NaN (same as before loading)
+    optional(player.duration() || undefined).map((duration) => {
+        const ended = player.ended();
+        player.currentTime(clamp(percentage, 0, 1) * duration);
+        if (ended) player.play();
+    });
+};
+
+const handleSeekTo = (percentage) => (player, event) => handleSeekPercentage(player, event, percentage);
+
+interface Hotkeys {
+    [actionName: string]: { match; handle; icon? };
+}
+
+/**
+ * See {@link handleHotkeys}.
+ */
+// TODO: is there any value to additional media key handling (MediaPause, MediaFastForward, ...)
+// see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values for documentation
+export const defaultOptions = {
+    hotkeys: {
+        fullscreen: {
+            match: ["f", "F"],
+            handle: handleWithClick("FullscreenToggle"),
+        },
+        mute: {
+            match: ["m", "M", "AudioVolumeMute", "VolumeMute"],
+            handle: handleMute,
+            icon: volumeIcon(true),
+        },
+        // "Spacebar" is for IE+old Firefox
+        playPause: {
+            // TODO: pause/play actions could depend on whether player is playing (e.g. "MediaPause" only pauses)
+            match: ["k", "K", " ", "Spacebar", "MediaPause", "Pause", "MediaPlay", "MediaPlayPause"],
+            handle: handleWithClick("PlayToggle"),
+            icon: (player) => vjsIcon(player.paused() ? "pause" : "play"),
+        },
+        // "Right" is for IE+old Firefox, same with other arrows below
+        seekForward: {
+            match: ["l", "L", "ArrowRight", "Right"],
+            handle: handleSeek(true),
+            icon: `${vjsIcon("replay")} -scale-x-100 rotate-45`,
+        },
+        seekBack: {
+            match: ["j", "J", "ArrowLeft", "Left"],
+            handle: handleSeek(false),
+            icon: `${vjsIcon("replay")} -rotate-45`,
+        },
+        volumeUp: {
+            match: ["ArrowUp", "Up", "AudioVolumeUp", "VolumeUp"],
+            handle: handleVolume(true),
+            icon: volumeIcon(true),
+        },
+        volumeDown: {
+            match: ["ArrowDown", "Down", "AudioVolumeDown", "VolumeDown"],
+            handle: handleVolume(false),
+            icon: volumeIcon(false),
+        },
+        increasePlaybackRate: {
+            match: [">", "MediaFastForward", "PlaySpeedUp"],
+            handle: handlePlaybackRate(true),
+            icon: fa("forward"),
+        },
+        decreasePlaybackRate: {
+            match: ["<", "MediaRewind", "PlaySpeedDown"],
+            handle: handlePlaybackRate(false),
+            icon: fa("backward"),
+        },
+        seekPercentage: {
+            match: matchSeekPercentage,
+            handle: handleSeekPercentage,
+        },
+        seekStart: {
+            match: ["Home"],
+            handle: handleSeekTo(0),
+        },
+        seekEnd: {
+            match: ["End"],
+            handle: handleSeekTo(1),
+        },
+    } as Hotkeys,
+};
+
+/**
+ * Factory function for hotkey handler.
+ * @param extraOptions Merged with {@link defaultOptions}.
+ *  Each action is an entry in the `extraOptions.hotkeys` property, and replaces the default actions if given.
+ *  Each value should have three properties: `match` may be an iterable of strings, in which case the action is triggered
+ *  if one of those keys is pressed (as per {@link KeyboardEvent#key}), or a function, which receives as its arguments
+ *  the VideoJS player and the keyboard event and should return a value if the action should be triggered, or `undefined` otherwise.
+ *  `handle` must be a function that receives the VideoJS player, the event and the return value of `match`
+ *  (the last of which is the {@link KeyboardEvent#key} if `match` was an iterable of strings).
+ *  `icon` is optional, and may be a class string or a function (passed the same arguments as `handle`)
+ *  that returns a class string.
+ *  Custom actions are also supported.
+ */
+export function handleHotkeys(extraOptions = {}) {
+    const options = videojs.mergeOptions(defaultOptions, extraOptions) as typeof defaultOptions;
+
+    return function (event: videojs.KeyboardEvent) {
+        // 'this' is the player instance
+        for (const [action, { match, handle, icon }] of Object.entries(options.hotkeys)) {
+            optional(matches(match, this, event)).map((data) => {
+                event.preventDefault();
+                event.stopPropagation();
+                handle(this, event, data);
+                optional(icon).map((i) => this.getChild("OverlayIcon").showIcon(getIcon(i, this, event)));
+            });
+        }
+    };
+}


### PR DESCRIPTION
Based more or less on [YouTube's hotkeys](https://support.google.com/youtube/answer/7631406?hl=en).

Calling `handleClick` on `Component`s is based off of [this](https://github.com/videojs/video.js/blob/3ec2ac7f99704434d2fdc61642247ef0aa4e77b3/src/js/player.js#L3222) VideoJS code, but that approach doesn't work for all actions.

Draft PR, feedback is appreciated! I've marked some things with `TODO`s as well.

Related to #358, #462: being able to change the amount of time skipped by seek buttons would be nice; imo 15 seconds is too long.

Closes #43, closes #398.