### PR TITLE
Update tzdata version in Worker Dockerfile

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.16
 
 RUN apk add --no-cache \
   ffmpeg=5.0.1-r1 \
-  tzdata=2022a-r0
+  tzdata=2022c-r0
 
 # copy shared libraries for tesseract
 COPY --from=builder /usr/lib/liblept*.so.* /usr/lib/


### PR DESCRIPTION
Deployment to the test server seems to broken due to a dependency issue, see https://github.com/joschahenningsen/TUM-Live/runs/7893465376?check_suite_focus=true.
Updating the tzdata version seems to do the trick.