### PR TITLE
Add x-cloak to info-dropdown

### DIFF
--- a/web/template/partial/info-dropdown.gohtml
+++ b/web/template/partial/info-dropdown.gohtml
@@ -1,5 +1,5 @@
 {{define "info-dropdown"}}
-    <div x-data="{showInfoDropdown: false, show: false, mobile: false}" class="relative text-right md:mt-px">
+    <div x-cloak x-data="{showInfoDropdown: false, show: false, mobile: false}" class="relative text-right md:mt-px">
         <button @click="showInfoDropdown=true;"
                 class="transition-colors duration-200 hover:text-gray-600 dark:hover:text-white text-gray-400">
             <i class="fa fa-bars text-xl md:text-normal"></i>


### PR DESCRIPTION
## Changes 

- Add `x-cloak` attribute to info-dropdown container

## Why 

On Reload or redirection to another page the dropdown was shown for a tiny amount of time until `hidden` was loaded. That's ugly.