### PR TITLE
Draft: Home page redesign prototype

### DIFF
--- a/dao/streams.go
+++ b/dao/streams.go
@@ -282,8 +282,10 @@ func (d streamsDao) GetLiveStreamsInLectureHall(lectureHallId uint) ([]model.Str
 
 // GetStreamsWithWatchState returns a list of streams with their progress information.
 func (d streamsDao) GetStreamsWithWatchState(courseID uint, userID uint) (streams []model.Stream, err error) {
+	// TODO: is the progress tracking even working as of now?
 	type watchedState struct {
-		Watched bool
+		Watched  bool
+		Progress float64
 	}
 	var watchedStates []watchedState
 	queriedStreams := DB.Table("streams").Where("course_id = ? and deleted_at is NULL", courseID)
@@ -299,6 +301,7 @@ func (d streamsDao) GetStreamsWithWatchState(courseID uint, userID uint) (stream
 	// Updates the watch state for each stream to compensate for split query.
 	for i := range streams {
 		streams[i].Watched = watchedStates[i].Watched
+		streams[i].Progress = watchedStates[i].Progress
 	}
 	return
 }

--- a/model/course.go
+++ b/model/course.go
@@ -34,6 +34,7 @@ type Course struct {
 	CameraPresetPreferences string // json encoded. e.g. [{lectureHallID:1, presetID:4}, ...]
 
 	Pinned bool `gorm:"-"` // Used to determine if the course is pinned when loaded for a specific user.
+	Hidden bool `gorm:"-"` // Used to determine if the course is hidden when loaded for a specific user.
 }
 
 // GetUrl returns the URL of the course, e.g. /course/2022/S/MyCourse

--- a/model/stream.go
+++ b/model/stream.go
@@ -52,7 +52,8 @@ type Stream struct {
 	TranscodingProgresses []TranscodingProgress `gorm:"foreignKey:StreamID"`
 	Private               bool                  `gorm:"not null;default:false"`
 
-	Watched bool `gorm:"-"` // Used to determine if stream is watched when loaded for a specific user.
+	Watched  bool    `gorm:"-"` // Used to determine if stream is watched when loaded for a specific user.
+	Progress float64 `gorm:"-"`
 }
 
 // GetVodFiles returns all downloadable files that user can see when using the download dropdown for a stream.

--- a/model/stream.go
+++ b/model/stream.go
@@ -43,6 +43,7 @@ type Stream struct {
 	Silences              []Silence
 	Files                 []File `gorm:"foreignKey:StreamID"`
 	ThumbInterval         uint32 `gorm:"default:null"`
+	Thumbnail             string `gorm:"default:null"`
 	Paused                bool   `gorm:"default:false"`
 	StreamName            string
 	Duration              uint32           `gorm:"default:null"`

--- a/model/user.go
+++ b/model/user.go
@@ -35,6 +35,7 @@ type User struct {
 	Courses             []Course       `gorm:"many2many:course_users" json:"-"` // courses a lecturer invited this user to
 	AdministeredCourses []Course       `gorm:"many2many:course_admins"`         // courses this user is an admin of
 	PinnedCourses       []Course       `gorm:"many2many:pinned_courses"`
+	HiddenCourses       []Course       `gorm:"many2many:hidden_courses"`
 
 	Settings []UserSetting `gorm:"foreignkey:UserID"`
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -28,6 +28,7 @@
         "handlebars-loader": "^1.7.2",
         "http-status-codes": "^2.2.0",
         "ical.js": "^1.5.0",
+        "luxon": "^3.0.1",
         "mini-css-extract-plugin": "^2.6.1",
         "moment": "^2.29.4",
         "nouislider": "^15.6.0",
@@ -279,15 +280,6 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
     },
     "node_modules/@silvermine/videojs-airplay": {
       "version": "1.1.0",
@@ -3242,6 +3234,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
+      "integrity": "sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/m3u8-parser": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.7.1.tgz",
@@ -4541,14 +4541,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "node_modules/tippy.js": {
-      "version": "6.3.7",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
-      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
-      "dependencies": {
-        "@popperjs/core": "^2.9.0"
-      }
-    },
     "node_modules/to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
@@ -5242,11 +5234,6 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
-    },
-    "@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@silvermine/videojs-airplay": {
       "version": "1.1.0",
@@ -7594,6 +7581,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "luxon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
+      "integrity": "sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw=="
+    },
     "m3u8-parser": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.7.1.tgz",
@@ -8468,14 +8460,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "tippy.js": {
-      "version": "6.3.7",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
-      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
-      "requires": {
-        "@popperjs/core": "^2.9.0"
-      }
     },
     "to-fast-properties": {
       "version": "1.0.3",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -280,6 +280,15 @@
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@silvermine/videojs-airplay": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@silvermine/videojs-airplay/-/videojs-airplay-1.1.0.tgz",
@@ -4532,6 +4541,14 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
@@ -5225,6 +5242,11 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
+    },
+    "@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@silvermine/videojs-airplay": {
       "version": "1.1.0",
@@ -8446,6 +8468,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "requires": {
+        "@popperjs/core": "^2.9.0"
+      }
     },
     "to-fast-properties": {
       "version": "1.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,7 @@
     "handlebars-loader": "^1.7.2",
     "http-status-codes": "^2.2.0",
     "ical.js": "^1.5.0",
+    "luxon": "^3.0.1",
     "mini-css-extract-plugin": "^2.6.1",
     "moment": "^2.29.4",
     "nouislider": "^15.6.0",

--- a/web/router.go
+++ b/web/router.go
@@ -24,6 +24,7 @@ var templatePaths = []string{
 	"template/admin/*.gohtml",
 	"template/admin/admin_tabs/*.gohtml",
 	"template/partial/*.gohtml",
+	"template/partial/components/*.gohtml",
 	"template/partial/stream/*.gohtml",
 	"template/partial/course/manage/*.gohtml",
 	"template/partial/stream/chat/*.gohtml",

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -39,6 +39,11 @@ module.exports = {
             blur: {
                 xxs: "1px",
             },
+            screens: {
+                'hover-hover': {
+                    raw: '(hover: hover) and (pointer: fine)'
+                }
+            }
         },
     },
     variants: {

--- a/web/template/cards.gohtml
+++ b/web/template/cards.gohtml
@@ -22,13 +22,13 @@
         {{with get . "thumbnail-url"}}
             {{with get $args "title-url"}}<a tabindex="-1" href="{{.}}">{{end}}
                 {{$watch_progress := get $args "watch-progress" | default (divf (randInt 0 101 | float64) 100.0)}}
-                <div class="rounded-lg overflow-hidden w-full [aspect-ratio:16/9] bg-gray-500 grid grid-cols-2 grid-rows-2"
+                <div class="rounded-sm overflow-hidden w-full [aspect-ratio:16/9] {{/*bg-gray-500*/}} grid grid-cols-2 grid-rows-2"
                         {{with $watch_progress}}
                             style="grid-template-columns: {{. | mulf 100}}% auto; grid-template-rows: 1fr 0.25rem"
                         {{end}}>
                     <div class="row-start-1 col-start-1 row-span-2 col-span-2">
 {{/*                        <img class="w-full h-full object-contain" src="https://picsum.photos/1920{{if randInt 0 2 | eq 0}}/1080{{end}}/?random={{randNumeric 16}}" alt="" />*/}}
-                        <img class="w-full h-full object-contain cat-img" src="" alt="" />
+                        <img class="w-full h-full object-cover cat-img" src="" alt="" />
                     </div>
                     {{if $watch_progress}}
                         <div class="row-start-2 col-start-2 col-span-1 row-span-1 bg-gray-50 opacity-50"></div>
@@ -250,16 +250,44 @@
 </div>
 {{end}}
 
-{{define "card-grid-head"}}
-<div class="flex flex-col gap-6 sm:gap-4 sm:flex-row sm:flex-wrap [align-items:stretch]">
+{{/*Reactive grid. Multiple rows on larger screens, single column on smaller screens.
+    Items must be card-grid-item-head/tail.*/}}
+{{define "card-grid-head"}} {{/*max-rows?, max-items? -> state*/}}
+{{if not (hasKey . "state")}}{{$_1 := set . "state" (dict)}}{{end}}
+{{$_2 := mergeOverwrite (get . "state") (pick . "max-rows" "max-items") (dict "index" 0) }}
+<div class="flex flex-col gap-6 sm:gap-2 sm:flex-row sm:flex-wrap [align-items:stretch]">
 {{end}}
 
 {{define "card-grid-tail"}}
 </div>
 {{end}}
 
+{{/*Grid item for card-grid-head/tail. Pass the 'state' value returned by card-grid-head (or pass the parameters manually).*/}}
 {{define "card-grid-item-head"}}
-<div class="sm:w-[calc((100%-1rem)/2)] lg:w-[calc((100%-2rem)/3)] 2xl:w-[calc((100%-3rem)/4)]"> {{/*account for flex gap*/}}
+{{$args := .}}
+{{/*could be a parameter but maybe overkill*/}}
+{{/*{{$config := list*/}}
+{{/*    (dict "screen" "sm"  "columns" 2)*/}}
+{{/*    (dict "screen" "lg"  "columns" 3)*/}}
+{{/*    (dict "screen" "2xl" "columns" 4)}}*/}}
+<div
+        class="
+            block
+            {{if ge (get . "index") (get . "max-items")}}hidden{{end}}
+            sm:block {{if ge (get . "index") (get . "max-rows" | mul 2)}}sm:hidden{{end}}
+            lg:block {{if ge (get . "index") (get . "max-rows" | mul 3)}}lg:hidden{{end}}
+            2xl:block {{if ge (get . "index") (get . "max-rows" | mul 4)}}2xl:hidden{{end}}
+            sm:w-[calc((100%-0.5rem)/2)] lg:w-[calc((100%-1rem)/3)] 2xl:w-[calc((100%-1.5rem)/4)]
+{{/*            block*/}}
+{{/*            {{if ge (get . "index") (get . "max-items")}}hidden{{end}}*/}}
+{{/*            {{range $sc := $config}}*/}}
+{{/*                {{$cols := get $sc "columns"}}*/}}
+{{/*                {{get $sc "screen"}}:block*/}}
+{{/*                {{if ge (get $args "index") (get $args "max-rows" | mul $cols)}}{{get $sc "screen"}}:hidden{{end}}*/}}
+{{/*                {{get $sc "screen"}}:w-[calc((100%-{{sub $cols 1}}rem)/{{$cols}})]*/}}
+{{/*            {{end}}*/}}
+            ">
+{{$_ := set . "index" (get . "index" | add 1)}}
 {{end}}
 
 {{define "card-grid-item-tail"}}

--- a/web/template/cards.gohtml
+++ b/web/template/cards.gohtml
@@ -13,87 +13,92 @@
     </div>
 {{end}}
 
-{{define "dropdown-actions"}} {{/*actions, icon? (fa icon), show-button-if? (alpine expression)*/}}
-    {{template "dropdown-head" dict "icon" (get . "icon") "show-button-if" (get . "show-button-if")}}
-    <ul class="absolute right-0 z-50 h-fit w-48 top-full text-left bg-white dark:bg-secondary rounded-lg shadow border dark:border-gray-800
-                        flex flex-col py-2">
-        {{range $action := get . "actions"}}
-            <li>
-                <button class="py-[0.125rem] px-2 w-full text-sm font-normal text-4 hover:text-1 hover: duration-100 flex flex-row gap-1 [align-items:center]"
-                        {{with get . "action"}}@click="{{.}}"{{end}}>
-                    <div class="mt-[0.05em] w-6 h-6 flex justify-center [align-items:center]">
-                        {{with get . "icon"}}<i class="fas fa-{{.}}"></i>{{end}}
-                    </div>
-                    <span class="pr-1">{{get . "label"}}</span>
-                </button>
-            </li>
-        {{end}}
-    </ul>
-    {{template "dropdown-tail"}}
-{{end}}
-
-{{define "item-card-head"}} {{/*title, title-url?, subtitle?, subtitle-url?, date?, date-context?, location?, badges?, actions?*/}}
+{{define "item-card-head"}} {{/*title, title-url?, thumbnail-url?, watch-progress, subtitle?, subtitle-url?, date?, date-context?, location?, badges?, actions?*/}}
 {{$args := .}}
-<div class="{{if get . "show-border"}}p-6 {{template "box-border"}}{{else}}p-2{{end}} h-full" x-data="{ hover: false }" @mouseover="hover = true" @mouseover.away="hover = false" >
-    <div class="flex flex-row space-between">
-        {{/*Main Content*/}}
-        <div class="grow flex flex-col gap-1 text-sm text-5 font-light">
-            <div>
-                <h3 class="text-lg text-2 hover:text-1 duration-100 font-semibold inline">
-                    {{with get . "title-url"}}<a href="{{.}}">{{end}}
-                        {{get . "title"}}
-                    {{if get . "title-url"}}</a>{{end}}
-                </h3>
+<div class="{{if get . "show-border"}}p-6 {{template "box-border"}}{{else}}p-2{{end}} h-full"
+        x-data="{ hover: false }" @mouseover="hover = true" @mouseover.away="hover = false" >
+    {{/* outer container: thumbnail on top, remaining content below */}}
+    <div class="flex flex-col gap-2">
+        {{with get . "thumbnail-url"}}
+            {{with get $args "title-url"}}<a href="{{.}}">{{end}}
+                {{$watch_progress := get $args "watch-progress" | default (divf (randInt 0 101 | float64) 100.0)}}
+                <div class="rounded-lg overflow-hidden w-full [aspect-ratio:16/9] bg-gray-500 grid grid-cols-2 grid-rows-2"
+                        {{with $watch_progress}}
+                            style="grid-template-columns: {{. | mulf 100}}% auto; grid-template-rows: 1fr 0.25rem"
+                        {{end}}>
+                    <div class="row-start-1 col-start-1 row-span-2 col-span-2">
+                        <img class="w-full h-full object-contain" src="https://picsum.photos/1920{{if randInt 0 2 | eq 0}}/1080{{end}}/?random={{randNumeric 16}}" alt="" />
+                    </div>
+                    {{if $watch_progress}}
+                        <div class="row-start-2 col-start-2 col-span-1 row-span-1 bg-gray-50 opacity-50"></div>
+                        <div class="row-start-2 col-start-1 col-span-1 row-span-1 bg-danger"></div>
+                    {{end}}
+                </div>
+            {{if get $args "title-url"}}</a>{{end}}
+        {{end}}
+        {{/* inner container: content on the left, dropdown in the top-right corner */}}
+        <div class="flex flex-row space-between">
+            {{/* main content */}}
+            <div class="grow flex flex-col gap-1 text-sm text-5 font-light">
+                <div>
+                    {{/* title */}}
+                    <h3 class="text-lg text-2 hover:text-1 duration-100 font-semibold inline">
+                        {{with get . "title-url"}}<a href="{{.}}">{{end}}
+                            {{get . "title"}}
+                        {{if get . "title-url"}}</a>{{end}}
+                    </h3>
 
-                {{with get . "subtitle"}}
-                    <p>
-                        {{with get $args "subtitle-url"}}<a class="hover:text-1 duration-100" href="{{.}}">{{end}}
-                            {{.}}
-                        {{if get $args "subtitle-url"}}</a>{{end}}
-                    </p>
-                {{end}}
-            </div>
+                    {{/* subtitle */}}
+                    {{with get . "subtitle"}}
+                        <h4>
+                            {{with get $args "subtitle-url"}}<a class="hover:text-1 duration-100" href="{{.}}">{{end}}
+                                {{.}}
+                            {{if get $args "subtitle-url"}}</a>{{end}}
+                        </h4>
+                    {{end}}
+                </div>
 {{end}}
 
 {{define "item-card-tail"}}
 {{$args := .}}
-            {{if pick . "date" "location" | values | compact}} {{/*any of date or location set*/}}
-                <div class="flex flex-row flex-wrap gap-x-6 gap-y-1">
-                    {{with get . "date"}}
-                        {{template "timestamp" dict "date" . "context" (get $args "date-context")}}
-                    {{end}}
+                {{if pick . "date" "location" | values | compact}} {{/*any of date or location set*/}}
+                    <div class="flex flex-row flex-wrap gap-x-6 gap-y-1">
+                        {{with get . "date"}}
+                            {{template "timestamp" dict "date" . "context" (get $args "date-context")}}
+                        {{end}}
     {{/*                {{$location := dict "id" 1 "name" "TUM Campus im Olympiapark: Hörsaal 1b (nur Mo-Do)"}}*/}}
-                    {{$location := dict "id" 1 "name" "Hörsaal 1b (nur Mo-Do)"}}
-                    {{with get . "location"}}{{$_ := $location | set "id" .Model.ID | set "name" .Name}}{{end}}
-                    <div class="inline-block">
-                        <span>
-                            <a class="hover:text-1 duration-100" href="/admin/lectureHalls#{{get $location "id"}}">
-                                <i class="pr-1 fas fa-location-pin"></i>
-                                {{get $location "name"}}
-                            </a>
-                        </span>
+                        {{$location := dict "id" 1 "name" "Hörsaal 1b (nur Mo-Do)"}}
+                        {{with get . "location"}}{{$_ := $location | set "id" .Model.ID | set "name" .Name}}{{end}}
+    {{/*                    <div class="inline-block">*/}}
+    {{/*                        <span>*/}}
+    {{/*                            <a class="hover:text-1 duration-100" href="/admin/lectureHalls#{{get $location "id"}}">*/}}
+    {{/*                                <i class="pr-1 fas fa-location-pin"></i>*/}}
+    {{/*                                {{get $location "name"}}*/}}
+    {{/*                            </a>*/}}
+    {{/*                        </span>*/}}
+    {{/*                    </div>*/}}
+                        {{/*TODO: remove dummy and make conditional on get . "location"*/}}
                     </div>
-                    {{/*TODO: remove dummy and make conditional on get . "location"*/}}
-                </div>
-            {{end}}
+                {{end}}
 
-            {{with get . "badges"}}
-                <div class="media-card-badges my-1 text-xs flex flex-row flex-wrap gap-2">
-                    {{range $badge := .}}
-                        <div class="{{get . "color"}} inline-block px-3 py-[0.125rem] rounded-full">
-                            <span class="uppercase font-semibold">
-                                {{with get . "icon"}}<i class="pr-1 fas fa-{{.}}"></i>{{end}}
-                                {{get . "label"}}
-                            </span>
-                        </div>
-                    {{end}}
-                </div>
+                {{with get . "badges"}}
+                    <div class="media-card-badges my-1 text-xs flex flex-row flex-wrap gap-2">
+                        {{range $badge := .}}
+                            <div class="{{get . "color"}} inline-block px-3 py-[0.125rem] rounded-full">
+                                <span class="uppercase font-semibold">
+                                    {{with get . "icon"}}<i class="pr-1 fas fa-{{.}}"></i>{{end}}
+                                    {{get . "label"}}
+                                </span>
+                            </div>
+                        {{end}}
+                    </div>
+                {{end}}
+            </div>
+            {{/*Dropdown Menu*/}}
+            {{with get . "actions"}}
+                {{template "dropdown-actions" dict "actions" . "show-button-if" "hover" "width" 40}}
             {{end}}
         </div>
-        {{/*Dropdown Menu*/}}
-        {{with get . "actions"}}
-            {{template "dropdown-actions" dict "actions" . "show-button-if" "hover"}}
-        {{end}}
     </div>
 </div>
 {{end}}
@@ -124,6 +129,7 @@
     "title-url" (printf "/w/%s/%d" $course.Slug $stream.Model.ID)
     "subtitle" ($standalone | ternary $course.Name "")
     "subtitle-url" ($standalone | ternary (printf "/course/%d/%s/%s" $course.Year $course.TeachingTerm $course.Slug) "")
+    "thumbnail-url" (true | default "TODO replace this with an actual url")
     "badges" (list
         ($stream.LiveNow | ternary (dict "label" "Live" "color" "bg-danger text-white" "icon" "tower-cell") (dict))
         ($course.IsHidden | ternary (dict "label" "Hidden" "color" "bg-blue-800 text-white" "icon" "eye-slash") (dict))
@@ -133,8 +139,8 @@
     "location" $lectureHall
     "actions" ($standalone | ternary
         (list
-            (dict "label" "Hide this course" "icon" "eye-slash" "action" "hide()")
-            (dict "label" ($course.Pinned | ternary "Unpin this course" "Pin this course") "icon" "thumbtack" "action" "pinUnpin()")
+            (dict "label" "Hide course" "icon" "eye-slash" "action" "hide()")
+            (dict "label" ($course.Pinned | ternary "Unpin this course" "Pin course") "icon" "thumbtack" "action" "pinUnpin()")
             | compact)
         (list))}}
 
@@ -145,7 +151,7 @@
 
 {{/*<div x-show="menu_open" x-cloak>*/}}
 {{/*    <i class="fancyeye opacity-0 group-hover:opacity-100 transition-colors duration-200 dark:hover:text-white hover:text-black text-gray-500 mr-2 cursor-pointer"*/}}
-{{/*       title="Hide this course" onclick="global.hideCourse({{$course.Model.ID}}, {{$course.Name}});{{if $course.Pinned}}global.unpinCourse({{$course.Model.ID}}){{end}}"></i>*/}}
+{{/*       title="Hide course" onclick="global.hideCourse({{$course.Model.ID}}, {{$course.Name}});{{if $course.Pinned}}global.unpinCourse({{$course.Model.ID}}){{end}}"></i>*/}}
 {{/*    {{if $user}}*/}}
 {{/*        <i class="fa-solid fa-thumbtack opacity-0 group-hover:opacity-100 transition-colors duration-200 dark:hover:text-white hover:text-black text-gray-500 mr-2 cursor-pointer"*/}}
 {{/*           {{if $course.Pinned}}title="Unpin this course" onclick="global.unpinCourse({{$course.Model.ID}})" {{else}}title="Pin this course" onclick="global.pinCourse({{$course.Model.ID}})"{{end}}></i>*/}}
@@ -171,8 +177,8 @@
         | compact)
     "location" .LectureHall
     "actions" (list
-        (dict "label" "Hide this course" "icon" "eye-slash" "action" "hide()")
-        (dict "label" ($course.Pinned | ternary "Unpin this course" "Pin this course") "icon" "thumbtack" "action" "pinUnpin()")
+        (dict "label" "Hide course" "icon" "eye-slash" "action" "hide()")
+        (dict "label" ($course.Pinned | ternary "Unpin this course" "Pin course") "icon" "thumbtack" "action" "pinUnpin()")
         | compact)}}
 </div>
 {{end}}
@@ -223,18 +229,18 @@
     </div>
     {{template "item-card-tail" dict
     "actions" (list
-        (dict "label" "Hide this course" "icon" "eye-slash" "action" "hide()")
-        (dict "label" (.Pinned | default false | ternary "Unpin this course" "Pin this course") "icon" "thumbtack" "action" "pinUnpin()")
+        (dict "label" "Hide course" "icon" "eye-slash" "action" "hide()")
+        (dict "label" (.Pinned | default false | ternary "Unpin course" "Pin course") "icon" "thumbtack" "action" "pinUnpin()")
         | compact)}}
 </div>
 {{end}}
 
 {{define "card-container-head"}}
-<div class="px-2 pl-5 h-[0.6rem]">
-    <span class="p-2 font-normal text-5 bg-white dark:bg-secondary uppercase">{{. | default "Latest"}}</span>
+<div class="px-2 pl-5 h-[0.6rem] ">
+    <span class="p-2 font-normal text-5 bg-white dark:bg-secondary uppercase">{{.}}</span>
 </div>
-<div class="{{template "box-border"}} {{/*flex flex-col*/}} {{/*md:flex-row*/}}">
-    <div class="w-full p-5 pt-4">
+<div class="pt-[0.4rem] {{template "box-border"}} {{/*flex flex-col*/}} {{/*md:flex-row*/}}">
+    <div class="w-full p-5 py-4">
 {{end}}
 
 {{define "card-container-tail"}}
@@ -243,7 +249,7 @@
 {{end}}
 
 {{define "card-grid-head"}}
-<div class="flex flex-col gap-2 md:gap-4 md:flex-row md:flex-wrap [align-items:stretch]">
+<div class="flex flex-col gap-6 sm:gap-4 sm:flex-row sm:flex-wrap [align-items:stretch]">
 {{end}}
 
 {{define "card-grid-tail"}}
@@ -251,7 +257,7 @@
 {{end}}
 
 {{define "card-grid-item-head"}}
-<div class="md:w-[calc((100%-1rem)/2)] 2xl:w-[calc((100%-2rem)/3)]"> {{/*account for flex gap*/}}
+<div class="sm:w-[calc((100%-1rem)/2)] lg:w-[calc((100%-2rem)/3)] 2xl:w-[calc((100%-3rem)/4)]"> {{/*account for flex gap*/}}
 {{end}}
 
 {{define "card-grid-item-tail"}}

--- a/web/template/cards.gohtml
+++ b/web/template/cards.gohtml
@@ -1,0 +1,259 @@
+{{define "box-border"}}border dark:border-gray-800 rounded-lg{{end}}
+
+{{/*TODO: make dynamic*/}}
+{{/*TODO: is this done*/}}
+{{define "timestamp"}}
+    <div x-data="{ timestamp: global.DateTime.fromSeconds({{get . "date" | unixEpoch}}) }"
+         :title="timestamp.toLocaleString(global.DateTime.DATETIME_MED_WITH_WEEKDAY)"
+         class="inline-block">
+        <i class="pr-1 fas fa-clock"></i>
+        {{with get . "context"}}<span>{{.}}{{end}}
+        <span x-text="timestamp.toRelative()"></span>
+    {{if get . "context"}}</span>{{end}}
+    </div>
+{{end}}
+
+{{define "dropdown-actions"}} {{/*actions, icon? (fa icon), show-button-if? (alpine expression)*/}}
+    {{template "dropdown-head" dict "icon" (get . "icon") "show-button-if" (get . "show-button-if")}}
+    <ul class="absolute right-0 z-50 h-fit w-48 top-full text-left bg-white dark:bg-secondary rounded-lg shadow border dark:border-gray-800
+                        flex flex-col py-2">
+        {{range $action := get . "actions"}}
+            <li>
+                <button class="py-[0.125rem] px-2 w-full text-sm font-normal text-4 hover:text-1 hover: duration-100 flex flex-row gap-1 [align-items:center]"
+                        {{with get . "action"}}@click="{{.}}"{{end}}>
+                    <div class="mt-[0.05em] w-6 h-6 flex justify-center [align-items:center]">
+                        {{with get . "icon"}}<i class="fas fa-{{.}}"></i>{{end}}
+                    </div>
+                    <span class="pr-1">{{get . "label"}}</span>
+                </button>
+            </li>
+        {{end}}
+    </ul>
+    {{template "dropdown-tail"}}
+{{end}}
+
+{{define "item-card-head"}} {{/*title, title-url?, subtitle?, subtitle-url?, date?, date-context?, location?, badges?, actions?*/}}
+{{$args := .}}
+<div class="{{if get . "show-border"}}p-6 {{template "box-border"}}{{else}}p-2{{end}} h-full" x-data="{ hover: false }" @mouseover="hover = true" @mouseover.away="hover = false" >
+    <div class="flex flex-row space-between">
+        {{/*Main Content*/}}
+        <div class="grow flex flex-col gap-1 text-sm text-5 font-light">
+            <div>
+                <h3 class="text-lg text-2 hover:text-1 duration-100 font-semibold inline">
+                    {{with get . "title-url"}}<a href="{{.}}">{{end}}
+                        {{get . "title"}}
+                    {{if get . "title-url"}}</a>{{end}}
+                </h3>
+
+                {{with get . "subtitle"}}
+                    <p>
+                        {{with get $args "subtitle-url"}}<a class="hover:text-1 duration-100" href="{{.}}">{{end}}
+                            {{.}}
+                        {{if get $args "subtitle-url"}}</a>{{end}}
+                    </p>
+                {{end}}
+            </div>
+{{end}}
+
+{{define "item-card-tail"}}
+{{$args := .}}
+            {{if pick . "date" "location" | values | compact}} {{/*any of date or location set*/}}
+                <div class="flex flex-row flex-wrap gap-x-6 gap-y-1">
+                    {{with get . "date"}}
+                        {{template "timestamp" dict "date" . "context" (get $args "date-context")}}
+                    {{end}}
+    {{/*                {{$location := dict "id" 1 "name" "TUM Campus im Olympiapark: Hörsaal 1b (nur Mo-Do)"}}*/}}
+                    {{$location := dict "id" 1 "name" "Hörsaal 1b (nur Mo-Do)"}}
+                    {{with get . "location"}}{{$_ := $location | set "id" .Model.ID | set "name" .Name}}{{end}}
+                    <div class="inline-block">
+                        <span>
+                            <a class="hover:text-1 duration-100" href="/admin/lectureHalls#{{get $location "id"}}">
+                                <i class="pr-1 fas fa-location-pin"></i>
+                                {{get $location "name"}}
+                            </a>
+                        </span>
+                    </div>
+                    {{/*TODO: remove dummy and make conditional on get . "location"*/}}
+                </div>
+            {{end}}
+
+            {{with get . "badges"}}
+                <div class="media-card-badges my-1 text-xs flex flex-row flex-wrap gap-2">
+                    {{range $badge := .}}
+                        <div class="{{get . "color"}} inline-block px-3 py-[0.125rem] rounded-full">
+                            <span class="uppercase font-semibold">
+                                {{with get . "icon"}}<i class="pr-1 fas fa-{{.}}"></i>{{end}}
+                                {{get . "label"}}
+                            </span>
+                        </div>
+                    {{end}}
+                </div>
+            {{end}}
+        </div>
+        {{/*Dropdown Menu*/}}
+        {{with get . "actions"}}
+            {{template "dropdown-actions" dict "actions" . "show-button-if" "hover"}}
+        {{end}}
+    </div>
+</div>
+{{end}}
+
+{{define "item-card"}}
+    {{template "item-card-head" .}}
+    {{template "item-card-tail" .}}
+{{end}}
+
+{{define "stream-card"}} {{/*stream, standalone?, course?, lectureHall?*/}}
+
+{{/*TODO: default title*/}}
+{{/*TODO: pinned courses*/}}
+{{$stream := get . "stream"}}
+{{$course := get . "course"}}
+{{$standalone := get . "standalone" | default false}} {{/*default true doesn't work because false is empty too*/}}
+{{$lectureHall := get . "lectureHall"}}
+
+<div class="h-full"
+        data-course-name="{{$course.Name}}"
+        {{if $standalone}}
+            x-data="{
+                hide: function() { global.hideCourse({{$course.Model.ID}}, $el.dataset$courseName);{{if $course.Pinned}}global.unpinCourse({{$course.Model.ID}});{{end}} },
+                pinUnpin: function() { {{if $course.Pinned}}global.unpinCourse({{$course.Model.ID}}){{else}}global.pinCourse({{$course.Model.ID}}){{end}}; } }"
+        {{end}}>
+{{template "item-card" dict
+    "title" ($stream.Name | default (printf "%s: TODO (Unnamed) Live Stream" $course.Name))
+    "title-url" (printf "/w/%s/%d" $course.Slug $stream.Model.ID)
+    "subtitle" ($standalone | ternary $course.Name "")
+    "subtitle-url" ($standalone | ternary (printf "/course/%d/%s/%s" $course.Year $course.TeachingTerm $course.Slug) "")
+    "badges" (list
+        ($stream.LiveNow | ternary (dict "label" "Live" "color" "bg-danger text-white" "icon" "tower-cell") (dict))
+        ($course.IsHidden | ternary (dict "label" "Hidden" "color" "bg-blue-800 text-white" "icon" "eye-slash") (dict))
+        | compact)
+    "date" $stream.End
+    "date-context" ($stream.LiveNow | ternary "Ends " "Streamed ")
+    "location" $lectureHall
+    "actions" ($standalone | ternary
+        (list
+            (dict "label" "Hide this course" "icon" "eye-slash" "action" "hide()")
+            (dict "label" ($course.Pinned | ternary "Unpin this course" "Pin this course") "icon" "thumbtack" "action" "pinUnpin()")
+            | compact)
+        (list))}}
+
+{{/*    (randNumeric 1 | atoi | ge 5 | ternary (dict "label" "Live" "color" "bg-red-700 text-white" "icon" "tower-cell") (dict))*/}}
+{{/*    ((.Course.IsHidden | and false | or (randNumeric 1 | atoi | ge 5)) | ternary (dict "label" "Hidden" "color" "bg-blue-800 text-white" "icon" "eye-slash") (dict))*/}}
+</div>
+{{end}}
+
+{{/*<div x-show="menu_open" x-cloak>*/}}
+{{/*    <i class="fancyeye opacity-0 group-hover:opacity-100 transition-colors duration-200 dark:hover:text-white hover:text-black text-gray-500 mr-2 cursor-pointer"*/}}
+{{/*       title="Hide this course" onclick="global.hideCourse({{$course.Model.ID}}, {{$course.Name}});{{if $course.Pinned}}global.unpinCourse({{$course.Model.ID}}){{end}}"></i>*/}}
+{{/*    {{if $user}}*/}}
+{{/*        <i class="fa-solid fa-thumbtack opacity-0 group-hover:opacity-100 transition-colors duration-200 dark:hover:text-white hover:text-black text-gray-500 mr-2 cursor-pointer"*/}}
+{{/*           {{if $course.Pinned}}title="Unpin this course" onclick="global.unpinCourse({{$course.Model.ID}})" {{else}}title="Pin this course" onclick="global.pinCourse({{$course.Model.ID}})"{{end}}></i>*/}}
+{{/*    {{end}}*/}}
+{{/*</div>*/}}
+
+
+{{define "course-card-2"}} {{/*course, user*/}}
+{{/*TODO: countdown*/}}
+{{/*TODO: proper labels for pin/unpin*/}}
+{{/*TODO: hiding courses*/}}
+{{/*TODO: why user?*/}}
+{{$course := get . "course"}}
+{{$user := get . "user"}}
+<div data-course-name="{{$course.Name}}" x-data="{
+    hide: function() { global.hideCourse({{$course.Model.ID}}, $el.dataset.courseName);{{if $course.Pinned}}global.unpinCourse({{$course.Model.ID}});{{end}} },
+    pinUnpin: function() { {{if $course.Pinned}}global.unpinCourse({{$course.Model.ID}}){{else}}global.pinCourse({{$course.Model.ID}}){{end}}; } }">
+{{template "item-card" dict
+    "title" $course.Name
+    "title-url" (printf "/course/%d/%s/%s" $course.Year $course.TeachingTerm $course.Slug)
+    "badges" (list
+        (randNumeric 1 | atoi | ge 5 | and false | ternary (dict "label" "New" "color" "bg-gray-700 text-white") (dict))
+        | compact)
+    "location" .LectureHall
+    "actions" (list
+        (dict "label" "Hide this course" "icon" "eye-slash" "action" "hide()")
+        (dict "label" ($course.Pinned | ternary "Unpin this course" "Pin this course") "icon" "thumbtack" "action" "pinUnpin()")
+        | compact)}}
+</div>
+{{end}}
+
+{{/*{{define "stream-card"}}*/}}
+{{/*{{$liveStream := .}}*/}}
+{{/*<div class="pt-1 px-4 mb-2 course{{$liveStream.Course.Model.ID}}">*/}}
+{{/*    <a href="/w/{{$liveStream.Course.Slug}}/{{$liveStream.Stream.Model.ID}}">*/}}
+{{/*        <h3 class="text-lg text-2 inline">{{$liveStream.Course.Name}}{{if $liveStream.Stream.Name}}: {{$liveStream.Stream.Name}}{{end}}</h3>*/}}
+{{/*    </a>*/}}
+{{/*    <p class="font-sans font-light text-sm">*/}}
+{{/*        {{if $liveStream.Course.IsHidden}} {{- /* only admins have hidden courses here */ -}}*/}}
+{{/*        <span class="bg-blue-800 text-blue-100 px-2 mr-1 capitalize rounded-full font-semibold">Hidden</span>*/}}
+{{/*        {{end}}*/}}
+{{/*        <span class="bg-red-800 text-red-100 px-2 mr-1 capitalize rounded-full font-semibold">Live</span>*/}}
+{{/*        <span class="font-light text-3">{{printf "until %2d:%02d" $liveStream.Stream.End.Hour $liveStream.Stream.End.Minute}}</span>*/}}
+{{/*        {{if and $liveStream.LectureHall}}<a href="/admin/lectureHalls#{{$liveStream.LectureHall.Model.ID}}" class="font-semibold text-3"> - <i class="fas fa-location-pin"></i> {{$liveStream.LectureHall.Name}}</a>{{end}}*/}}
+{{/*    </p>*/}}
+{{/*</div>*/}}
+{{/*{{end}}*/}}
+
+{{define "course-group-head"}}
+
+{{/*TODO duplication with course-card-2*/}}
+<div data-course-name="{{.Name}}" x-data="{
+        hide: function() { global.hideCourse({{.Model.ID}}, $el.dataset.courseName);{{if .Pinned}}global.unpinCourse({{.Model.ID}});{{end}} },
+        pinUnpin: function() { {{if .Pinned}}global.unpinCourse({{.Model.ID}}){{else}}global.pinCourse({{.Model.ID}}){{end}}; } }">
+
+    {{template "item-card-head" dict
+        "title" .Name
+        "title-url" (printf "/course/%d/%s/%s" .Year .TeachingTerm .Slug)}}
+
+    {{$course := .}}
+    {{/*Order of conditions is important*/}}
+    {{/*TODO: restore the full logic*/}}
+    {{if .IsLive | and false}}
+        Live now
+    {{else if .HasNextLecture}}
+        {{template "timestamp" dict "date" .GetNextLecture.Start "context" "Scheduled "}}
+    {{else}}
+        No upcoming lectures
+    {{end}}
+
+    <div class="mt-2">
+{{end}}
+
+{{define "course-group-tail"}}
+    </div>
+    {{template "item-card-tail" dict
+    "actions" (list
+        (dict "label" "Hide this course" "icon" "eye-slash" "action" "hide()")
+        (dict "label" (.Pinned | default false | ternary "Unpin this course" "Pin this course") "icon" "thumbtack" "action" "pinUnpin()")
+        | compact)}}
+</div>
+{{end}}
+
+{{define "card-container-head"}}
+<div class="px-2 pl-5 h-[0.6rem]">
+    <span class="p-2 font-normal text-5 bg-white dark:bg-secondary uppercase">{{. | default "Latest"}}</span>
+</div>
+<div class="{{template "box-border"}} {{/*flex flex-col*/}} {{/*md:flex-row*/}}">
+    <div class="w-full p-5 pt-4">
+{{end}}
+
+{{define "card-container-tail"}}
+    </div>
+</div>
+{{end}}
+
+{{define "card-grid-head"}}
+<div class="flex flex-col gap-2 md:gap-4 md:flex-row md:flex-wrap [align-items:stretch]">
+{{end}}
+
+{{define "card-grid-tail"}}
+</div>
+{{end}}
+
+{{define "card-grid-item-head"}}
+<div class="md:w-[calc((100%-1rem)/2)] 2xl:w-[calc((100%-2rem)/3)]"> {{/*account for flex gap*/}}
+{{end}}
+
+{{define "card-grid-item-tail"}}
+</div>
+{{end}}

