### PR TITLE
Multiple frontend tweaks and fixes

### DIFF
--- a/web/template/admin/admin.gohtml
+++ b/web/template/admin/admin.gohtml
@@ -122,7 +122,7 @@
 <div class="flex">
     <div style="min-height: calc(100vh - 5rem);"
          class="fixed z-40 inset-0 flex-none w-full lg:static lg:h-auto lg:overflow-y-visible lg:pt-0 lg:w-60 xl:w-72 lg:block hidden bg-gray-100 dark:bg-secondary-lighter dark:border-r dark:border-secondary">
-        <div class="overflow-y-auto scrolling-touch lg:h-auto lg:block lg:relative lg:sticky overflow-hidden lg:top-18 mr-24 lg:mr-0">
+        <div class="overflow-y-auto scrolling-touch lg:h-auto lg:block lg:sticky overflow-hidden lg:top-18 mr-24 lg:mr-0">
             <nav class="px-1 overflow-y-auto font-medium text-base sm:px-3 xl:px-5 lg:text-sm pb-10 lg:pb-14 sticky?lg:h-(screen-18)">
                 <ul>
                     {{if eq $curUser.Role 1}}
@@ -187,7 +187,7 @@
                     {{end}}
                     <li class="mt-8"><span
                                 class="mb-3 lg:mb-3 uppercase tracking-wide font-semibold text-sm lg:text-xs text-2 flex">
-                            <span class="grow">Courses</span><a href="/admin/create-course"><i
+                            <span class="grow">Courses</span><a title="Create Course" href="/admin/create-course"><i
                                         class="fas fa-plus"></i></a></span>
                         <ul>
                             <li>

--- a/web/template/admin/admin_tabs/course-import.gohtml
+++ b/web/template/admin/admin_tabs/course-import.gohtml
@@ -9,68 +9,74 @@
             <i class="fas fa-circle-notch animate-spin animate"></i> Loading...
         </div>
         <div x-show="step===0">
-            <form>
-                <h3 class="font-bold">Semester</h3>
-                <div class="flex ">
-                    <div class="relative inline-block w-full text-gray-700 my-2 mx-4">
-                        <select x-model="year"
-                                class="w-full h-10 pl-3 pr-6 text-base placeholder-gray-600 border rounded-sm appearance-none focus:shadow-outline">
-                            <option>2020</option>
-                            <option>2021</option>
-                            <option>2022</option>
-                            <option>2023</option>
-                            <option>2024</option>
-                            <option>2025</option>
-                            <option>2026</option>
-                        </select>
-                        <div class="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
-                            <svg class="w-4 h-4 fill-current" viewBox="0 0 20 20">
-                                <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                                      clip-rule="evenodd" fill-rule="evenodd"></path>
-                            </svg>
-                        </div>
+            <form class="grid grid-cols-2 gap-4">
+                <h3 class="font-bold col-span-2">Semester</h3>
+                <label class="relative text-gray-700">
+                    <span class="font-bold text-4">Year</span>
+                    <select x-model="year"
+                            class="cursor-pointer text-6 dark:bg-gray-900 w-full h-10 pl-3 pr-6 text-base rounded-sm appearance-none focus:shadow-outline">
+                        <option>2020</option>
+                        <option>2021</option>
+                        <option>2022</option>
+                        <option>2023</option>
+                        <option>2024</option>
+                        <option>2025</option>
+                        <option>2026</option>
+                    </select>
+                    <div class="absolute right-2 bottom-3">
+                        <svg class="w-4 h-4 fill-current" viewBox="0 0 20 20">
+                            <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                                  clip-rule="evenodd" fill-rule="evenodd"></path>
+                        </svg>
                     </div>
