### PR TITLE
Don't preload stream stats

### DIFF
--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="PROJECT" dialect="MariaDB" />
+  </component>
+</project>

--- a/api/chat.go
+++ b/api/chat.go
@@ -545,6 +545,9 @@ func CollectStats(daoWrapper dao.DaoWrapper) func() {
 	return func() {
 		BroadcastStats(daoWrapper.StreamsDao)
 		for sID, sessions := range sessionsMap {
+			if len(sessions) == 0 {
+				continue
+			}
 			stat := model.Stat{
 				Time:     time.Now(),
 				StreamID: sID,

--- a/dao/courses.go
+++ b/dao/courses.go
@@ -75,7 +75,7 @@ func (d coursesDao) AddAdminToCourse(userID uint, courseID uint) error {
 	return DB.Exec("insert into course_admins (user_id, course_id) values (?, ?)", userID, courseID).Error
 }
 
-//GetCurrentOrNextLectureForCourse Gets the next lecture for a course or the lecture that is currently live. Error otherwise.
+// GetCurrentOrNextLectureForCourse Gets the next lecture for a course or the lecture that is currently live. Error otherwise.
 func (d coursesDao) GetCurrentOrNextLectureForCourse(ctx context.Context, courseID uint) (model.Stream, error) {
 	var res model.Stream
 	err := DB.Model(&model.Stream{}).Preload("Chats").Order("start").First(&res, "course_id = ? AND (end > NOW() OR live_now)", courseID).Error
@@ -200,9 +200,11 @@ func (d coursesDao) GetCourseByToken(token string) (course model.Course, err err
 
 func (d coursesDao) GetCourseById(ctx context.Context, id uint) (course model.Course, err error) {
 	var foundCourse model.Course
-	dbErr := DB.Preload("Streams.TranscodingProgresses").Preload("Streams.Stats").Preload("Streams.Files").Preload("Streams", func(db *gorm.DB) *gorm.DB {
-		return db.Order("streams.start desc")
-	}).Find(&foundCourse, "id = ?", id).Error
+	dbErr := DB.Preload("Streams.TranscodingProgresses").
+		Preload("Streams.Files").
+		Preload("Streams", func(db *gorm.DB) *gorm.DB {
+			return db.Order("streams.start desc")
+		}).Find(&foundCourse, "id = ?", id).Error
 	return foundCourse, dbErr
 }
 

--- a/dao/streams.go
+++ b/dao/streams.go
@@ -79,7 +79,7 @@ func (d streamsDao) SaveTranscodingProgress(progress model.TranscodingProgress) 
 	return DB.Clauses(clause.OnConflict{UpdateAll: true}).Create(&progress).Error
 }
 
-//AddVodView Adds a stat entry to the database or increases the one existing for this hour
+// AddVodView Adds a stat entry to the database or increases the one existing for this hour
 func (d streamsDao) AddVodView(id string) error {
 	intId, err := strconv.Atoi(id)
 	if err != nil {
@@ -176,7 +176,7 @@ func (d streamsDao) GetStreamByID(ctx context.Context, id string) (stream model.
 	return res, nil
 }
 
-//AddVodView Adds a stat entry to the database or increases the one existing for this hour
+// AddVodView Adds a stat entry to the database or increases the one existing for this hour
 func AddVodView(id string) error {
 	intId, err := strconv.Atoi(id)
 	if err != nil {
@@ -206,16 +206,6 @@ func AddVodView(id string) error {
 	return err
 }
 
-func UpdateStream(stream model.Stream) error {
-	defer Cache.Clear()
-	err := DB.Model(&stream).Updates(map[string]interface{}{
-		"name":        stream.Name,
-		"description": stream.Description,
-		"start":       stream.Start,
-		"end":         stream.End}).Error
-	return err
-}
-
 func (d streamsDao) UpdateLectureSeries(stream model.Stream) error {
 	defer Cache.Clear()
 	err := DB.Table("streams").Where(
@@ -241,7 +231,7 @@ func (d streamsDao) GetWorkersForStream(stream model.Stream) ([]model.Worker, er
 	return res, err
 }
 
-//GetAllStreams returns all streams of the tumlive
+// GetAllStreams returns all streams of the tumlive
 func (d streamsDao) GetAllStreams() ([]model.Stream, error) {
 	var res []model.Stream
 	err := DB.Find(&res).Error


### PR DESCRIPTION
I deployed #609 out of curiosity and found, that the stat preloading makes up for a significant amount of our request times:

![image](https://user-images.githubusercontent.com/44805696/183055789-377b9a6f-2363-47ed-a158-954173739647.png)
![image](https://user-images.githubusercontent.com/44805696/183055863-8e58b219-065a-4e60-b076-703450894cf2.png)

Since the stats have their own rest endpoints, there is no need to preload them when fetching the course.