### PR TITLE
load service worker from absolute location

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SwUserDefinedSpecifications">
+    <option name="specTypeByUrl">
+      <map />
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="SwUserDefinedSpecifications">
-    <option name="specTypeByUrl">
-      <map />
-    </option>
-  </component>
-</project>

--- a/web/template/headImports.gohtml
+++ b/web/template/headImports.gohtml
@@ -15,7 +15,7 @@
     {{template "theme-selector-head"}}
     <style>[x-cloak] { display: none !important; }</style>
     <script>
-        if ('serviceWorker' in navigator) navigator.serviceWorker.register('./service-worker.js', { scope: './' })
+        if ('serviceWorker' in navigator) navigator.serviceWorker.register('/service-worker.js', { scope: '/' })
             .catch((err) => console.error("Service Worker Failed to Register", err))
     </script>
 {{end}}


### PR DESCRIPTION
Currently the service worker can only be loaded from the main page, not from sub pages.

Because it (e.g.) tries to load the script on the admin page from `/admin/service-worker.js`  instead of `/service-worker.js`