### PR TITLE
Add Admin Middleware to Notification Router

### DIFF
--- a/api/notifications.go
+++ b/api/notifications.go
@@ -13,9 +13,11 @@ import (
 func configNotificationsRouter(r *gin.Engine, daoWrapper dao.DaoWrapper) {
 	routes := notificationRoutes{daoWrapper}
 	notifications := r.Group("/api/notifications")
-	notifications.GET("/", routes.getNotifications)
-	notifications.POST("/", routes.createNotification)
-	notifications.DELETE("/:id", routes.deleteNotification)
+	{
+		notifications.GET("/", routes.getNotifications)
+		notifications.POST("/", tools.Admin, routes.createNotification)
+		notifications.DELETE("/:id", tools.Admin, routes.deleteNotification)
+	}
 }
 
 type notificationRoutes struct {

--- a/api/notifications_test.go
+++ b/api/notifications_test.go
@@ -109,15 +109,17 @@ func TestNotifications(t *testing.T) {
 
 		testutils.TestCases{
 			"invalid body": {
-				Method:       http.MethodPost,
-				Url:          url,
-				DaoWrapper:   dao.DaoWrapper{},
-				Body:         nil,
-				ExpectedCode: http.StatusBadRequest,
+				Method:         http.MethodPost,
+				Url:            url,
+				TumLiveContext: &testutils.TUMLiveContextAdmin,
+				DaoWrapper:     dao.DaoWrapper{},
+				Body:           nil,
+				ExpectedCode:   http.StatusBadRequest,
 			},
 			"can not add notification": {
-				Method: http.MethodPost,
-				Url:    url,
+				Method:         http.MethodPost,
+				Url:            url,
+				TumLiveContext: &testutils.TUMLiveContextAdmin,
 				DaoWrapper: dao.DaoWrapper{
 					NotificationsDao: func() dao.NotificationsDao {
 						mock := mock_dao.NewMockNotificationsDao(gomock.NewController(t))
@@ -134,8 +136,9 @@ func TestNotifications(t *testing.T) {
 				ExpectedCode: http.StatusInternalServerError,
 			},
 			"success": {
-				Method: http.MethodPost,
-				Url:    url,
+				Method:         http.MethodPost,
+				Url:            url,
+				TumLiveContext: &testutils.TUMLiveContextAdmin,
 				DaoWrapper: dao.DaoWrapper{
 					NotificationsDao: func() dao.NotificationsDao {
 						mock := mock_dao.NewMockNotificationsDao(gomock.NewController(t))
@@ -162,13 +165,15 @@ func TestNotifications(t *testing.T) {
 
 		testutils.TestCases{
 			"invalid id": {
-				Method:       http.MethodDelete,
-				Url:          "/api/notifications/abc",
-				ExpectedCode: http.StatusBadRequest,
+				Method:         http.MethodDelete,
+				Url:            "/api/notifications/abc",
+				TumLiveContext: &testutils.TUMLiveContextAdmin,
+				ExpectedCode:   http.StatusBadRequest,
 			},
 			"can not delete notification": {
-				Method: http.MethodDelete,
-				Url:    url,
+				Method:         http.MethodDelete,
+				Url:            url,
+				TumLiveContext: &testutils.TUMLiveContextAdmin,
 				DaoWrapper: dao.DaoWrapper{
 					NotificationsDao: func() dao.NotificationsDao {
 						mock := mock_dao.NewMockNotificationsDao(gomock.NewController(t))
@@ -183,8 +188,9 @@ func TestNotifications(t *testing.T) {
 				ExpectedCode: http.StatusInternalServerError,
 			},
 			"success": {
-				Method: http.MethodDelete,
-				Url:    url,
+				Method:         http.MethodDelete,
+				Url:            url,
+				TumLiveContext: &testutils.TUMLiveContextAdmin,
 				DaoWrapper: dao.DaoWrapper{
 					NotificationsDao: func() dao.NotificationsDao {
 						mock := mock_dao.NewMockNotificationsDao(gomock.NewController(t))

--- a/tools/testutils/testdata.go
+++ b/tools/testutils/testdata.go
@@ -20,6 +20,7 @@ var (
 	TUMLiveContextStudent  = tools.TUMLiveContext{User: &Student}
 	TUMLiveContextLecturer = tools.TUMLiveContext{User: &Lecturer}
 	TUMLiveContextAdmin    = tools.TUMLiveContext{User: &Admin}
+	TUMLiveContextEmpty    = tools.TUMLiveContext{}
 )
 
 // Models


### PR DESCRIPTION
## Why?
I haven't tested it, but I am pretty sure that it is currently possible to send a POST (and DELETE for that matter) request to https://live.rbg.tum.de/api/notifications and create a notification for _all_ users without any sort of authentication whatsoever.

## Changes 
- 🍒-pick updated notification tests from #592 
- Add `tools.Admin` middleware to POST and DELETE endpoints.
- Update test