### PR TITLE
Retry dial-in after dynamic backoff

### DIFF
--- a/worker/cfg/cfg.go
+++ b/worker/cfg/cfg.go
@@ -1,12 +1,9 @@
 package cfg
 
 import (
-	"context"
-	"fmt"
-	"github.com/joschahenningsen/TUM-Live/worker/pb"
+	"github.com/getsentry/sentry-go"
+	"github.com/makasim/sentryhook"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"os"
 	"time"
 )
@@ -95,30 +92,21 @@ func init() {
 		}
 	}
 
-	// join main tumlive:
-	var conn *grpc.ClientConn
-	// retry connecting to tumlive every 5 seconds until successful
-	for {
-		conn, err = grpc.Dial(fmt.Sprintf("%s:50052", MainBase), grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err == nil {
-			break
-		} else {
-			log.Warnf("Could not connect to main tumlive: %v\n", err)
-			time.Sleep(time.Second * 5)
+	if os.Getenv("SentryDSN") != "" {
+		err := sentry.Init(sentry.ClientOptions{
+			Dsn:              os.Getenv("SentryDSN"),
+			TracesSampleRate: 1,
+			Debug:            true,
+			AttachStacktrace: true,
+			Environment:      "Worker",
+		})
+		if err != nil {
+			log.Fatalf("sentry.Init: %s", err)
 		}
+		// Flush buffered events before the program terminates.
+		defer sentry.Flush(2 * time.Second)
+		defer sentry.Recover()
+		log.AddHook(sentryhook.New([]log.Level{log.PanicLevel, log.FatalLevel, log.ErrorLevel, log.WarnLevel}))
 	}
 
-	client := pb.NewFromWorkerClient(conn)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	resp, err := client.JoinWorkers(ctx, &pb.JoinWorkersRequest{
-		Token:    Token,
-		Hostname: Hostname,
-	})
-	if err != nil {
-		log.Warnf("Could not join main tumlive: %v\n", err)
-		return
-	}
-	WorkerID = resp.WorkerId
-	log.Infof("Joined main tumlive with worker id: %s\n", WorkerID)
 }

--- a/worker/client/main.go
+++ b/worker/client/main.go
@@ -7,7 +7,9 @@ import (
 	"github.com/joschahenningsen/TUM-Live/worker/pb"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials/insecure"
+	"time"
 )
 
 // interactively test your implementation here
@@ -30,7 +32,13 @@ func main() {
 
 func dialIn(host string) (*grpc.ClientConn, error) {
 	credentials := insecure.NewCredentials()
-	log.Info("Connecting to:" + fmt.Sprintf("%s:50051", host))
-	conn, err := grpc.Dial(fmt.Sprintf("%s:50051", host), grpc.WithTransportCredentials(credentials))
+	conn, err := grpc.Dial(fmt.Sprintf("%s:50051", host), grpc.WithConnectParams(grpc.ConnectParams{
+		Backoff: backoff.Config{
+			BaseDelay:  1 * time.Second,
+			Multiplier: 1.6,
+			MaxDelay:   15 * time.Second,
+		},
+	}), grpc.WithTransportCredentials(credentials))
+
 	return conn, err
 }

--- a/worker/cmd/worker/worker.go
+++ b/worker/cmd/worker/worker.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	"github.com/getsentry/sentry-go"
 	"github.com/joschahenningsen/TUM-Live/worker/api"
+	"github.com/joschahenningsen/TUM-Live/worker/cfg"
+	"github.com/joschahenningsen/TUM-Live/worker/pb"
 	"github.com/joschahenningsen/TUM-Live/worker/rest"
 	"github.com/joschahenningsen/TUM-Live/worker/worker"
-	"github.com/makasim/sentryhook"
 	"github.com/pkg/profile"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -20,7 +23,7 @@ import (
 
 // OsSignal contains the current os signal received.
 // Application exits when it's terminating (kill, int, sigusr, term)
-var OsSignal chan os.Signal
+var OsSignal = make(chan os.Signal, 1)
 var VersionTag = "dev"
 
 //prepare checks if the required dependencies are installed
@@ -30,38 +33,52 @@ func prepare() {
 	if err != nil {
 		log.Fatal("ffmpeg is not installed")
 	}
+	_, err = exec.LookPath("tesseract")
+	if err != nil {
+		log.Fatal("tesseract is not installed")
+	}
 }
 
 func main() {
 	prepare()
 
+	// join main tumlive:
+	var conn *grpc.ClientConn
+	var err error
+	// retry connecting to tumlive every 5 seconds until successful
+	for {
+		conn, err = grpc.Dial(fmt.Sprintf("%s:50052", cfg.MainBase), grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err == nil {
+			break
+		} else {
+			log.Warnf("Could not connect to main tumlive: %v\n", err)
+			time.Sleep(time.Second * 5)
+		}
+	}
+
+	client := pb.NewFromWorkerClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	resp, err := client.JoinWorkers(ctx, &pb.JoinWorkersRequest{
+		Token:    cfg.Token,
+		Hostname: cfg.Hostname,
+	})
+	if err != nil {
+		log.Warnf("Could not join main tumlive: %v\n", err)
+		return
+	}
+	cfg.WorkerID = resp.WorkerId
+	log.Infof("Joined main tumlive with worker id: %s\n", cfg.WorkerID)
 	worker.VersionTag = VersionTag
 	defer profile.Start(profile.MemProfile).Stop()
 	go func() {
 		_ = http.ListenAndServe(":8082", nil) // debug endpoint
 	}()
 
-	OsSignal = make(chan os.Signal, 1)
-
 	// log with time, fmt "23.09.2021 10:00:00"
 	log.SetFormatter(&log.TextFormatter{TimestampFormat: "02.01.2006 15:04:05", FullTimestamp: true})
 	log.SetLevel(log.DebugLevel)
-	if os.Getenv("SentryDSN") != "" {
-		err := sentry.Init(sentry.ClientOptions{
-			Dsn:              os.Getenv("SentryDSN"),
-			TracesSampleRate: 1,
-			Debug:            true,
-			AttachStacktrace: true,
-			Environment:      "Worker",
-		})
-		if err != nil {
-			log.Fatalf("sentry.Init: %s", err)
-		}
-		// Flush buffered events before the program terminates.
-		defer sentry.Flush(2 * time.Second)
-		defer sentry.Recover()
-		log.AddHook(sentryhook.New([]log.Level{log.PanicLevel, log.FatalLevel, log.ErrorLevel, log.WarnLevel}))
-	}
+
 	// setup apis
 	go api.InitApi(":50051")
 	go rest.InitApi(":8060")

--- a/worker/cmd/worker/worker.go
+++ b/worker/cmd/worker/worker.go
@@ -27,16 +27,12 @@ import (
 var OsSignal = make(chan os.Signal, 1)
 var VersionTag = "dev"
 
-//prepare checks if the required dependencies are installed
+// prepare checks if the required dependencies are installed
 func prepare() {
 	//check if ffmpeg is installed
 	_, err := exec.LookPath("ffmpeg")
 	if err != nil {
 		log.Fatal("ffmpeg is not installed")
-	}
-	_, err = exec.LookPath("tesseract")
-	if err != nil {
-		log.Fatal("tesseract is not installed")
 	}
 }
 

--- a/worker/cmd/worker/worker.go
+++ b/worker/cmd/worker/worker.go
@@ -24,7 +24,7 @@ import (
 
 // OsSignal contains the current os signal received.
 // Application exits when it's terminating (kill, int, sigusr, term)
-var OsSignal = make(chan os.Signal, 1)
+var OsSignal chan os.Signal
 var VersionTag = "dev"
 
 // prepare checks if the required dependencies are installed
@@ -79,6 +79,7 @@ func main() {
 	go api.InitApi(":50051")
 	go rest.InitApi(":8060")
 	worker.Setup()
+	OsSignal = make(chan os.Signal, 1)
 	awaitSignal()
 }
 


### PR DESCRIPTION
**Motivation**: When deploying to the testserver, the worker has to be restarted as it starts faster than the backend and terminates early since it can't find the backend.

- Adds a backoff to the worker grpc client dial in using https://pkg.go.dev/google.golang.org/grpc@v1.48.0/backoff. Params are somewhat arbitrary: Start retrying every second, if failed multiply by 1.6 and cap it at 15s. I am very open to alternative values here.
- Dial is blocking now to prevent the status cronjobs from getting started when there is no backend to connect to.
- Moved the grpc setup into main as it does not belong to `cfg` semantically.
- I left the current behavior regarding joining the backend as is, since a fatal error is a good hint that the general setup seems to be faulty. Otherwise it might run and retry forever. Could be confusing...
