### PR TITLE
 Add "Copy HSL URL" button next to each video in course overview

### DIFF
--- a/web/template/partial/stream/actions.gohtml
+++ b/web/template/partial/stream/actions.gohtml
@@ -42,9 +42,10 @@
         {{end}}
         {{/* Copy HLS Link for video */}}
         {{if or $stream.PlaylistUrlPRES (or $stream.PlaylistUrlCAM $stream.PlaylistUrl)}}
-            <i title="Copy HLS URL"
-               class="m-auto text-lg cursor-pointer fas fa-link text-4 dark:hover:text-white hover:text-black"
-               onclick="global.copyToClipboard('{{if eq .Version "PRES"}}{{$stream.PlaylistUrlPRES}}{{else if eq .Version "CAM"}}{{$stream.PlaylistUrlCAM}}{{else}}{{$stream.PlaylistUrl}}{{end}}{{if .Unit}}?wowzaplaystart={{.Unit.UnitStart}}&wowzaplayduration={{.Unit.GetUnitDurationMS}}{{else if $stream.StartOffset}}?wowzaplaystart={{$stream.StartOffset}}&wowzaplayduration={{$stream.EndOffset}}{{end}}'.replaceAll('\{\{quality\}\}', ''))">
+            <i x-data="{ copied: false }" title="Copy HLS URL"
+               :class="copied ? 'fa-check' : 'fa-link'"
+               class="m-auto text-lg cursor-pointer text-4 dark:hover:text-white hover:text-black fas fa-fw"
+               @click="if (global.copyToClipboard('{{if eq .Version "PRES"}}{{$stream.PlaylistUrlPRES}}{{else if eq .Version "CAM"}}{{$stream.PlaylistUrlCAM}}{{else}}{{$stream.PlaylistUrl}}{{end}}{{if .Unit}}?wowzaplaystart={{.Unit.UnitStart}}&wowzaplayduration={{.Unit.GetUnitDurationMS}}{{else if $stream.StartOffset}}?wowzaplaystart={{$stream.StartOffset}}&wowzaplayduration={{$stream.EndOffset}}{{end}}'.replaceAll('\{\{quality\}\}', ''))) {  copied=true; setTimeout(() => { copied=false }, 1000); }">
             </i>
         {{end}}
     </div>

--- a/web/template/vod_course_list.gohtml
+++ b/web/template/vod_course_list.gohtml
@@ -72,6 +72,14 @@
                                 <i class="fas fa-comments"></i>
                             </a>
                         {{end}}
+                        {{/* Copy HLS Link for video */}}
+                        {{if $lecture.PlaylistUrl}}
+                            <i x-data="{ copied: false }" title="Copy HLS URL for combined stream"
+                               :class="copied ? 'fa-check' : 'fa-link'"
+                               class="flex text-lg cursor-pointer text-3 dark:hover:text-white hover:text-black hover:text-gray-600 fas fa-fw"
+                               @click="if (global.copyToClipboard('{{$lecture.PlaylistUrl}}{{if $lecture.StartOffset}}?wowzaplaystart={{$lecture.StartOffset}}&wowzaplayduration={{$lecture.EndOffset}}{{end}}'.replaceAll('\{\{quality\}\}', ''))) { copied=true; setTimeout(() => { copied=false }, 1000); }">
+                            </i>
+                        {{end}}
                     </div>
                 </div>
                 {{if $lecture.Units}}

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -41,13 +41,19 @@ export function showMessage(msg: string) {
     alertBox.classList.remove("hidden");
 }
 
-export function copyToClipboard(text: string) {
-    const dummy = document.createElement("input");
-    document.body.appendChild(dummy);
-    dummy.value = text;
-    dummy.select();
-    document.execCommand("copy");
-    document.body.removeChild(dummy);
+/**
+ * Copies a string to the clipboard using clipboard API.
+ * @param text the string that is copied to the clipboard.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+    return navigator.clipboard.writeText(text).then(
+        () => {
+            return true;
+        },
+        () => {
+            return false;
+        },
+    );
 }
 
 export function hideCourse(id: number, name: string) {


### PR DESCRIPTION
Fixes https://github.com/joschahenningsen/TUM-Live/issues/548
- Adds a button in the course overview to copy the hls of a combined stream (if it exists)
- Adds an indicator check mark that copying was successful
![Peek 2022-07-12 15-46](https://user-images.githubusercontent.com/30267166/178505104-9cbb94eb-44f9-4e15-8323-aebee52a6469.gif)
- Use more modern clipboard API, see https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText (only Internet Explorer does not support it)

Might interfere with https://github.com/joschahenningsen/TUM-Live/pull/580 but should not be too bad.