-                    <div class="relative inline-block w-full text-gray-700 my-2  mx-4">
-                        <select x-model="semester"
-                                class="w-full h-10 pl-3 pr-6 text-base placeholder-gray-600 border rounded-sm appearance-none focus:shadow-outline">
-                            <option>W</option>
-                            <option>S</option>
-                        </select>
-                        <div class="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
-                            <svg class="w-4 h-4 fill-current" viewBox="0 0 20 20">
-                                <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                                      clip-rule="evenodd" fill-rule="evenodd"></path>
-                            </svg>
-                        </div>
+                </label>
+                <label class="relative text-gray-700">
+                    <span class="font-bold text-4">Summer / Winter</span>
+                    <select x-model="semester"
+                            class="cursor-pointer text-6 dark:bg-gray-900 w-full h-10 pl-3 pr-6 text-base placeholder-gray-600 rounded-sm appearance-none focus:shadow-outline">
+                        <option>W</option>
+                        <option>S</option>
+                    </select>
+                    <div class="absolute right-2 bottom-3">
+                        <svg class="w-4 h-4 fill-current" viewBox="0 0 20 20">
+                            <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                                  clip-rule="evenodd" fill-rule="evenodd"></path>
+                        </svg>
                     </div>
-                </div>
-                <div class="flex mt-6">
-                    <label class="w-1/2 text-gray-700 py-2 mx-4">
-                        <span class="font-bold">Department:</span>
-                        <select x-model="department"
-                                class="w-full h-10 pl-3 pr-6 text-base placeholder-gray-600 border rounded-sm appearance-none focus:shadow-outline">
-                            <option>In</option>
-                            <option>Ma</option>
-                            <option>Ph</option>
-                        </select>
-                    </label>
-                </div>
-                <div class="flex mt-6">
-                    <label class="w-1/2 text-gray-700 py-2 mx-4">
-                        <span class="font-bold"></span>
-                        <select x-model="optInOut"
-                                class="w-full h-10 pl-3 pr-6 text-base placeholder-gray-600 border rounded-sm appearance-none focus:shadow-outline">
-                            <option>Opt In</option>
-                            <option>Opt Out</option>
-                        </select>
-                    </label>
-                </div>
-                <div class="flex mt-6">
-                    <label class="w-1/2" x-init="flatpickr($refs.range, {'mode': 'range'})">
-                        <span class="font-bold">Import events in this range</span>
-                        <input class="text-1" type="text" x-ref="range" x-model="range" placeholder="click me!">
-                    </label>
-                </div>
+                </label>
+                <label class="relative text-gray-700">
+                    <span class="font-bold text-4">Department</span>
+                    <select x-model="department"
+                            class="cursor-pointer text-6 dark:bg-gray-900 w-full h-10 pl-3 pr-6 text-base placeholder-gray-600 rounded-sm appearance-none focus:shadow-outline">
+                        <option>In</option>
+                        <option>Ma</option>
+                        <option>Ph</option>
+                    </select>
+                    <div class="absolute right-2 bottom-3">
+                        <svg class="w-4 h-4 fill-current" viewBox="0 0 20 20">
+                            <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                                  clip-rule="evenodd" fill-rule="evenodd"></path>
+                        </svg>
+                    </div>
+                </label>
+                <label class="relative text-gray-700">
+                    <span class="font-bold text-4">Opt In / Opt Out</span>
+                    <select x-model="optInOut"
+                            class="cursor-pointer text-6 dark:bg-gray-900 w-full h-10 pl-3 pr-6 text-base placeholder-gray-600 rounded-sm appearance-none focus:shadow-outline">
+                        <option>Opt In</option>
+                        <option>Opt Out</option>
+                    </select>
+                    <div class="absolute right-2 bottom-3">
+                        <svg class="w-4 h-4 fill-current" viewBox="0 0 20 20">
+                            <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                                  clip-rule="evenodd" fill-rule="evenodd"></path>
+                        </svg>
+                    </div>
+                </label>
+                <label class="col-span-2" x-init="flatpickr($refs.range, {'mode': 'range'})">
+                    <span class="font-bold text-4">Import events in this range</span>
+                    <input class="text-1" type="text" x-ref="range" x-model="range" placeholder="click me!">
+                </label>
             </form>
         </div>
 
@@ -116,7 +122,7 @@
                                         <span x-text="new Date(event.start).toISOString().slice(0, 16).replace('T',' ') + ' - ' + new Date(event.end).toISOString().slice(11, 16)"
                                               class="text-2"></span>
                                     </label>