--- a/web/template/cards.gohtml
+++ b/web/template/cards.gohtml
@@ -20,14 +20,15 @@
     {{/* outer container: thumbnail on top, remaining content below */}}
     <div class="flex flex-col gap-2">
         {{with get . "thumbnail-url"}}
-            {{with get $args "title-url"}}<a href="{{.}}">{{end}}
+            {{with get $args "title-url"}}<a tabindex="-1" href="{{.}}">{{end}}
                 {{$watch_progress := get $args "watch-progress" | default (divf (randInt 0 101 | float64) 100.0)}}
                 <div class="rounded-lg overflow-hidden w-full [aspect-ratio:16/9] bg-gray-500 grid grid-cols-2 grid-rows-2"
                         {{with $watch_progress}}
                             style="grid-template-columns: {{. | mulf 100}}% auto; grid-template-rows: 1fr 0.25rem"
                         {{end}}>
                     <div class="row-start-1 col-start-1 row-span-2 col-span-2">
-                        <img class="w-full h-full object-contain" src="https://picsum.photos/1920{{if randInt 0 2 | eq 0}}/1080{{end}}/?random={{randNumeric 16}}" alt="" />
+{{/*                        <img class="w-full h-full object-contain" src="https://picsum.photos/1920{{if randInt 0 2 | eq 0}}/1080{{end}}/?random={{randNumeric 16}}" alt="" />*/}}
+                        <img class="w-full h-full object-contain cat-img" src="" alt="" />
                     </div>
                     {{if $watch_progress}}
                         <div class="row-start-2 col-start-2 col-span-1 row-span-1 bg-gray-50 opacity-50"></div>
