### PR TITLE
Fix saving request interval

### DIFF
--- a/worker/worker/thumbnails.go
+++ b/worker/worker/thumbnails.go
@@ -13,18 +13,17 @@ const (
 
 // createThumbnailSprite creates a thumbnail sprite from the given video file and stores it in mass storage.
 func createThumbnailSprite(ctx *StreamContext) error {
-	var ThumbInterval int // Specifies the interval between thumbnails in seconds.
 	secondsPerHour := uint32(time.Hour.Seconds())
 	switch {
 	case ctx.duration < secondsPerHour:
-		ThumbInterval = 10
+		ctx.thumbInterval = 10
 	case ctx.duration > secondsPerHour*3:
-		ThumbInterval = 60
+		ctx.thumbInterval = 60
 	default:
-		ThumbInterval = 30
+		ctx.thumbInterval = 30
 	}
 	log.WithField("File", ctx.getThumbnailSpriteFileName()).Info("Start creating thumbnail sprite")
-	g, err := thumbgen.New(ctx.getTranscodingFileName(), ThumbWidth, ThumbInterval, ctx.getThumbnailSpriteFileName(), thumbgen.WithJpegCompression(Compression))
+	g, err := thumbgen.New(ctx.getTranscodingFileName(), ThumbWidth, int(ctx.thumbInterval), ctx.getThumbnailSpriteFileName(), thumbgen.WithJpegCompression(Compression))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Actually writes the interval the interval in the request, so it is actually sent to the backend.

Test stream can be found here: https://test.live.mm.rbg.tum.de/w/airplay/498/CAM