### PR TITLE
Restructure stream router definitions

### DIFF
--- a/api/stream.go
+++ b/api/stream.go
@@ -32,29 +32,29 @@ func configGinStreamRestRouter(router *gin.Engine, daoWrapper dao.DaoWrapper) {
 	{
 		// Endpoint for API users with token
 		stream.GET("/live", tools.AdminToken(daoWrapper), routes.liveStreams)
-	}
 
-	streamById := stream.Group("/:streamID")
-	streamById.Use(tools.InitStream(daoWrapper))
-	{
-		// All User Endpoints
-		streamById.GET("/sections", routes.getVideoSections)
-		streamById.GET("/thumbs/:fid", routes.getThumbs)
-	}
-	{
-		// Admin-Only Endpoints
-		admins := streamById.Use(tools.AdminOfCourse)
-		admins.GET("", routes.getStream)
-		admins.GET("/pause", routes.pauseStream)
-		admins.GET("/end", routes.endStream)
-		admins.POST("/issue", routes.reportStreamIssue)
-		admins.PATCH("/visibility", routes.updateStreamVisibility)
+		streamById := stream.Group("/:streamID")
+		streamById.Use(tools.InitStream(daoWrapper))
+		{
+			// All User Endpoints
+			streamById.GET("/sections", routes.getVideoSections)
+			streamById.GET("/thumbs/:fid", routes.getThumbs)
+		}
+		{
+			// Admin-Only Endpoints
+			admins := streamById.Use(tools.AdminOfCourse)
+			admins.GET("", routes.getStream)
+			admins.GET("/pause", routes.pauseStream)
+			admins.GET("/end", routes.endStream)
+			admins.POST("/issue", routes.reportStreamIssue)
+			admins.PATCH("/visibility", routes.updateStreamVisibility)
 
-		admins.POST("/sections", routes.createVideoSectionBatch)
-		admins.DELETE("/sections/:id", routes.deleteVideoSection)
+			admins.POST("/sections", routes.createVideoSectionBatch)
+			admins.DELETE("/sections/:id", routes.deleteVideoSection)
 
-		admins.POST("/files", routes.newAttachment)
-		admins.DELETE("/files/:fid", routes.deleteAttachment)
+			admins.POST("/files", routes.newAttachment)
+			admins.DELETE("/files/:fid", routes.deleteAttachment)
+		}
 	}
 }
 

--- a/api/stream.go
+++ b/api/stream.go
@@ -42,18 +42,25 @@ func configGinStreamRestRouter(router *gin.Engine, daoWrapper dao.DaoWrapper) {
 		}
 		{
 			// Admin-Only Endpoints
-			admins := streamById.Use(tools.AdminOfCourse)
+			admins := streamById.Group("")
+			admins.Use(tools.AdminOfCourse)
 			admins.GET("", routes.getStream)
 			admins.GET("/pause", routes.pauseStream)
 			admins.GET("/end", routes.endStream)
 			admins.POST("/issue", routes.reportStreamIssue)
 			admins.PATCH("/visibility", routes.updateStreamVisibility)
 
-			admins.POST("/sections", routes.createVideoSectionBatch)
-			admins.DELETE("/sections/:id", routes.deleteVideoSection)
+			sections := admins.Group("/sections")
+			{
+				sections.POST("", routes.createVideoSectionBatch)
+				sections.DELETE("/:id", routes.deleteVideoSection)
+			}
 
-			admins.POST("/files", routes.newAttachment)
-			admins.DELETE("/files/:fid", routes.deleteAttachment)
+			files := admins.Group("files")
+			{
+				files.POST("", routes.newAttachment)
+				files.DELETE("/:fid", routes.deleteAttachment)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Changes 
- Refactor route definitions for `configGinStreamRestRouter(...)` for readability reasons

## Further considerations 
We could think about splitting up the big router configuration (such as streams and courses) functions into smaller ones.