### PR TITLE
Fix 'follow sections' jumps to not existing page

### DIFF
--- a/web/ts/video-sections.ts
+++ b/web/ts/video-sections.ts
@@ -63,6 +63,7 @@ export abstract class VideoSections {
  */
 export class VideoSectionsMobile extends VideoSections {
     minimize: boolean;
+
     getList(): Section[] {
         return this.minimize ? [this.list.at(this.currentHighlightIndex)] : this.list;
     }
@@ -91,7 +92,7 @@ export class VideoSectionsDesktop extends VideoSections {
 
     getList(): Section[] {
         const currentHighlightPage = Math.floor(this.currentHighlightIndex / this.sectionsPerGroup);
-        const startIndex = this.followSections ? currentHighlightPage : this.currentIndex;
+        const startIndex = this.followSections && this.validHighlightIndex() ? currentHighlightPage : this.currentIndex;
         return this.list.slice(
             startIndex * this.sectionsPerGroup,
             startIndex * this.sectionsPerGroup + this.sectionsPerGroup,


### PR DESCRIPTION
## Changes 
- Add `validHighlightIndex` check

### Description 
This bug exists since `highlight(...)` is only called after the player is ready.
In particular this means that `currentHighlightIndex` is in an invalid state and still set to `-1`. Then, a click on the `Follow Sections` button was leading to the disappearing of the sections because of an invalid page index.