-                                    <div class="w-2/6 whitespace-nowrap	overflow-x-hidden overflow-ellipsis"><i
+                                    <div class="w-2/6 whitespace-nowrap overflow-x-hidden overflow-ellipsis"><i
                                                 class="fas fa-location-arrow text-3 mr-2"></i><span class="text-5"
                                                                                                     x-text="event.room_name"
                                                                                                     :title="event.room_name"></span>

--- a/web/template/admin/admin_tabs/create-course.gohtml
+++ b/web/template/admin/admin_tabs/create-course.gohtml
@@ -52,12 +52,11 @@
                     <div class="px-3">
                         {{template "course_settings"}}
                     </div>
-                </form>
-                <br>
-                <button onclick="" id="createCourseBtn" class="btn"
-                        x-bind:disabled="slug === '' || title === '' || year === ''">
-                    Create Course
-                </button>
+                    <br>
+                    <button onclick="" id="createCourseBtn" class="btn"
+                            x-bind:disabled="slug === '' || title === '' || year === ''">
+                        Create Course
+                    </button>
                 </form>
             </div>
         </div>

--- a/web/template/admin/admin_tabs/users.gohtml
+++ b/web/template/admin/admin_tabs/users.gohtml
@@ -65,7 +65,7 @@
                                     <div x-show="user.changing" x-cloak @click.outside="user.changing=false">
                                         <div x-data="{dropdownMenu: true}" class="relative">
                                             <div x-show="dropdownMenu"
-                                                 class="absolute left-0 py-2 mt-2 bg-white bg-gray-50 rounded-md shadow w-44">
+                                                 class="absolute left-0 py-2 mt-2 bg-gray-50 rounded-md shadow w-44">
                                                 <a href="#"
                                                    class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-black"
                                                    @click="admin.updateUser(user.id, 1).then((r)=>{r!==-1?user.role=r:user.role=user.role})">
@@ -99,9 +99,9 @@
                             <td class="py-3 px-6 text-center">
                                 <div class="flex item-center justify-center">
                                     <template x-if="user.role !== 1">
-                                        <div class="w-4 mr-2 transform hover:text-purple-500 hover:scale-110 cursor-pointer">
+                                        <button title="Delete User" class="w-4 mr-2 transform hover:text-purple-500 hover:scale-110 cursor-pointer">
                                             <i @click="admin.deleteUser(user.id)" class="fas fa-trash"></i>
-                                        </div>
+                                        </button>
                                     </template>
                                 </div>
                             </td>
@@ -149,8 +149,8 @@
                     </div>
                     <div class="w-full mt-2">
                         <button id="createUser"
+                                title="Create User"
                                 class="w-full py-1 rounded-b-lg bg-gray-100 dark:bg-gray-600 hover:bg-transparent dark:hover:bg-transparent cursor-pointer"
-                                type="button"
                                 @click="admin.createUser()">
                             <span class="text-sm font-semibold m-auto text-3">
                                 <i class="fas fa-plus"></i>

--- a/web/template/admin/admin_tabs/users.gohtml
+++ b/web/template/admin/admin_tabs/users.gohtml
@@ -3,7 +3,7 @@
     <div class="dark:border-secondary bg-gray-100 rounded-md overflow-x-auto mb-6 my-3 shadow-md dark:bg-secondary-lighter">
         <div class="grid gap-5 w-full p-3" x-data="{userlist: new admin.AdminUserList({{.}})}">
             <div>
-                <h2 class="font-bold pl-1 mb-2">Search</h2>
+                <h2 class="font-bold pl-1 mb-2 text-2">Search</h2>
                 <div class="bg-white dark:bg-secondary border rounded-lg dark:border-gray-800 shadow px-2 py-1">
                     <form class="flex flex-row">
                         <label class="w-full">
@@ -99,7 +99,7 @@
                             <td class="py-3 px-6 text-center">
                                 <div class="flex item-center justify-center">
                                     <template x-if="user.role !== 1">
