### PR TITLE
Include Timestamp in URL

### DIFF
--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -303,8 +303,8 @@
     {{else}}
     watch.initPlayer(true, false, false, {{.IndexData.TUMLiveContext.User.GetPlaybackSpeeds.GetEnabled}}, {{$stream.LiveNow}});
     {{end}}
-    {{if and $stream.Recording .IndexData.TUMLiveContext.User}}
-    watch.watchProgress({{$stream.Model.ID}}, {{ .Progress.Progress }});
+    {{if and $stream.Recording}}
+    watch.watchProgress({{$stream.Model.ID}}, {{ .Progress.Progress }}, {{.IndexData.TUMLiveContext.User}});
     {{end}}
     {{if $stream.Silences}}
     watch.skipSilence({{$stream.GetSilencesJson}});

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -300,11 +300,9 @@
 <script>
     {{if $stream.Recording}}
     watch.initPlayer(true, false, false, {{.IndexData.TUMLiveContext.User.GetPlaybackSpeeds.GetEnabled}}, {{$stream.LiveNow}}, {{$stream.GetThumbIdForSource .Version}}, {{$stream.ThumbInterval}}, {{$stream.Model.ID}});
+    watch.watchProgress({{$stream.Model.ID}}, {{ .Progress.Progress }}, {{not (empty .IndexData.TUMLiveContext.User)}});
     {{else}}
     watch.initPlayer(true, false, false, {{.IndexData.TUMLiveContext.User.GetPlaybackSpeeds.GetEnabled}}, {{$stream.LiveNow}});
-    {{end}}
-    {{if and $stream.Recording}}
-    watch.watchProgress({{$stream.Model.ID}}, {{ .Progress.Progress }}, {{.IndexData.TUMLiveContext.User}});
     {{end}}
     {{if $stream.Silences}}
     watch.skipSilence({{$stream.GetSilencesJson}});

--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -201,9 +201,9 @@ export const skipSilence = function (options) {
  * Saves and retrieves the watch progress of the user as a fraction of the total watch time
  * @param streamID The ID of the currently watched stream
  * @param lastProgress The last progress fetched from the database
- * @param user: .TUMLiveContext.User
+ * @param loggedIn: User logged in?
  */
-export const watchProgress = function (streamID: number, lastProgress: number, user: object) {
+export const watchProgress = function (streamID: number, lastProgress: number, loggedIn: boolean) {
     const player = videojs("my-video");
     player.ready(() => {
         let duration;
@@ -234,7 +234,7 @@ export const watchProgress = function (streamID: number, lastProgress: number, u
         };
 
         // check if user is logged-in, if so proceed
-        if (user !== null && user !== undefined) {
+        if (loggedIn !== null && loggedIn !== undefined && loggedIn) {
             if (isNaN(queryT)) {
                 // Fetch the user's video progress from the database and set the time in the player
                 player.on("loadedmetadata", () => {

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -252,15 +252,7 @@ export type Section = {
 };
 
 export function getQueryParam(name: string): string {
-    const query = window.location.search.substring(1); // remove '?'
-    const params = query.split("&");
-    for (let i = 0; i < params.length; i++) {
-        const pair = params[i].split("=");
-        if (pair[0] == name) {
-            return pair[1];
-        }
-    }
-    return undefined;
+    return new URL(window.location.href).searchParams.get(name) ?? undefined;
 }
 
 window.onload = function () {

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -251,6 +251,18 @@ export type Section = {
     fileID?: number;
 };
 
+export function getQueryParam(name: string): string {
+    const query = window.location.search.substring(1); // remove '?'
+    const params = query.split("&");
+    for (let i = 0; i < params.length; i++) {
+        const pair = params[i].split("=");
+        if (pair[0] == name) {
+            return pair[1];
+        }
+    }
+    return undefined;
+}
+
 window.onload = function () {
     initHiddenCourses();
 };


### PR DESCRIPTION
## Changes
- Closes #632
- Add `getQueryParam` function to `global.ts`
- Set the timestamp of the player for the given parameter in the `watchProgress` handler.
- Move logged-in check from .gohtml file to typescript

## Further Information
The current implementation ignores the user's video progress if query parameter `t` is set. (`if ... else`). 