### PR TITLE
Self Stream/Worker enhancements

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="SwUserDefinedSpecifications">
-    <option name="specTypeByUrl">
-      <map />
-    </option>
-  </component>
-</project>

--- a/worker/worker/request_handlers.go
+++ b/worker/worker/request_handlers.go
@@ -90,6 +90,9 @@ func HandleSelfStreamRecordEnd(ctx *StreamContext) {
 	} else {
 		ctx.TranscodingSuccessful = true
 	}
+	if ctx.canceled {
+		return
+	}
 	S.endTranscoding(ctx.getStreamName())
 	notifyTranscodingDone(ctx)
 	if ctx.publishVoD {
@@ -156,7 +159,8 @@ func HandleStreamEnd(ctx *StreamContext, cancelTranscoding bool) {
 	cancelCmdGroup(ctx.streamCmd)
 	if cancelTranscoding {
 		ctx.publishVoD = false
-		cancelCmdGroup(ctx.transcodingCmd)
+		ctx.canceled = true
+		cancelCmd(ctx.transcodingCmd)
 	}
 }
 
@@ -429,11 +433,13 @@ type StreamContext struct {
 	streamCmd      *exec.Cmd // command used for streaming
 	transcodingCmd *exec.Cmd // command used for transcoding
 	isSelfStream   bool      //deprecated
-	streamName     string    // ingest target
-	ingestServer   string    // ingest tumlive e.g. rtmp://user:password@my.tumlive
-	stopped        bool      // whether the stream has been stopped
-	outUrl         string    // url the stream will be available at
-	discardVoD     bool      // whether the VoD should be discarded
+	canceled       bool      // selfstreams are canceled when the same stream starts again.
+
+	streamName   string // ingest target
+	ingestServer string // ingest tumlive e.g. rtmp://user:password@my.tumlive
+	stopped      bool   // whether the stream has been stopped
+	outUrl       string // url the stream will be available at
+	discardVoD   bool   // whether the VoD should be discarded
 
 	// calculated after stream:
 	duration      uint32 //duration of the stream in seconds

--- a/worker/worker/request_handlers.go
+++ b/worker/worker/request_handlers.go
@@ -90,10 +90,11 @@ func HandleSelfStreamRecordEnd(ctx *StreamContext) {
 	} else {
 		ctx.TranscodingSuccessful = true
 	}
+	S.endTranscoding(ctx.getStreamName())
 	if ctx.canceled {
+		// self stream restarted while transcoding
 		return
 	}
-	S.endTranscoding(ctx.getStreamName())
 	notifyTranscodingDone(ctx)
 	if ctx.publishVoD {
 		upload(ctx)

--- a/worker/worker/request_handlers_test.go
+++ b/worker/worker/request_handlers_test.go
@@ -24,7 +24,6 @@ func setup() {
 		publishVoD:    true,
 		stream:        true,
 		endTime:       time.Now().Add(time.Hour),
-		commands:      nil,
 	}
 	cfg.TempDir = "/recordings"
 }

--- a/worker/worker/transcode.go
+++ b/worker/worker/transcode.go
@@ -30,7 +30,7 @@ func transcode(streamCtx *StreamContext) error {
 		cmd = exec.Command("nice", "-n", "10", "ffmpeg", "-y", "-nostats", "-i", in, "-vsync", "2", "-c:v", "libx264", "-level", "4.0", "-movflags", "+faststart", "-c:a", "aac", "-b:a", "128k", "-crf", "26", out)
 	}
 	log.WithFields(log.Fields{"input": in, "output": out, "command": cmd.String()}).Info("Transcoding")
-
+	streamCtx.transcodingCmd = cmd
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		log.WithFields(log.Fields{"output": string(output)}).Error("Transcoding failed")


### PR DESCRIPTION
fixes #378  
fixes #433 (hopefully)

This PR makes sure all sub-processes are properly canceled when self streams end or restart.