-                                        <div class="w-4 mr-2 transform hover:text-purple-500 hover:scale-110">
+                                        <div class="w-4 mr-2 transform hover:text-purple-500 hover:scale-110 cursor-pointer">
                                             <i @click="admin.deleteUser(user.id)" class="fas fa-trash"></i>
                                         </div>
                                     </template>
@@ -131,7 +131,7 @@
                 </template>
             </div>
             <div class="">
-                <h2 class="font-bold pl-1 mb-2">New User</h2>
+                <h2 class="font-bold pl-1 mb-2 text-2">New User</h2>
                 <div class="w-full bg-white rounded-lg shadow border dark:bg-secondary dark:border-gray-600">
                     <div class="flex flex-wrap w-full py-3 px-6 ">
                         <div class="w-full md:w-1/2 p-1 text-left whitespace-nowrap">

--- a/web/template/header.gohtml
+++ b/web/template/header.gohtml
@@ -1,14 +1,14 @@
 {{define "header"}} {{- /*gotype: github.com/joschahenningsen/TUM-Live/tools.TUMLiveContext*/ -}}
 <div x-data="{dark: false}" class="inline">
-    <nav class="flex lg:z-50 sticky top-0 w-full items-center justify-between dark:bg-secondary bg-white
+    <nav class="flex lg:z-50 sticky w-full items-center dark:bg-secondary
                     shadow border-b dark:border-0 p-3 h-20 z-40">
-        <a title="Start" href="/" class="mx-6">
+        <a title="Start" href="/" class="mx-4">
             <svg width="75" height="50" viewBox="0 0 75 50">
                 <path fill="#3070B3"
                       d="M 30,7 v 30 h 8 V 7 h 37 v 38 h -7 V14 h-8 v 31 h -7 V 14 h -8 v 31 h -22 V 14 h -7 v 31 h -7 V 14 h -7 V 7 H 40 z"></path>
             </svg>
         </a>
-        <div class="md:flex grow items-center w-auto">
+        <div class="w-full mx-4 md:flex items-center justify-between">
             <div class="hidden md:flex text-sm grow">
                 <a href="/"
                    class="inline-block align-middle mt-0 mr-4 text-5 hover:text-1 font-medium">
@@ -22,7 +22,7 @@
                 {{else}}
                     <div class="inline-block align-middle mt-0 mr-4" x-data="{ show: false }"
                          @click.outside="show=false">
-                        <a role="button" class="text-5 hover:text-1 font-medium" @click="show=!show">
+                        <a title="User Actions" role="button" class="text-5 hover:text-1 font-medium" @click="show=!show">
                             {{.User.GetPreferredName}}
                             <i class="ml-1 fa-angle-down fas"></i>
                         </a>

--- a/web/template/header.gohtml
+++ b/web/template/header.gohtml
@@ -3,9 +3,9 @@
     <nav class="flex lg:z-50 sticky top-0 w-full items-center justify-between dark:bg-secondary bg-white
                     shadow border-b dark:border-0 p-3 h-20 z-40">
         <a title="Start" href="/" class="flex items-center flex-no-shrink text-white mr-6">
-            <svg class="mr-2" width="100" height="54" viewBox="0 0 100 54" xmlns="http://www.w3.org/2000/svg">
+            <svg width="75" height="50" viewBox="0 0 75 50">
                 <path fill="#3070B3"
-                      d="M49.986,7v31h8V7h37v38h-7V14h-8v31h-7V14h-8v31h-22V14h-7v31h-7V14h-7V7H49.986z"></path>
+                      d="M 30,7 v 30 h 8 V 7 h 37 v 38 h -7 V14 h-8 v 31 h -7 V 14 h -8 v 31 h -22 V 14 h -7 v 31 h -7 V 14 h -7 V 7 H 40 z"></path>
             </svg>
         </a>
         <div class="md:flex grow items-center w-auto">

--- a/web/template/header.gohtml
+++ b/web/template/header.gohtml
@@ -1,6 +1,6 @@
 {{define "header"}} {{- /*gotype: github.com/joschahenningsen/TUM-Live/tools.TUMLiveContext*/ -}}
 <div x-data="{dark: false}" class="inline">
