### PR TITLE
Fix safari icons and theme selector dropdown

### DIFF
--- a/web/template/partial/notifications.gohtml
+++ b/web/template/partial/notifications.gohtml
@@ -2,7 +2,7 @@
     {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.User*/ -}}
     <div class="relative" x-data="{ n: new global.Notifications(), show: false}" x-init="n.fetchNotifications();"
          @keyup.escape="show=false; n.writeToStorage(true)">
-        <button class="transition-colors duration-200 hover:text-gray-600 dark:hover:text-white text-gray-400 mr-6 relative h-4 w-4"
+        <button class="transition-colors duration-200 hover:text-gray-600 dark:hover:text-white text-gray-400 mr-6 relative w-4"
                 type="button" @click="show=!show; show===false && n.writeToStorage(true)">
             <span x-cloak x-show="n.notifications.some(notification => !notification.read)"
                   class="bg-gradient-to-r from-cyan-500 to-blue-500 rounded-full absolute -top-1 -right-1 h-3 w-3 border-2 border-white dark:border-secondary"> </span>

--- a/web/template/partial/theme-selector.gohtml
+++ b/web/template/partial/theme-selector.gohtml
@@ -1,8 +1,8 @@
 {{define "theme-selector-content"}}
     <div class="my-auto w-full min-h-30 max-h-60 overflow-y-auto">
         <template x-for="[modeId, mode] of Object.entries($store.theme.modes)" :key="modeId">
-            <div role="button" tabindex="0"
-                 x-data="{ active: () => modeId == $store.theme.activeMode }"
+            <button role="button" tabindex="0"
+                 x-data="{ active: () => modeId === $store.theme.activeMode }"
                  class="p-2 w-full border-b dark:border-gray-800 relative last:border-0
                                transition-colors duration-200 text-5 hover:text-1"
                  :class="(active() ? ['bg-gray-100', 'dark:bg-secondary-lighter'] : []).concat(mobile ? ['px-5'] : [])"
@@ -12,7 +12,7 @@
                     <i class="fa-solid" :class="['fa-' + mode.faIconId, mobile ? 'ml-8' : 'mr-2']"></i>
                     <p x-text="mode.name" :class="mobile ? 'mr-2' : ''"></p>
                 </div>
-            </div>
+            </button>
         </template>
     </div>
 {{end}}
@@ -24,7 +24,7 @@
 {{define "theme-selector"}}
     <div class="relative" x-data="{ show: false, mobile: false }">
         <button class="transition-colors duration-200 hover:text-gray-600
-                       dark:hover:text-white text-gray-400 mr-6 relative h-4 w-4"
+                       dark:hover:text-white text-gray-400 mr-6 relative w-4"
                 type="button" @click="show=!show">
             {{template "theme-switcher-icon"}}
         </button>


### PR DESCRIPTION
Before:
<img width="176" alt="image" src="https://user-images.githubusercontent.com/29633518/170925181-f4acf681-3d29-4a08-a648-7b03f766721b.png">
<img width="174" alt="image" src="https://user-images.githubusercontent.com/29633518/170925199-d4c92a60-ed22-4a5d-a470-39e934c562c0.png">

After:
<img width="153" alt="image" src="https://user-images.githubusercontent.com/29633518/170925220-9060c30a-3392-4138-8ce3-2fa672e6cfd4.png">
<img width="166" alt="image" src="https://user-images.githubusercontent.com/29633518/170925235-4d6a0a4c-3ddd-49db-81c5-dd692b309b87.png">



**Tested with**
Version 15.5 (17613.2.7.1.8)
MacOS Monterey V12.4