### PR TITLE
Edit button for course and stream on their pages

### DIFF
--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -19,7 +19,7 @@
                href="/admin/course/{{$course.Model.ID}}"
                :title="'Edit course settings'">
                <span class="font-semibold text-lg dark:text-white">
-                   <i class="fa-solid w-5 py-2 fa-gears"></i>
+                   <i class="fa-solid w-5 py-2 fa-pen"></i>
                </span>
             </a>{{end}}
     </div>

--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -12,8 +12,16 @@
 {{$course := .IndexData.TUMLiveContext.Course}}
 <!-- 6.5 = nav height + padding -->
 <div class="m-auto px-1 sm:px-3 lg:px-5 w-full xl:w-2/3" style="height: calc(100vh - (6.5rem));">
-    <div class="my-8 pl-2 md:pl-0">
+    <div class="flex my-8 pl-2 md:pl-0">
         <h1 class="font-bold text-3xl text-3 my-auto">{{$course.Name}}</h1>
+        {{if or (.IndexData.TUMLiveContext.User.IsAdminOfCourse .IndexData.TUMLiveContext.Course) .IndexData.IsAdmin}}
+            <a class="hover:bg-gray-200 dark:hover:bg-gray-600 w-fit mx-2 inline-block rounded px-2 my-auto"
+               href="/admin/course/{{$course.Model.ID}}"
+               :title="'Edit course settings'">
+               <span class="font-semibold text-lg dark:text-white">
+                   <i class="fa-solid w-5 py-2 fa-gears"></i>
+               </span>
+            </a>{{end}}
     </div>
     <div class="m-auto flex flex-wrap pb-3 md:h-5/6 md:grid md:grid-rows-6 md:grid-cols-5 md:gap-4 md:pb-0">
         <!-- VoD -->

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -185,7 +185,7 @@
                            href="/admin/course/{{$course.Model.ID}}#lecture-li-{{$stream.Model.ID}}"
                            :title="'Edit course settings'">
                         <span class="font-semibold text-sm">
-                           <i class="fa-solid w-fit py-2 fa-gears"></i>
+                           <i class="fa-solid w-fit py-2 fa-pen"></i>
                         </span>
                         </a>{{end}}
                 </div>

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -182,7 +182,7 @@
                         <span class="text-5 hover:text-1 hover:underline text-lg">{{$course.Name}}</span></a>
                     {{if or (.IndexData.TUMLiveContext.User.IsAdminOfCourse .IndexData.TUMLiveContext.Course) .IndexData.IsAdmin}}
                         <a class="hover:bg-gray-200 dark:hover:bg-gray-600 text-5 hover:text-1 hover:underline w-fit m-2 px-1 inline-block rounded my-auto"
-                           href="/admin/course/{{$course.Model.ID}}"
+                           href="/admin/course/{{$course.Model.ID}}#lecture-li-{{$stream.Model.ID}}"
                            :title="'Edit course settings'">
                         <span class="font-semibold text-sm">
                            <i class="fa-solid w-fit py-2 fa-gears"></i>

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -177,8 +177,19 @@
                 </p>
             </div>
             <div class="flex justify-between pb-4">
-                <a href="/course/{{$course.Year}}/{{$course.TeachingTerm}}/{{$course.Slug}}">
-                    <span class="text-5 hover:text-1 hover:underline text-lg">{{$course.Name}}</span></a>
+                <div class="flex my-auto">
+                    <a href="/course/{{$course.Year}}/{{$course.TeachingTerm}}/{{$course.Slug}}">
+                        <span class="text-5 hover:text-1 hover:underline text-lg">{{$course.Name}}</span></a>
+                    {{if or (.IndexData.TUMLiveContext.User.IsAdminOfCourse .IndexData.TUMLiveContext.Course) .IndexData.IsAdmin}}
+                        <a class="hover:bg-gray-200 dark:hover:bg-gray-600 text-5 hover:text-1 hover:underline w-fit m-2 px-1 inline-block rounded my-auto"
+                           href="/admin/course/{{$course.Model.ID}}"
+                           :title="'Edit course settings'">
+                        <span class="font-semibold text-sm">
+                           <i class="fa-solid w-fit py-2 fa-gears"></i>
+                        </span>
+                        </a>{{end}}
+                </div>
+
                 {{if $stream.LiveNow}}
                     {{if .DVR}}
                         <a href="./{{$stream.Model.ID}}"><span class="text-5 hover:text-1 hover:underline text-lg">Disable Beta stream</span></a>


### PR DESCRIPTION
Added buttons to the stream watch page and course overview page.
The buttons are only visible to admins of courses and redirect the user to the settings page of the respective course.

I chose the icon to be fa-gears instead of fa-pen-and-paper since the latter is already used to denote presentation view.