@@ -222,16 +223,17 @@
         No upcoming lectures
     {{end}}
 
-    <div class="mt-2">
-{{end}}
-
-{{define "course-group-tail"}}
-    </div>
     {{template "item-card-tail" dict
     "actions" (list
         (dict "label" "Hide course" "icon" "eye-slash" "action" "hide()")
         (dict "label" (.Pinned | default false | ternary "Unpin course" "Pin course") "icon" "thumbtack" "action" "pinUnpin()")
         | compact)}}
+
+    <div class="mt-2">
+{{end}}
+
+{{define "course-group-tail"}}
+    </div>
 </div>
 {{end}}
 

--- a/web/template/cards.gohtml
+++ b/web/template/cards.gohtml
@@ -1,15 +1,21 @@
 {{define "box-border"}}border dark:border-gray-800 rounded-lg{{end}}
 
-{{/*TODO: make dynamic*/}}
-{{/*TODO: is this done*/}}
-{{define "timestamp"}}
-    <div x-data="{ timestamp: global.DateTime.fromSeconds({{get . "date" | unixEpoch}}) }"
+{{define "timestamp"}} {{/*context?(always?, before?, after?)*/}}
+{{/*    <div x-data="{ timestamp: global.DateTime.fromSeconds({{get . "date" | unixEpoch}}) }"*/}}
+    <div x-data="{ timestamp: global.DateTime.fromSeconds({{now | unixEpoch | add (eq (randInt 0 2) 0 | ternary (randInt -90 91) (randInt -259200 259200))}}) }"
          :title="timestamp.toLocaleString(global.DateTime.DATETIME_MED_WITH_WEEKDAY)"
          class="inline-block">