-    <nav class="flex z-40 lg:z-50 sticky top-0 w-full items-center justify-between dark:bg-secondary bg-white
+    <nav class="flex lg:z-50 sticky top-0 w-full items-center justify-between dark:bg-secondary bg-white
                     shadow border-b dark:border-0 p-3 h-20 z-40">
         <a title="Start" href="/" class="flex items-center flex-no-shrink text-white mr-6">
             <svg class="mr-2" width="100" height="54" viewBox="0 0 100 54" xmlns="http://www.w3.org/2000/svg">
@@ -11,12 +11,12 @@
         <div class="md:flex grow items-center w-auto">
             <div class="hidden md:flex text-sm grow">
                 <a href="/"
-                   class="block inline-block align-middle mt-0 mr-4 text-5 hover:text-1 font-medium">
+                   class="inline-block align-middle mt-0 mr-4 text-5 hover:text-1 font-medium">
                     Start
                 </a>
                 {{if not .User}}
                     <a href="/login"
-                       class="block inline-block align-middle mt-0 mr-4 text-5 hover:text-1 font-medium">
+                       class="inline-block align-middle mt-0 mr-4 text-5 hover:text-1 font-medium">
                         Login
                     </a>
                 {{else}}

--- a/web/template/header.gohtml
+++ b/web/template/header.gohtml
@@ -2,7 +2,7 @@
 <div x-data="{dark: false}" class="inline">
     <nav class="flex lg:z-50 sticky top-0 w-full items-center justify-between dark:bg-secondary bg-white
                     shadow border-b dark:border-0 p-3 h-20 z-40">
-        <a title="Start" href="/" class="flex items-center flex-no-shrink text-white mr-6">
+        <a title="Start" href="/" class="mx-6">
             <svg width="75" height="50" viewBox="0 0 75 50">
                 <path fill="#3070B3"
                       d="M 30,7 v 30 h 8 V 7 h 37 v 38 h -7 V14 h-8 v 31 h -7 V 14 h -8 v 31 h -22 V 14 h -7 v 31 h -7 V 14 h -7 V 7 H 40 z"></path>

--- a/web/template/partial/info-dropdown.gohtml
+++ b/web/template/partial/info-dropdown.gohtml
@@ -58,7 +58,7 @@
 
 {{define "info-dropdown-mobile"}}
     <div x-show="showInfoDropdown" @click.outside="showInfoDropdown=false"
-         class="absolute w-56 text-left h-fit w-fit top-full right-0 bg-white dark:bg-secondary mt-2 rounded-lg shadow-lg border dark:border-gray-800">
+         class="absolute text-left h-fit w-fit top-full right-0 bg-white dark:bg-secondary mt-2 rounded-lg shadow-lg border dark:border-gray-800">
         <div class="grid gap-5 p-6">
             <a href="/" class="flex">
                 <i class="text-3 fas fa-home w-8 mr-2"></i>

--- a/web/template/semester-selection.gohtml
+++ b/web/template/semester-selection.gohtml
@@ -31,7 +31,7 @@
                 </div>
             </div>
         </div>
-        <button @click="showSemesterSelect = !showSemesterSelect"
+        <button title="Select Semester" @click="showSemesterSelect = !showSemesterSelect"
                 class="lg:w-1/5 lg:right-4 lg:bottom-10 lg:rounded-lg
                         flex w-full fixed bottom-0 bg-white border shadow-sm rounded-t-lg
                         h-12 px-4 dark:bg-secondary dark:border-gray-800">


### PR DESCRIPTION
In the `Course Import` section under `Admin`
- added the missing small arrows to select elements
- label text now changes color when in dark mode
- made the code much more readable by using CSS `grid` instead of `flexbox`
- select elements become darker when in dark mode

In the `Users` section under `Admin`
- change cursor to pointer when hovering over trash icon
- fixed same issue like in `Course Import`: label text now changes color when in dark mode

Open for suggestions about colors, though the design differs from in the different admin sections.
I could try to fix that if it is ok?

In the `nav` bar
- TUM logo svg element now fits it's width
- aligned all items so that the margins on all sides nicely fit

The moon and bell icons could stay, also for mobile screens as there is plenty of room?