### PR TITLE
Detailed stats in Safari

### DIFF
--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -258,7 +258,7 @@ export const videoStatListener = {
     },
     update() {
         const player = getPlayer();
-        const vhs = player.tech().vhs;
+        const vhs = player.tech({ IWillNotUseThisInPlugins: true }).vhs;
         const notAvailable = vhs == null;
 
         const data = {


### PR DESCRIPTION
## Changes 
- Closes #531 
- Remove the player-js warning by initializing tech with `player.tech({ IWillNotUseThisInPlugins: true })`

## Further Information 
Unfortunately this bug can't be fixed since Safari doesn't support `.vhs`. 
See https://github.com/videojs/http-streaming/issues/1102 and https://github.com/videojs/video.js/issues/7139 for more information.