-        <i class="pr-1 fas fa-clock"></i>
-        {{with get . "context"}}<span>{{.}}{{end}}
-        <span x-text="timestamp.toRelative()"></span>
-    {{if get . "context"}}</span>{{end}}
+        <div x-data="dynamicRelativeTime(timestamp, { unit: ['years', 'months', 'weeks', 'days', 'hours', 'minutes'] })">
+            <i class="pr-1 fas fa-clock"></i>
+            <span>
+            {{with get . "context"}}
+                    <span x-data="{{. | toJson}}"
+                          x-text="{{if get . "always"}}always{{else}}isFuture ? before : after{{end}}">
+                    </span>
+            {{end}}
+                <span x-text="relativeTime"></span>
+            </span>
+        </div>
     </div>
 {{end}}
 
@@ -135,8 +141,8 @@
         ($stream.LiveNow | ternary (dict "label" "Live" "color" "bg-danger text-white" "icon" "tower-cell") (dict))
         ($course.IsHidden | ternary (dict "label" "Hidden" "color" "bg-blue-800 text-white" "icon" "eye-slash") (dict))
         | compact)
-    "date" $stream.End
-    "date-context" ($stream.LiveNow | ternary "Ends " "Streamed ")
+    "date" ($stream.LiveNow | ternary $stream.End (ge (now | unixEpoch) ($stream.End | unixEpoch) | ternary $stream.End $stream.Start))
+    "date-context" (dict "before" ($stream.LiveNow | ternary "Ends" "Scheduled") "after" "Streamed")
     "location" $lectureHall
     "actions" ($standalone | ternary
         (list
@@ -145,6 +151,7 @@
             | compact)
         (list))}}
 
+    {{/*TODO: enhance dynamic dates to accept various ranges and replace "date" above*/}}
 {{/*    (randNumeric 1 | atoi | ge 5 | ternary (dict "label" "Live" "color" "bg-red-700 text-white" "icon" "tower-cell") (dict))*/}}
 {{/*    ((.Course.IsHidden | and false | or (randNumeric 1 | atoi | ge 5)) | ternary (dict "label" "Hidden" "color" "bg-blue-800 text-white" "icon" "eye-slash") (dict))*/}}
 </div>
@@ -218,7 +225,7 @@
     {{if .IsLive | and false}}
         Live now
     {{else if .HasNextLecture}}
-        {{template "timestamp" dict "date" .GetNextLecture.Start "context" "Scheduled "}}
+        {{template "timestamp" dict "date" .GetNextLecture.Start "context" (dict "always" "Scheduled ")}}
     {{else}}
         No upcoming lectures
     {{end}}

--- a/web/template/cards.gohtml
+++ b/web/template/cards.gohtml
@@ -118,19 +118,23 @@
 {{define "stream-card"}} {{/*stream, standalone?, course?, lectureHall?*/}}
 
 {{/*TODO: default title*/}}
-{{/*TODO: pinned courses*/}}
+{{/*TODO: signed-out pin/hide*/}}
 {{$stream := get . "stream"}}
 {{$course := get . "course"}}
 {{$standalone := get . "standalone" | default false}} {{/*default true doesn't work because false is empty too*/}}
 {{$lectureHall := get . "lectureHall"}}
 
-<div class="h-full"
-        data-course-name="{{$course.Name}}"
-        {{if $standalone}}
-            x-data="{
-                hide: function() { global.hideCourse({{$course.Model.ID}}, $el.dataset$courseName);{{if $course.Pinned}}global.unpinCourse({{$course.Model.ID}});{{end}} },
-                pinUnpin: function() { {{if $course.Pinned}}global.unpinCourse({{$course.Model.ID}}){{else}}global.pinCourse({{$course.Model.ID}}){{end}}; } }"
-        {{end}}>
+<div
+    class="h-full"
+    data-course-name="{{$course.Name}}"
+    x-data="{
+        pinUnpin: function() {
+            global.updateCourseFlag({{$course.Model.ID}}, global.CourseFlag.Pinned, {{not $course.Pinned}})
+        },
+        hideUnhide: function() {
+            global.updateCourseFlag({{$course.Model.ID}}, global.CourseFlag.Hidden, {{not $course.Hidden}})
+        }
+    }">
 {{template "item-card" dict
     "title" ($stream.Name | default (printf "%s: TODO (Unnamed) Live Stream" $course.Name))
     "title-url" (printf "/w/%s/%d" $course.Slug $stream.Model.ID)
@@ -146,9 +150,8 @@
     "location" $lectureHall
     "actions" ($standalone | ternary
         (list
-            (dict "label" "Hide course" "icon" "eye-slash" "action" "hide()")
-            (dict "label" ($course.Pinned | ternary "Unpin this course" "Pin course") "icon" "thumbtack" "action" "pinUnpin()")
-            | compact)
+            (dict "label" ($course.Hidden | ternary "Show course" "Hide course") "icon" ($course.Hidden | ternary "eye" "eye-slash") "action" "hideUnhide()")
+            (dict "label" ($course.Pinned | ternary "Unpin course" "Pin course") "icon" "thumbtack" "action" "pinUnpin()"))
         (list))}}
 
     {{/*TODO: enhance dynamic dates to accept various ranges and replace "date" above*/}}
@@ -167,29 +170,33 @@
 {{/*</div>*/}}
 
 
-{{define "course-card-2"}} {{/*course, user*/}}
+{{/*{{define "course-card-2"}} */}}{{/*course, user*/}}
 {{/*TODO: countdown*/}}
-{{/*TODO: proper labels for pin/unpin*/}}
-{{/*TODO: hiding courses*/}}
 {{/*TODO: why user?*/}}
-{{$course := get . "course"}}
-{{$user := get . "user"}}
-<div data-course-name="{{$course.Name}}" x-data="{
-    hide: function() { global.hideCourse({{$course.Model.ID}}, $el.dataset.courseName);{{if $course.Pinned}}global.unpinCourse({{$course.Model.ID}});{{end}} },
-    pinUnpin: function() { {{if $course.Pinned}}global.unpinCourse({{$course.Model.ID}}){{else}}global.pinCourse({{$course.Model.ID}}){{end}}; } }">
-{{template "item-card" dict
-    "title" $course.Name
-    "title-url" (printf "/course/%d/%s/%s" $course.Year $course.TeachingTerm $course.Slug)
-    "badges" (list
-        (randNumeric 1 | atoi | ge 5 | and false | ternary (dict "label" "New" "color" "bg-gray-700 text-white") (dict))
-        | compact)
-    "location" .LectureHall
-    "actions" (list
-        (dict "label" "Hide course" "icon" "eye-slash" "action" "hide()")
-        (dict "label" ($course.Pinned | ternary "Unpin this course" "Pin course") "icon" "thumbtack" "action" "pinUnpin()")
-        | compact)}}
-</div>
-{{end}}
+{{/*{{$course := get . "course"}}*/}}
+{{/*{{$user := get . "user"}}*/}}
+{{/*<div*/}}
+{{/*    data-course-name="{{$course.Name}}"*/}}
+{{/*    x-data="{*/}}
+{{/*        pinUnpin: function() {*/}}
+{{/*            global.updateCourseFlag({{$course.Model.ID}}, global.CourseFlag.Pinned, {{not $course.Pinned}})*/}}
+{{/*        },*/}}
+{{/*        hide: function() {*/}}
+{{/*            global.updateCourseFlag({{$course.Model.ID}}, global.CourseFlag.Hidden, true)*/}}
+{{/*        }*/}}
+{{/*    }">*/}}
+{{/*{{template "item-card" dict*/}}
+{{/*    "title" $course.Name*/}}
+{{/*    "title-url" (printf "/course/%d/%s/%s" $course.Year $course.TeachingTerm $course.Slug)*/}}
+{{/*    "badges" (list*/}}
+{{/*        (randNumeric 1 | atoi | ge 5 | and false | ternary (dict "label" "New" "color" "bg-gray-700 text-white") (dict))*/}}
+{{/*        | compact)*/}}
+{{/*    "location" .LectureHall*/}}
+{{/*    "actions" (list*/}}
+{{/*        (dict "label" "Hide course" "icon" "eye-slash" "action" "hide()")*/}}
+{{/*        (dict "label" ($course.Pinned | ternary "Unpin course" "Pin course") "icon" "thumbtack" "action" "pinUnpin()"))}}*/}}
+{{/*</div>*/}}
+{{/*{{end}}*/}}
 
 {{/*{{define "stream-card"}}*/}}
 {{/*{{$liveStream := .}}*/}}
@@ -211,30 +218,38 @@
 {{define "course-group-head"}}
 
 {{/*TODO duplication with course-card-2*/}}
-<div data-course-name="{{.Name}}" x-data="{
-        hide: function() { global.hideCourse({{.Model.ID}}, $el.dataset.courseName);{{if .Pinned}}global.unpinCourse({{.Model.ID}});{{end}} },
-        pinUnpin: function() { {{if .Pinned}}global.unpinCourse({{.Model.ID}}){{else}}global.pinCourse({{.Model.ID}}){{end}}; } }">
+{{$course := .}}
+<div
+    data-course-name="{{$course.Name}}"
+    x-data="{
+        pinUnpin: function() {
+            global.updateCourseFlag({{$course.Model.ID}}, global.CourseFlag.Pinned, {{not $course.Pinned}})
+        },
+        hideUnhide: function() {
+            global.updateCourseFlag({{$course.Model.ID}}, global.CourseFlag.Hidden, {{not $course.Hidden}})
+        }
+    }">
 
     {{template "item-card-head" dict
         "title" .Name
         "title-url" (printf "/course/%d/%s/%s" .Year .TeachingTerm .Slug)}}
 
-    {{$course := .}}
     {{/*Order of conditions is important*/}}
     {{/*TODO: restore the full logic*/}}
     {{if .IsLive | and false}}
         Live now
     {{else if .HasNextLecture}}
-        {{template "timestamp" dict "date" .GetNextLecture.Start "context" (dict "always" "Scheduled ")}}
+        {{template "timestamp" dict
+            "date" .GetNextLecture.Start
+            "context" (dict "always" "Scheduled ")}}
     {{else}}
         No upcoming lectures
     {{end}}
 
     {{template "item-card-tail" dict
     "actions" (list
-        (dict "label" "Hide course" "icon" "eye-slash" "action" "hide()")
-        (dict "label" (.Pinned | default false | ternary "Unpin course" "Pin course") "icon" "thumbtack" "action" "pinUnpin()")
-        | compact)}}
+        (dict "label" (.Hidden | ternary "Show course" "Hide course") "icon" (.Hidden | ternary "eye" "eye-slash") "action" "hideUnhide()")
+        (dict "label" (.Pinned | ternary "Unpin course" "Pin course") "icon" "thumbtack" "action" "pinUnpin()"))}}
 
     <div class="mt-2">
 {{end}}
@@ -272,7 +287,8 @@
 {{/*Grid item for card-grid-head/tail. Pass the 'state' value returned by card-grid-head (or pass the parameters manually).*/}}
 {{define "card-grid-item-head"}}
 {{$args := .}}
-{{/*could be a parameter but maybe overkill*/}}
+{{/*idea: could be a parameter but maybe overkill*/}}
+{{/*unfortunately, doesn't work with tailwind*/}}
 {{/*{{$config := list*/}}
 {{/*    (dict "screen" "sm"  "columns" 2)*/}}
 {{/*    (dict "screen" "lg"  "columns" 3)*/}}

--- a/web/template/course-card.gohtml
+++ b/web/template/course-card.gohtml
@@ -50,7 +50,7 @@
                     {{$next := $course.GetNextLecture.Start}}Next lecture: {{printf "%v %02d. %02d:%02d" $next.Month $next.Day $next.Hour $next.Minute}}
                 {{end}}
             {{else}}
-                No upcoming Lectures
+                No upcoming lectures
             {{end}}
         </p>
     </div>

--- a/web/template/course_list.gohtml
+++ b/web/template/course_list.gohtml
@@ -12,11 +12,11 @@
             <li class="pl-4 p-2">
                 <div class="flex justify-between">
                     {{if or (or $lecture.LiveNow $lecture.Recording) $lecture.IsComingUp}}
-                        <a href="/w/{{$course.Slug}}/{{$lecture.Model.ID}}" class="text-l text-3 p-0">
+                        <a href="/w/{{$course.Slug}}/{{$lecture.Model.ID}}" class="text-lg text-3 p-0">
                             {{if $lecture.Name}}{{$lecture.Name}}{{else}}Lecture: {{$lecture.Start.Month}} {{printf "%02d." $lecture.Start.Day}} {{$lecture.Start.Year}}{{end}}
                         </a>
                     {{else}}
-                        <h3 class="text-l text-3 p-0">
+                        <h3 class="text-lg text-3 p-0">
                             {{if $lecture.Name}}{{$lecture.Name}}{{else}}Lecture: {{$lecture.Start.Month}} {{printf "%02d." $lecture.Start.Day}} {{$lecture.Start.Year}}{{end}}
                         </h3>
                     {{end}}

--- a/web/template/headImports.gohtml
+++ b/web/template/headImports.gohtml
@@ -18,4 +18,9 @@
         if ('serviceWorker' in navigator) navigator.serviceWorker.register('/service-worker.js', { scope: '/' })
             .catch((err) => console.error("Service Worker Failed to Register", err))
     </script>
+    <script>
+        document.addEventListener('alpine:init', (e) => {
+            Alpine.data('dynamicRelativeTime', global.dynamicRelativeTime);
+        });
+    </script>
 {{end}}

--- a/web/template/header.gohtml
+++ b/web/template/header.gohtml
@@ -1,62 +1,44 @@
 {{define "header"}} {{- /*gotype: github.com/joschahenningsen/TUM-Live/tools.TUMLiveContext*/ -}}
 <div x-data="{dark: false}" class="inline">
     <nav class="flex z-40 lg:z-50 sticky top-0 w-full items-center justify-between dark:bg-secondary bg-white
-                    shadow border-b dark:border-0 p-3 h-20 z-40">
-        <a title="Start" href="/" class="flex items-center flex-no-shrink text-white mr-6">
-            <svg class="mr-2" width="100" height="54" viewBox="0 0 100 54" xmlns="http://www.w3.org/2000/svg">
+                    shadow-sm border-b dark:border-0 p-4 md:px-8 h-16 z-40">
+        <a title="Start" href="/" class="h-full flex items-center flex-no-shrink text-white mr-6">
+            <svg class="w-[calc((5*73px)/7)]" viewBox="0 0 73 38" xmlns="http://www.w3.org/2000/svg">
                 <path fill="#3070B3"
-                      d="M49.986,7v31h8V7h37v38h-7V14h-8v31h-7V14h-8v31h-22V14h-7v31h-7V14h-7V7H49.986z"></path>
+                      d="M28 0v31h8V0h37v38h-7V7h-8v31h-7V7h-8v31H21V7h-7v31H7V7H0V0h28z"/>
             </svg>
         </a>
         <div class="md:flex grow items-center w-auto">
-            <div class="hidden md:flex text-sm grow">
+            <div class="hidden md:flex [align-items:center] gap-3 text-sm font-semibold grow text-5">
                 <a href="/"
-                   class="block inline-block align-middle mt-0 mr-4 text-5 hover:text-1 font-medium">
+                   class="block inline-block align-middle">
                     Start
                 </a>
                 {{if not .User}}
                     <a href="/login"
-                       class="block inline-block align-middle mt-0 mr-4 text-5 hover:text-1 font-medium">
+                       class="block inline-block align-middle hover:text-1">
                         Login
                     </a>
                 {{else}}
-                    <div class="inline-block align-middle mt-0 mr-4" x-data="{ show: false }"
-                         @click.outside="show=false">
-                        <a role="button" class="text-5 hover:text-1 font-medium" @click="show=!show">
-                            {{.User.GetPreferredName}}
-                            <i class="ml-1 fa-angle-down fas"></i>
-                        </a>
-                        <div class="relative">
-                            <div x-cloak x-show="show"
-                                 @click.outside="show=false"
-                                 class="origin-top-right absolute left-0 mt-4 shadow-sm rounded-lg h-fit bg-white border w-36 dark:bg-secondary dark:border-gray-800 overflow-hidden">
-                                <a href="/logout"
-                                   class="w-full border-b dark:border-gray-800 relative transition-colors duration-200 text-5 hover:text-1">
-                                    <div class="flex items-center p-2">
-                                        <i class="fa-solid fa-sign-out mr-2"></i>
-                                        <p>Logout</p>
-                                    </div>
-                                </a>
-                                <a href="/settings"
-                                   class="w-full relative transition-colors duration-200 text-5 hover:text-1">
-                                    <div class="flex items-center p-2">
-                                        <i class="fa-solid fa-gear mr-2"></i>
-                                        <p>Settings</p>
-                                    </div>
-                                </a>
-                            </div>
-                        </div>
+                    <div class="hover:text-1">
+                        {{template "dropdown-actions" dict
+                            "text" .User.GetPreferredName
+                            "icon" "angle-down"
+                            "width" 36
+                            "actions" (list
+                                (dict "label" "Log out" "icon" "sign-out" "url" "/logout")
+                                (dict "label" "Settings" "icon" "gear" "url" "/settings"))}}
                     </div>
 
                     {{if or (eq .User.Role 1) (eq .User.Role 2) }}
                         <a href="/admin"
-                           class="inline-block align-middle mt-0 mr-4 text-5 hover:text-1 font-medium">
+                           class="inline-block align-middle hover:text-1">
                             Admin
                         </a>
                     {{end}}
                 {{end}}
             </div>
-            <div class="mr-6 md:flex">
+            <div class="md:flex">
                 <div class="hidden md:flex">
                     {{template "theme-selector"}}
                     {{template "notifications"}}

--- a/web/template/header.gohtml
+++ b/web/template/header.gohtml
@@ -56,7 +56,7 @@
                     {{end}}
                 {{end}}
             </div>
-            <div class="md:flex">
+            <div class="mr-6 md:flex">
                 <div class="hidden md:flex">
                     {{template "theme-selector"}}
                     {{template "notifications"}}

--- a/web/template/index.gohtml
+++ b/web/template/index.gohtml
@@ -61,6 +61,7 @@
             {{if $show_suggested}} [suggested-start] 'suggested suggested' auto [suggested-end] {{end}}
             {{if $show_preferred_courses}} [preferred-courses-start] 'preferred-courses preferred-courses' auto [preferred-courses-end] {{end}}
             {{if $show_other_courses}} [other-courses-start] 'other-courses other-courses' auto [other-courses-end] {{end}}
+            [hidden-courses-start] 'hidden-courses hidden-courses' auto [hidden-courses-end]
         }
     </style>
 
@@ -179,6 +180,14 @@
                 {{template "highlight-box-tail"}}
             </div>
         {{end}}
+        <div style="grid-area: hidden-courses">
+            {{template "highlight-box-head" dict "title" "Hidden Courses"}} {{/*"highlight-color" "dark:bg-purple-400 bg-purple-600" */}}
+            {{range $course := .HiddenCourses}}
+                {{template "course-group-head" $course}}
+                {{template "course-group-tail"}}
+            {{end}}
+            {{template "highlight-box-tail"}}
+        </div>
     </div>
 </div>
 {{template "semesterselection" .}}
@@ -192,7 +201,7 @@
             { headers: { "x-api-key" : {{env "CAT_API_KEY"}} }});
         const data = await response.json();
         for (let i = 0; i < catImages.length; i++) {
-            catImages[i].src = data[i].url;
+            catImages[i].src = data[i % data.length].url;
         }
     })();
 </script>

--- a/web/template/index.gohtml
+++ b/web/template/index.gohtml
@@ -68,11 +68,12 @@
         {{if $show_suggested}}
             <div style="grid-area: suggested">
                 {{template "highlight-box-head" dict "highlight-color" "dark:bg-green-400 bg-green-500" "title" "Suggested"}}
-                    {{template "card-grid-head"}}
+                    {{$card_grid_state := (dict)}}
+                    {{template "card-grid-head" dict "max-rows" 2 "max-items" 4 "state" $card_grid_state}}
                         {{$args := .}}
-                        {{range $i := list 1}}
+                        {{range $i := list 1 2 3}}
                         {{range $stream := $args.SuggestedStreams}}
-                            {{template "card-grid-item-head"}}
+                            {{template "card-grid-item-head" $card_grid_state}}
                                 {{template "stream-card" dict
                                     "stream" $stream.Stream
                                     "course" $stream.Course
@@ -104,13 +105,14 @@
                                             {{template "course-group-head" $course}}
                                                 {{/*TODO: dropdown button unnecessarily reduces width of container*/}}
                                                 {{template "card-container-head" "Latest"}}
-                                                    {{template "card-grid-head"}}
-                                                        {{range $_ := list 1}}
+                                                    {{$card_grid_state := (dict)}}
+                                                    {{template "card-grid-head" dict "max-rows" 1 "max-items" 3 "state" $card_grid_state}}
+                                                        {{range $_ := list 1 2 3}}
                                                         {{/*TODO: show only past streams*/}}
                                                         {{/*TODO: show the three most recent streams including a live stream if live now*/}}
                                                         {{range $i, $stream := $course.Streams}}
-                                                            {{if ge $i 3 | or (ge $i 1 | and (randInt 0 101 | ge 30))}}{{break}}{{end}}
-                                                            {{template "card-grid-item-head"}}
+{{/*                                                            {{if ge $i 3 | or (ge $i 1 | and (randInt 0 101 | ge 30))}}{{break}}{{end}}*/}}
+                                                            {{template "card-grid-item-head" $card_grid_state}}
                                                                 {{template "stream-card" dict
                                                                     "stream" $stream
                                                                     "course" $course
@@ -140,12 +142,13 @@
                                             {{if and (not $course.IsHidden) (not $course.Pinned)}}
                                                 {{template "course-group-head" $course}}
                                                     {{template "card-container-head" "Latest"}}
-                                                        {{template "card-grid-head"}}
-                                                            {{range $_ := list 1}}
+                                                        {{$card_grid_state := (dict)}}
+                                                        {{template "card-grid-head" dict "max-rows" 1 "max-items" 3 "state" $card_grid_state}}
+                                                            {{range $_ := list 1 2 3}}
                                                                 {{/*TODO: show only past streams*/}}
                                                                 {{range $i, $stream := $course.Streams}}
-                                                                    {{if ge $i 3 | or (ge $i 1 | and (randNumeric 1 | atoi | ge 5))}}{{break}}{{end}}
-                                                                    {{template "card-grid-item-head"}}
+{{/*                                                                    {{if ge $i 3 | or (ge $i 1 | and (randNumeric 1 | atoi | ge 5))}}{{break}}{{end}}*/}}
+                                                                    {{template "card-grid-item-head" $card_grid_state}}
                                                                     {{template "stream-card" dict
                                                                     "stream" $stream
                                                                     "course" $course

--- a/web/template/index.gohtml
+++ b/web/template/index.gohtml
@@ -180,6 +180,20 @@
 </div>
 {{template "semesterselection" .}}
 {{template "reloadpagebutton" .}}
+
+<script>
+    (async () => {
+        const catImages = document.getElementsByClassName("cat-img");
+        const response = await fetch(
+            "https://api.thecatapi.com/v1/images/search?limit=" + catImages.length,
+            { headers: { "x-api-key" : {{env "CAT_API_KEY"}} }});
+        const data = await response.json();
+        for (let i = 0; i < catImages.length; i++) {
+            catImages[i].src = data[i].url;
+        }
+    })();
+</script>
+
 </body>
 <!--       _
        .__(.)< (MEOW)

--- a/web/template/index.gohtml
+++ b/web/template/index.gohtml
@@ -15,16 +15,16 @@
 <div x-init="global.liveUpdateListener.init()" class="m-auto px-1 sm:px-3 lg:px-5 w-full xl:w-2/3 flex flex-col pb-16">
 
     <div class="my-8 pl-2 md:pl-0">
-        <h1 class="font-bold text-3xl text-3 my-auto">Streams and Courses</h1>
-        {{if not .TUMLiveContext.User}}
-            <p class="text-2"><a href="/login" class="underline">Log in</a> to see your courses</p>
-        {{else if .TUMLiveContext.User.Name}}
-            <p class="text-2">
+        <h1 class="font-bold text-3xl text-1 my-auto">Streams and Courses</h1>
+        <p class="text-lg text-3">
+            {{if not .TUMLiveContext.User}}
+                <a href="/login" class="underline">Log in</a> to see your courses
+            {{else if .TUMLiveContext.User.Name}}
                 {{.TUMLiveContext.User.GetPreferredGreeting}}
                 <span class="underline"><a href="/settings">{{.TUMLiveContext.User.GetPreferredName}}</a></span>,
                 nice to see you!
-            </p>
-        {{end}}
+            {{end}}
+        </p>
     </div>
 
     {{if .ServerNotifications}}
@@ -91,7 +91,7 @@
                 {{template "highlight-box-head" dict "title" "My Courses"}} {{/*"highlight-color" "dark:bg-red-500 bg-red-600" */}}
                     <div class="flex flex-col gap-6">
                         {{if get $has_courses_where "pinned"}}
-                            <div class="py-2">
+                            <div>
                                 {{if get $has_courses_where "my-courses"}}
                                     <p class="mx-2 mb-2 text-5 text-sm uppercase">Pinned</p>
                                 {{end}}
@@ -102,20 +102,21 @@
                                     {{range $i, $course := $args.PinnedCourses}}
                                         {{if not $course.IsHidden}}
                                             {{template "course-group-head" $course}}
-                                                {{template "card-container-head"}}
+                                                {{/*TODO: dropdown button unnecessarily reduces width of container*/}}
+                                                {{template "card-container-head" "Latest"}}
                                                     {{template "card-grid-head"}}
                                                         {{range $_ := list 1}}
-                                                            {{/*TODO: show only past streams*/}}
-                                                            {{range $i, $stream := $course.Streams}}
-                                                                {{/*TODO: show the three most recent streams including a live stream if live now*/}}
-                                                                {{if ge $i 3 | or (ge $i 1 | and (randNumeric 2 | atoi | ge 30))}}{{break}}{{end}}
-                                                                {{template "card-grid-item-head"}}
-                                                                    {{template "stream-card" dict
-                                                                        "stream" $stream
-                                                                        "course" $course
-                                                                        "standalone" false}}
-                                                                {{template "card-grid-item-tail"}}
-                                                            {{end}}
+                                                        {{/*TODO: show only past streams*/}}
+                                                        {{/*TODO: show the three most recent streams including a live stream if live now*/}}
+                                                        {{range $i, $stream := $course.Streams}}
+                                                            {{if ge $i 3 | or (ge $i 1 | and (randInt 0 101 | ge 30))}}{{break}}{{end}}
+                                                            {{template "card-grid-item-head"}}
+                                                                {{template "stream-card" dict
+                                                                    "stream" $stream
+                                                                    "course" $course
+                                                                    "standalone" false}}
+                                                            {{template "card-grid-item-tail"}}
+                                                        {{end}}
                                                         {{end}}
                                                     {{template "card-grid-tail"}}
                                                 {{template "card-container-tail"}}
@@ -128,7 +129,7 @@
                         {{end}}
                         {{/*TODO: duplication*/}}
                         {{if get $has_courses_where "my-courses"}}
-                            <div class="py-2">
+                            <div>
                                 {{if get $has_courses_where "pinned"}}
                                     <p class="mx-2 mb-2 text-5 text-sm uppercase">Registered</p>
                                 {{end}}
@@ -138,7 +139,7 @@
                                         {{range $i, $course := $args.Courses}}
                                             {{if and (not $course.IsHidden) (not $course.Pinned)}}
                                                 {{template "course-group-head" $course}}
-                                                    {{template "card-container-head"}}
+                                                    {{template "card-container-head" "Latest"}}
                                                         {{template "card-grid-head"}}
                                                             {{range $_ := list 1}}
                                                                 {{/*TODO: show only past streams*/}}

--- a/web/template/index.gohtml
+++ b/web/template/index.gohtml
@@ -12,64 +12,169 @@
 
 {{- /*gotype: github.com/joschahenningsen/TUM-Live/web.IndexData*/ -}}
 {{$user := .TUMLiveContext.User}}
-<div x-init="global.liveUpdateListener.init()" class="container flex flex-col pb-16">
+<div x-init="global.liveUpdateListener.init()" class="m-auto px-1 sm:px-3 lg:px-5 w-full xl:w-2/3 flex flex-col pb-16">
+
+    <div class="my-8 pl-2 md:pl-0">
+        <h1 class="font-bold text-3xl text-3 my-auto">Streams and Courses</h1>
+        {{if not .TUMLiveContext.User}}
+            <p class="text-2"><a href="/login" class="underline">Log in</a> to see your courses</p>
+        {{else if .TUMLiveContext.User.Name}}
+            <p class="text-2">
+                {{.TUMLiveContext.User.GetPreferredGreeting}}
+                <span class="underline"><a href="/settings">{{.TUMLiveContext.User.GetPreferredName}}</a></span>,
+                nice to see you!
+            </p>
+        {{end}}
+    </div>
+
     {{if .ServerNotifications}}
         {{range $notification := .ServerNotifications}}
             <p class="{{if $notification.Warn}} text-red-400{{else}} text-yellow-400{{end}}"><i
                         class="fas fa-exclamation-triangle mr-2"></i><span>{{$notification.Text}}</span></p>
         {{end}}
     {{end}}
-    {{if not .TUMLiveContext.User}}
-        <p class="text-2"><a href="/login" class="underline">Log in</a> to see your courses</p>
-    {{else if .TUMLiveContext.User.Name}}
-        <p class="text-2">{{.TUMLiveContext.User.GetPreferredGreeting}} {{.TUMLiveContext.User.GetPreferredName}}, nice to see you!</p>
-    {{end}}
-    {{if .PinnedCourses}}
-        <h2 class="text-2xl text-1 mt-2">Pinned Courses</h2>
-        {{range $course := .PinnedCourses}}
-            {{if not $course.IsHidden}}
-                {{template "course-card" (dict "course" $course "user" $user)}}
-            {{end}}
-        {{end}}
-    {{end}}
-    {{if .LiveStreams}}
-        <h2 class="text-2xl text-1">Active Livestreams</h2>
-    {{end}}
-    {{range $liveStream := .LiveStreams}}
-        <div class="pt-1 px-4 mb-2 course{{$liveStream.Course.Model.ID}}">
-            <a href="/w/{{$liveStream.Course.Slug}}/{{$liveStream.Stream.Model.ID}}">
-                <h3 class="text-lg text-2 inline">{{$liveStream.Course.Name}}{{if $liveStream.Stream.Name}}: {{$liveStream.Stream.Name}}{{end}}</h3>
-            </a>
-            <p class="font-sans font-light text-sm">
-                {{if $liveStream.Course.IsHidden}} {{- /* only admins have hidden courses here */ -}}
-                <span class="bg-blue-800 text-blue-100 px-2 mr-1 capitalize rounded-full font-semibold">Hidden</span>
-                {{end}}
-                <span class="bg-red-800 text-red-100 px-2 mr-1 capitalize rounded-full font-semibold">Live</span>
-                <span class="font-light text-3">{{printf "until %2d:%02d" $liveStream.Stream.End.Hour $liveStream.Stream.End.Minute}}</span>
-                {{if and $liveStream.LectureHall}}<a href="/admin/lectureHalls#{{$liveStream.LectureHall.Model.ID}}" class="font-semibold text-3"> - <i class="fas fa-location-pin"></i> {{$liveStream.LectureHall.Name}}</a>{{end}}
-            </p>
-        </div>
-    {{end}}
-    {{if .Courses}}
-        <h2 class="text-2xl text-1">My Courses</h2>
-    {{end}}
-    {{range $course := .Courses }}
+
+    {{/*TODO: move out of template*/}}
+    {{$has_courses_where := dict "preferred" false "pinned" false "my-courses" false}}
+    {{range $course := .PinnedCourses}}
         {{if not $course.IsHidden}}
-            {{template "course-card" (dict "course" $course "user" $user) }}
+            {{$_1 := set $has_courses_where "preferred" true}}
+            {{$_2 := set $has_courses_where "pinned" true}}
+            {{break}}
         {{end}}
     {{end}}
-    {{if .PublicCourses}}
-        <h2 class="text-2xl text-1 mt-2">Public Courses</h2>
-        {{range $course := .PublicCourses }}
-            {{template "course-card" (dict "course" $course "user" $user)}}
+    {{range $course := .Courses}}
+        {{if and (not $course.IsHidden) (not $course.Pinned)}}
+            {{$_1 := set $has_courses_where "preferred" true}}
+            {{$_2 := set $has_courses_where "my-courses" true}}
+            {{break}}
         {{end}}
     {{end}}
-    <div>
-        <p class="text-4 hover:text-1 cursor-pointer" id="hiddenCoursesText"></p>
-        <div class="hidden text-4">
-            <ul id="hiddenCoursesRestoreList">
-            </ul>
-        </div>
+    {{$show_suggested := .SuggestedStreams}}
+    {{$show_preferred_courses := get $has_courses_where "preferred"}}
+    {{$show_other_courses := .PublicCourses }} {{/* use as boolean */}}
+
+    <style>
+        /*TODO get rid of "this"...*/
+        .home-page-grid {
+            grid:
+            {{if $show_suggested}} [suggested-start] 'suggested suggested' auto [suggested-end] {{end}}
+            {{if $show_preferred_courses}} [preferred-courses-start] 'preferred-courses preferred-courses' auto [preferred-courses-end] {{end}}
+            {{if $show_other_courses}} [other-courses-start] 'other-courses other-courses' auto [other-courses-end] {{end}}
+        }
+    </style>
+
+    <div class="grid gap-3 lg:gap-5 home-page-grid">
+        {{if $show_suggested}}
+            <div style="grid-area: suggested">
+                {{template "highlight-box-head" dict "highlight-color" "dark:bg-green-400 bg-green-500" "title" "Suggested"}}
+                    {{template "card-grid-head"}}
+                        {{$args := .}}
+                        {{range $i := list 1}}
+                        {{range $stream := $args.SuggestedStreams}}
+                            {{template "card-grid-item-head"}}
+                                {{template "stream-card" dict
+                                    "stream" $stream.Stream
+                                    "course" $stream.Course
+                                    "lecture-hall" $stream.LectureHall
+                                    "standalone" true}}
+                            {{template "card-grid-item-tail"}}
+                        {{end}}
+                        {{end}}
+                    {{template "card-grid-tail"}}
+                {{template "highlight-box-tail"}}
+            </div>
+        {{end}}
+        {{/*TODO: make less nested/simplify*/}}
+        {{if $show_preferred_courses}}
+            <div class="[grid-area:preferred-courses]">
+                {{template "highlight-box-head" dict "title" "My Courses"}} {{/*"highlight-color" "dark:bg-red-500 bg-red-600" */}}
+                    <div class="flex flex-col gap-6">
+                        {{if get $has_courses_where "pinned"}}
+                            <div class="py-2">
+                                {{if get $has_courses_where "my-courses"}}
+                                    <p class="mx-2 mb-2 text-5 text-sm uppercase">Pinned</p>
+                                {{end}}
+                                <div class="flex flex-col gap-3 md:gap-5">
+                                    {{$args := .}}
+                                    {{/*add more elements to the list to generate more items for testing*/}}
+                                    {{range $_ := list 1}}
+                                    {{range $i, $course := $args.PinnedCourses}}
+                                        {{if not $course.IsHidden}}
+                                            {{template "course-group-head" $course}}
+                                                {{template "card-container-head"}}
+                                                    {{template "card-grid-head"}}
+                                                        {{range $_ := list 1}}
+                                                            {{/*TODO: show only past streams*/}}
+                                                            {{range $i, $stream := $course.Streams}}
+                                                                {{/*TODO: show the three most recent streams including a live stream if live now*/}}
+                                                                {{if ge $i 3 | or (ge $i 1 | and (randNumeric 2 | atoi | ge 30))}}{{break}}{{end}}
+                                                                {{template "card-grid-item-head"}}
+                                                                    {{template "stream-card" dict
+                                                                        "stream" $stream
+                                                                        "course" $course
+                                                                        "standalone" false}}
+                                                                {{template "card-grid-item-tail"}}
+                                                            {{end}}
+                                                        {{end}}
+                                                    {{template "card-grid-tail"}}
+                                                {{template "card-container-tail"}}
+                                            {{template "course-group-tail" $course}}
+                                        {{end}}
+                                    {{end}}
+                                    {{end}}
+                                </div>
+                            </div>
+                        {{end}}
+                        {{/*TODO: duplication*/}}
+                        {{if get $has_courses_where "my-courses"}}
+                            <div class="py-2">
+                                {{if get $has_courses_where "pinned"}}
+                                    <p class="mx-2 mb-2 text-5 text-sm uppercase">Registered</p>
+                                {{end}}
+                                <div class="flex flex-col gap-3 md:gap-5">
+                                    {{$args := .}}
+                                    {{range $_ := list 1}}
+                                        {{range $i, $course := $args.Courses}}
+                                            {{if and (not $course.IsHidden) (not $course.Pinned)}}
+                                                {{template "course-group-head" $course}}
+                                                    {{template "card-container-head"}}
+                                                        {{template "card-grid-head"}}
+                                                            {{range $_ := list 1}}
+                                                                {{/*TODO: show only past streams*/}}
+                                                                {{range $i, $stream := $course.Streams}}
+                                                                    {{if ge $i 3 | or (ge $i 1 | and (randNumeric 1 | atoi | ge 5))}}{{break}}{{end}}
+                                                                    {{template "card-grid-item-head"}}
+                                                                    {{template "stream-card" dict
+                                                                    "stream" $stream
+                                                                    "course" $course
+                                                                    "standalone" false}}
+                                                                    {{template "card-grid-item-tail"}}
+                                                                {{end}}
+                                                            {{end}}
+                                                        {{template "card-grid-tail"}}
+                                                    {{template "card-container-tail"}}
+                                                {{template "course-group-tail" $course}}
+                                            {{end}}
+                                        {{end}}
+                                    {{end}}
+                                </div>
+                            </div>
+                        {{end}}
+                    </div>
+                {{template "highlight-box-tail"}}
+            </div>
+        {{end}}
+        {{if $show_other_courses}}
+            <div style="grid-area: other-courses">
+                {{template "highlight-box-head" dict "title" "Other Courses"}} {{/*"highlight-color" "dark:bg-purple-400 bg-purple-600" */}}
+                    {{range $course := .PublicCourses}}
+                        {{template "course-group-head" $course}}
+                        {{template "course-group-tail"}}
+                    {{end}}
+                {{template "highlight-box-tail"}}
+            </div>
+        {{end}}
     </div>
 </div>
 {{template "semesterselection" .}}

--- a/web/template/index_.gohtml
+++ b/web/template/index_.gohtml
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="UTF-8">
+    <title>TUM Live</title>
+    {{template "headImports" .VersionTag}}
+    <meta name="description"
+          content="TUM-Live, the livestreaming and VoD service of the Rechnerbetriebsgruppe at the department of informatics and mathematics at the Technical University of Munich"/>
+</head>
+<body>
+{{template "header" .TUMLiveContext}}
+
+{{- /*gotype: github.com/joschahenningsen/TUM-Live/web.IndexData*/ -}}
+{{$user := .TUMLiveContext.User}}
+<div x-init="global.liveUpdateListener.init()" class="container flex flex-col pb-16">
+    {{if .ServerNotifications}}
+        {{range $notification := .ServerNotifications}}
+            <p class="{{if $notification.Warn}} text-red-400{{else}} text-yellow-400{{end}}"><i
+                        class="fas fa-exclamation-triangle mr-2"></i><span>{{$notification.Text}}</span></p>
+        {{end}}
+    {{end}}
+    {{if not .TUMLiveContext.User}}
+        <p class="text-2"><a href="/login" class="underline">Log in</a> to see your courses</p>
+    {{else if .TUMLiveContext.User.Name}}
+        <p class="text-2">{{.TUMLiveContext.User.GetPreferredGreeting}} {{.TUMLiveContext.User.GetPreferredName}}, nice to see you!</p>
+    {{end}}
+    {{if .PinnedCourses}}
+        <h2 class="text-2xl text-1 mt-2">Pinned Courses</h2>
+        {{range $course := .PinnedCourses}}
+            {{if not $course.IsHidden}}
+                {{template "course-card" (dict "course" $course "user" $user)}}
+            {{end}}
+        {{end}}
+    {{end}}
+    {{if .LiveStreams}}
+        <h2 class="text-2xl text-1">Active Livestreams</h2>
+    {{end}}
+    {{range $liveStream := .LiveStreams}}
+        <div class="pt-1 px-4 mb-2 course{{$liveStream.Course.Model.ID}}">
+            <a href="/w/{{$liveStream.Course.Slug}}/{{$liveStream.Stream.Model.ID}}">
+                <h3 class="text-lg text-2 inline">{{$liveStream.Course.Name}}{{if $liveStream.Stream.Name}}: {{$liveStream.Stream.Name}}{{end}}</h3>
+            </a>
+            <p class="font-sans font-light text-sm">
+                {{if $liveStream.Course.IsHidden}} {{- /* only admins have hidden courses here */ -}}
+                <span class="bg-blue-800 text-blue-100 px-2 mr-1 capitalize rounded-full font-semibold">Hidden</span>
+                {{end}}
+                <span class="bg-red-800 text-red-100 px-2 mr-1 capitalize rounded-full font-semibold">Live</span>
+                <span class="font-light text-3">{{printf "until %2d:%02d" $liveStream.Stream.End.Hour $liveStream.Stream.End.Minute}}</span>
+                {{if and $liveStream.LectureHall}}<a href="/admin/lectureHalls#{{$liveStream.LectureHall.Model.ID}}" class="font-semibold text-3"> - <i class="fas fa-location-pin"></i> {{$liveStream.LectureHall.Name}}</a>{{end}}
+            </p>
+        </div>
+    {{end}}
+    {{if .Courses}}
+        <h2 class="text-2xl text-1">My Courses</h2>
+    {{end}}
+    {{range $course := .Courses }}
+        {{if not $course.IsHidden}}
+            {{template "course-card" (dict "course" $course "user" $user) }}
+        {{end}}
+    {{end}}
+    {{if .PublicCourses}}
+        <h2 class="text-2xl text-1 mt-2">Public Courses</h2>
+        {{range $course := .PublicCourses }}
+            {{template "course-card" (dict "course" $course "user" $user)}}
+        {{end}}
+    {{end}}
+    <div>
+        <p class="text-4 hover:text-1 cursor-pointer" id="hiddenCoursesText"></p>
+        <div class="hidden text-4">
+            <ul id="hiddenCoursesRestoreList">
+            </ul>
+        </div>
+    </div>
+</div>
+{{template "semesterselection" .}}
+{{template "reloadpagebutton" .}}
+</body>
+<!--
+           _
+       .__(.)< (MEOW)
+        \___)
+ ~~~~~~~~~~~~~~~~~~-->
+</html>

--- a/web/template/partial/components/dropdown.gohtml
+++ b/web/template/partial/components/dropdown.gohtml
@@ -1,0 +1,21 @@
+{{define "dropdown-head"}}
+<div x-cloak x-data="{ open: false, focused: false }" class="relative text-right md:mt-px"
+        @focusin.outside="focused = false; open = false;" @click.outside="open = false; focused = false;">
+    <div class="w-8 h-8">
+        <button :class="(open || focused || ({{get . "show-button-if" | default "true"}})) ? '' : 'opacity-0'"
+                @focus="focused = true;" @click="open = !open;"
+                class="{{/*border border-solid border-black*/}} duration-100 w-full h-full rounded-full flex justify-center [align-items:center]">
+            <i class="text-5 hover:text-1 transition-colors duration-200 fa fa-{{get . "icon" | default "ellipsis-vertical"}} text-xl md:text-normal"></i>
+        </button>
+    </div>
+
+    <div class="relative text-1" x-show="open">
+{{/*        <div class="border border-solid right-0 left-auto border-black absolute z-50 overflow-visible" >*/}}
+{{end}}
+
+{{define "dropdown-tail"}}
+{{/*        </div>*/}}
+    </div>
+</div>
+{{end}}
+

--- a/web/template/partial/components/dropdown.gohtml
+++ b/web/template/partial/components/dropdown.gohtml
@@ -1,21 +1,49 @@
 {{define "dropdown-head"}}
-<div x-cloak x-data="{ open: false, focused: false }" class="relative text-right md:mt-px"
-        @focusin.outside="focused = false; open = false;" @click.outside="open = false; focused = false;">
-    <div class="w-8 h-8">
-        <button :class="(open || focused || ({{get . "show-button-if" | default "true"}})) ? '' : 'opacity-0'"
-                @focus="focused = true;" @click="open = !open;"
-                class="{{/*border border-solid border-black*/}} duration-100 w-full h-full rounded-full flex justify-center [align-items:center]">
-            <i class="text-5 hover:text-1 transition-colors duration-200 fa fa-{{get . "icon" | default "ellipsis-vertical"}} text-xl md:text-normal"></i>
-        </button>
-    </div>
+<div x-cloak x-data="{ open: false, focused: false }"
+        @focusin.outside="focused = false; open = false;" @click.outside="open = false; focused = false;"
+        class="">
+    {{/* hide the button only on devices where there is hover support, when the dropdown is closed and a custom property evaluates to false*/}}
+    <button {{with get . "show-button-if"}}:class="(open || focused || ({{.}})) ? '' : 'hover-hover:opacity-0'"{{end}}
+            @focus="focused = true;" @click="open = !open;"
+            class="{{/*border border-black border-solid*/}} duration-100 rounded-full">
+        <div class="flex gap-2 [align-items:center] text-5 hover:text-1 transition-colors duration-200">
+            {{with get . "text"}}
+                <span class="inline-block">{{.}}</span>
+            {{end}}
+            <span class="{{/*border border-black border-solid*/}} {{if not (get . "text")}}w-[2em] h-[2em]{{end}} flex justify-center [align-items:center]">
+                <i class="{{/*border border-black border-solid*/}} fa fa-{{get . "icon" | default "ellipsis-vertical"}} "></i>
+            </span>
+        </div>
+    </button>
 
-    <div class="relative text-1" x-show="open">
-{{/*        <div class="border border-solid right-0 left-auto border-black absolute z-50 overflow-visible" >*/}}
+    <div class="relative" x-show="open">
 {{end}}
 
 {{define "dropdown-tail"}}
-{{/*        </div>*/}}
     </div>
 </div>
 {{end}}
 
+{{define "dropdown-actions"}} {{/*actions, icon? (fa icon), show-button-if? (alpine expression)*/}}
+{{template "dropdown-head" omit . "actions"}}
+<ul class="absolute right-0 top-full z-50 h-fit w-48
+                rounded-lg shadow bg-white dark:bg-secondary border dark:border-gray-800
+                flex flex-col py-2"
+            style="width: {{divf (get . "width" | default 48 | float64) 4}}rem">
+    {{range $action := get . "actions"}}
+        <li>
+            {{with get . "url"}}<a href="{{.}}">{{end}}
+                <button class="py-[0.125rem] px-2 w-full text-sm font-light text-4 hover:text-1 hover: duration-100 flex flex-row gap-1 [align-items:center]"
+                        {{with get . "action"}}@click="{{.}}"{{end}}>
+                    {{/* replace div inside button (which is forbidden) with span.block */}}
+                    <span class="block mt-[0.05em] w-6 h-6 flex justify-center [align-items:center]">
+                            {{with get . "icon"}}<i class="fas fa-{{.}}"></i>{{end}}
+                        </span>
+                    <span class="pr-1">{{get . "label"}}</span>
+                </button>
+            {{if get . "url"}}</a>{{end}}
+        </li>
+    {{end}}
+</ul>
+{{template "dropdown-tail"}}
+{{end}}

--- a/web/template/partial/components/highlight-box.gohtml
+++ b/web/template/partial/components/highlight-box.gohtml
@@ -8,6 +8,7 @@
              :class="{{$expand_if}} && 'border-b dark:border-gray-800'">
             <span class="{{with get . "highlight-color"}}{{.}} rounded-full px-5 text-white{{else}}text-1 px-4{{end}} text-lg font-bold my-auto">{{get . "title"}}</span>
             <div class="my-auto">
+                {{/*TODO: actions*/}}
 {{/*                <button class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded px-2 my-auto"*/}}
 {{/*                        @click="showPlanned = !showPlanned;">*/}}
 {{/*                        <span class="text-sm font-semibold uppercase dark:text-white"*/}}
@@ -23,7 +24,7 @@
 {{/*                </a>*/}}
             </div>
         </div>
-        <div x-show="{{$expand_if}}" class="p-5 pt-3">
+        <div x-show="{{$expand_if}}" class="px-5 py-4">
 {{end}}
 
 {{define "highlight-box-tail"}}

--- a/web/template/partial/components/highlight-box.gohtml
+++ b/web/template/partial/components/highlight-box.gohtml
@@ -1,0 +1,33 @@
+{{define "highlight-box-head"}}
+<div class="w-full">
+    {{$expand_if := get . "expand-if" | default "true"}} {{/*TODO: wrap in brackets*/}}
+    <div class="flex flex-col bg-white dark:bg-secondary border dark:border-gray-800 rounded-lg shadow-sm"
+         :class="{{$expand_if}} ? 'h-full' : 'h-fit'">
+        {{/* Header */}}
+        <div class="flex justify-between h-16 px-3"
+             :class="{{$expand_if}} && 'border-b dark:border-gray-800'">
+            <span class="{{with get . "highlight-color"}}{{.}} rounded-full px-5 text-white{{else}}text-1 px-4{{end}} text-lg font-bold my-auto">{{get . "title"}}</span>
+            <div class="my-auto">
+{{/*                <button class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded px-2 my-auto"*/}}
+{{/*                        @click="showPlanned = !showPlanned;">*/}}
+{{/*                        <span class="text-sm font-semibold uppercase dark:text-white"*/}}
+{{/*                              x-text="showPlanned ? '&#x25B2; hide' : '&#x25BC; show'">&#x25B2; hide</span>*/}}
+{{/*                </button>*/}}
+{{/*                <a class="hover:bg-gray-200 dark:hover:bg-gray-600 inline-block rounded px-2"*/}}
+{{/*                   href="/api/download_ics/{{$course.Year}}/{{$course.TeachingTerm}}/{{$course.Slug}}/events.ics"*/}}
+{{/*                   :title="'Export lecture dates'"*/}}
+{{/*                   x-show="lectures">*/}}
+{{/*                            <span class="text-sm font-semibold uppercase dark:text-white">*/}}
+{{/*                                <i class="fa-solid w-5 mr-1 fa-calendar"></i>ics*/}}
+{{/*                            </span>*/}}
+{{/*                </a>*/}}
+            </div>
+        </div>
+        <div x-show="{{$expand_if}}" class="p-5 pt-3">
+{{end}}
+
+{{define "highlight-box-tail"}}
+        </div>
+    </div>
+</div>
+{{end}}

--- a/web/template/planned_course_list.gohtml
+++ b/web/template/planned_course_list.gohtml
@@ -16,11 +16,11 @@
                         <div>
                             {{if $lecture.IsComingUp}}
                                 <a href="/w/{{$course.Slug}}/{{$lecture.Model.ID}}"
-                                   class="text-l text-3 font-semibold p-0">
+                                   class="text-lg text-3 font-semibold p-0">
                                     {{if $lecture.Name}}{{$lecture.Name}}{{else}}Lecture: {{$lecture.Start.Month}} {{printf "%02d." $lecture.Start.Day}} {{$lecture.Start.Year}}{{end}}
                                 </a>
                             {{else}}
-                                <span class="text-l text-3 font-semibold p-0">
+                                <span class="text-lg text-3 font-semibold p-0">
                                     {{if $lecture.Name}}{{$lecture.Name}}{{else}}Lecture: {{$lecture.Start.Month}} {{printf "%02d." $lecture.Start.Day}} {{$lecture.Start.Year}}{{end}}
                                 </span>
                             {{end}}

--- a/web/template/vod_course_list.gohtml
+++ b/web/template/vod_course_list.gohtml
@@ -18,7 +18,7 @@
                     <div>
                         <div>
                             <a href="/w/{{$course.Slug}}/{{$lecture.Model.ID}}"
-                               class="text-l text-3 font-semibold p-0">
+                               class="text-lg text-3 font-semibold p-0">
                                 {{if $lecture.Name}}{{$lecture.Name}}{{else}}Lecture: {{$lecture.Start.Month}} {{printf "%02d." $lecture.Start.Day}} {{$lecture.Start.Year}}{{end}}
                             </a>
                             {{if $user}}
@@ -31,7 +31,7 @@
                                         monthHidden = watchedTracker.userWatchedMonth(`{{$lecture.Start.Month.String}}`); {{/* Updates state in the client and in the database */}}
                                         watchedAll = watchedTracker.userWatchedAll();">
                                     <i :title="watched ? 'Mark as unwatched' : 'Mark as watched'"
-                                       class="fa-solid text-l text-3 font-semibold"
+                                       class="fa-solid text-lg text-3 font-semibold"
                                        :class="watched ? 'fa-clock-rotate-left' : 'fa-check'"></i>
                                 </button>
                             {{end}}

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -87,7 +87,7 @@
                     role="menu" aria-orientation="vertical" tabindex="-1">
                 <div class="flex justify-between align-middle pb-4">
                     <h3>Video Stats</h3>
-                    <button class="px-2 text-l" @click="watch.videoStatListener.clear(); videoStatsShown = false;">
+                    <button class="px-2 text-lg" @click="watch.videoStatListener.clear(); videoStatsShown = false;">
                         <i class="fas fa-close"></i>
                     </button>
                 </div>

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -4,6 +4,9 @@ export * from "./notifications";
 export * from "./user-settings";
 export * from "./start-page";
 
+import { DateTime } from "luxon";
+export { DateTime };
+
 export async function putData(url = "", data = {}) {
     return await fetch(url, {
         method: "PUT",

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -62,44 +62,17 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     );
 }
 
-export function hideCourse(id: number, name: string) {
-    const hidden: Array<Array<string>> = localStorage.getItem("hiddenCourses")
-        ? JSON.parse(localStorage.getItem("hiddenCourses"))
-        : new Array<Array<string>>();
-    if (!(hidden.indexOf([id.toString(), name]) !== -1)) {
-        hidden.push([id.toString(), name]);
-        localStorage.setItem("hiddenCourses", JSON.stringify(hidden));
-    }
+export enum CourseFlag {
+    Pinned = 1,
+    Hidden
+}
+
+// set/unsets the pinned/hidden flag for a signed-in user
+export async function updateCourseFlag(courseID: number, flag: CourseFlag, value: boolean) {
+    const r = await postData("/api/users/updateCourseFlag", { courseID, flag, value });
+    if (!r.ok)
+        showMessage(await r.text());
     document.location.reload();
-}
-
-export function unhideCourse(id: string) {
-    const hidden: Array<Array<string>> = localStorage.getItem("hiddenCourses")
-        ? JSON.parse(localStorage.getItem("hiddenCourses"))
-        : new Array<Array<string>>();
-    const newHidden: Array<Array<string>> = hidden.filter((e) => {
-        return e[0] !== id;
-    });
-    localStorage.setItem("hiddenCourses", JSON.stringify(newHidden));
-    document.location.reload();
-}
-
-export function pinCourse(id: number) {
-    postData(`/api/users/pinCourse`, { courseID: id }).then((response: Response) => {
-        if (response.status !== StatusCodes.OK) {
-            showMessage("There was an error pinning the course: " + response.body);
-        }
-        document.location.reload();
-    });
-}
-
-export function unpinCourse(id: number) {
-    postData(`/api/users/unpinCourse`, { courseID: id }).then((response: Response) => {
-        if (response.status !== StatusCodes.OK) {
-            showMessage("There was an error unpinning the course: " + response.body);
-        }
-        document.location.reload();
-    });
 }
 
 /**
@@ -120,45 +93,6 @@ export function mirror(parent: Element, levelSelectors: string[], levelIndex = 0
         a.replaceWith(placeholder);
         b.replaceWith(a);
         placeholder.replaceWith(b);
-    }
-}
-
-export function initHiddenCourses() {
-    const el = document.getElementById("hiddenCoursesText");
-    if (!el) {
-        return;
-    }
-    el.onclick = function () {
-        const clickableParent: HTMLElement = document.getElementById("hiddenCoursesRestoreList")?.parentElement;
-        if (clickableParent === undefined || clickableParent === null) {
-            return; // not on index page
-        }
-        if (clickableParent.classList.contains("hidden")) {
-            clickableParent.classList.remove("hidden");
-        } else {
-            clickableParent.classList.add("hidden");
-        }
-    };
-    const hidden: Array<Array<string>> = localStorage.getItem("hiddenCourses")
-        ? JSON.parse(localStorage.getItem("hiddenCourses"))
-        : new Array<Array<string>>();
-    const hiddenCoursesRestoreList = document.getElementById("hiddenCoursesRestoreList") as HTMLUListElement;
-    const hiddenCoursesText = document.getElementById("hiddenCoursesText") as HTMLParagraphElement;
-    hidden?.forEach((h) => {
-        const liElem = document.createElement("li");
-        liElem.classList.add("hover:text-1", "cursor-pointer");
-        liElem.innerText = "restore " + h[1];
-        liElem.onclick = function () {
-            unhideCourse(h[0]);
-        };
-        hiddenCoursesRestoreList.appendChild(liElem);
-        const elems = document.getElementsByClassName("course" + h[0]);
-        for (let i = 0; i < elems.length; i++) {
-            elems[i].classList.add("hidden");
-        }
-    });
-    if (hidden.length !== 0) {
-        hiddenCoursesText.innerText = hidden.length + " hidden courses";
     }
 }
 
@@ -292,8 +226,4 @@ export type Section = {
     streamID: number;
     friendlyTimestamp?: string;
     fileID?: number;
-};
-
-window.onload = function () {
-    initHiddenCourses();
 };


### PR DESCRIPTION
I've put together a prototype for a start page redesign (#597).

### Screenshots

#### Desktop

![desktop](https://user-images.githubusercontent.com/17551908/182035460-71d00e03-9e68-43d6-9817-78e49e8b4567.png)
<details><summary><h4>Tablet and Mobile</h4></summary>
<p float="left" width="100%">
<img width="72.67588%" src="https://user-images.githubusercontent.com/17551908/182035406-633ac18c-1757-41b5-aab1-41c4127b9f9a.png" />
<img width="26.32411%" src="https://user-images.githubusercontent.com/17551908/182035376-c69fca93-ae92-43e4-b98d-26e691f46a09.png" />
</p>
</details>

### Ideas/Background/Plan

Things that are not yet fully implemented marked with [*].

Design is based on the course overview page.

The idea for the sections (names could be changed, for now it's just what I came up with). Based on the idea of moving the things I want to see when I visit the home page close to the top and accessible in a single click.

- Suggested: Currently live streams, then completed VoDs, sorted by most recent completed first. If the user is logged in, only show streams/VoDs from pinned or registered courses (the ones that currently show up under "My Courses") that are not watched (currently considered "watched" if marked as watched or >50% watch percentage); otherwise from all courses. When a user opens TUM-Live, they are likely to want to join a lecture that is currently streaming or watch a recently completed VoD that they missed (at least that's my thinking). [\*] Probably limit to about two rows of suggestions depending on screen size.
- My Courses: Combine pinned courses and registered courses. These are the courses a user is interested in seeing. Pinned courses are shown first. For each course  ([\*] if there are any streams to show), show the current live stream for the course (if there is one), then the most recent completed VoDs. [\*] Limit to one row/a handful of items per course.
- Other Courses: The user is generally not interested in these courses, so just show the same information that is shown on the current home page.
- [*] A section at the bottom would contain the hidden courses, and be collapsed by default. As suggested in the issue, the handling for this should be unified with that for pinned courses (i.e. also saved server-side).

Courses can be [\*] (un-)hidden/pinned from a dropdown menu:

![image](https://user-images.githubusercontent.com/17551908/182036807-11f01923-ea70-4d27-a7af-15940da3ae7c.png)

This has been made keyboard-navigation-friendly too.

I added friendly dates (e.g. "Streamed 1 hour ago" or "Scheduled tomorrow") with [Luxon](https://github.com/moment/luxon). Personally I think this adds some polish, and the exact date/time is shown by hovering (i.e. on the `title`). The current home page kind of does this for upcoming streams. [*] This should be made dynamic, which should be doable since it's contained in a component, but I haven't thought about how to do that best.

I've also moved a whole bunch of components into reusable templates. Not sure if it could be done better with the template engine, maybe someone has better ideas.

### TODO/Next Steps

- Just search for "TODO" on the diff :)
- Didn't add any database queries yet, the things I needed are currently just hacked together.
- Logged-out view could use work.
- Tests