### PR TITLE
Fix course creation and TUMOnline fetching

### DIFF
--- a/api/courses.go
+++ b/api/courses.go
@@ -1023,6 +1023,9 @@ func (r coursesRoutes) createCourse(c *gin.Context) {
 	go tum.GetEventsForCourses(courses, r.DaoWrapper)
 	go tum.FindStudentsForCourses(courses, r.DaoWrapper)
 	go tum.FetchCourses(r.DaoWrapper)
+
+	// send id to client for further requests
+	c.JSON(http.StatusCreated, gin.H{"id": courseWithID.ID})
 }
 
 func (r coursesRoutes) deleteCourse(c *gin.Context) {

--- a/web/template/admin/admin_tabs/create-course.gohtml
+++ b/web/template/admin/admin_tabs/create-course.gohtml
@@ -1,8 +1,8 @@
 {{- /*gotype: github.com/joschahenningsen/TUM-Live/web.CreateCourseData*/ -}}
 {{template "header" .IndexData.TUMLiveContext}}
 {{define "create-course"}}
-    <div class="text-1 container mx-auto" x-init="new admin.CreateCourse()"
-         x-data="{ tumonlineid: '', slug: '', title: '', year: '', yearW: '', semester: 'Wintersemester' }">
+    <div class="text-1 container mx-auto"
+         x-data="{ tumonlineid: '', slug: '', title: '', year: '', yearW: '', semester: 'Wintersemester', numberAttendees: null }">
         <div class="min-w-screen flex items-center justify-center">
             <div class="w-full lg:w-5/6 p-3 bg-gray-100 dark:bg-secondary rounded dark:border dark:border-gray-500 shadow">
                 <h1>Create a new course:</h1>
@@ -11,23 +11,23 @@
                         <label class="hidden" for="courseID">TUM online id:</label>
                         <input class="w-4/5" id="courseID" name="courseID" type="text" autocomplete="off"
                                placeholder="TUMOnline ID" x-model="tumonlineid"/>
-                        <!--suppress XmlUnboundNsPrefix -->
                         <button type="button"
-                                id="loadCourseInfoBtn"
+                                @click="admin.loadCourseInfo(tumonlineid).then(r => {title = r.title, semester = r.semester, year = r.year, yearW = r.yearW, numberAttendees = r.numberAttendees });"
                                 class="w-1/5 btn"
-                                x-bind:disabled="tumonlineid===''"
-                        >Load Course
+                                :disabled="tumonlineid===''">
+                            Load Course
                         </button>
                     </div>
-                    <div class="px-2">
+                    <div class="px-2" x-show="tumonlineid === '' || numberAttendees !== null">
                         <div class="bg-gray-50 border rounded-lg dark:bg-secondary-light dark:border-gray-800 px-2 py-1">
-                            <div x-show="tumonlineid === ''" id="TUMOnlineInfo"
+                            <div id="TUMOnlineInfo"
                                  class="grid gap-1 text-sm text-3 text-center">
                                 <span class="block">
                                     <i class="fa fa-exclamation-triangle text-warn mr-2"></i>
-                                    Without a TUMOnline ID you won't be able to make this course public to participants only.
+                                    <span x-show="tumonlineid === ''">Without a TUMOnline ID you won't be able to make this course public to participants only.</span>
+                                    <span x-show="numberAttendees !== null">Currently there are <span x-text="numberAttendees"></span> students enrolled in this course, please verify that this looks right.</span>
                                 </span>
-                                <a target="_blank" class="underline"
+                                <a x-show="tumonlineid === ''" target="_blank" class="underline"
                                    href="https://github.com/joschahenningsen/TUM-Live/wiki/How-do-I-find-the-right-TUMOnline-ID-for-my-course%3F">
                                     How do I find the right TUMOnline ID for my course?
                                 </a>
@@ -49,16 +49,12 @@
                                :class="slug === '' ? 'border-red-500 focus:border-red-500' : ''"/>
                     </div>
                     {{template "semester-selection"}}
-                    <div class="px-3">
-                        {{template "course_settings"}}
-                    </div>
                 </form>
                 <br>
-                <button onclick="" id="createCourseBtn" class="btn"
-                        x-bind:disabled="slug === '' || title === '' || year === ''">
+                <button class="btn" @click="admin.createCourse(tumonlineid, semester, year, yearW, title, slug);"
+                        :disabled="slug === '' || title === '' || year === ''">
                     Create Course
                 </button>
-                </form>
             </div>
         </div>
     </div>

--- a/web/template/admin/admin_tabs/edit-course.gohtml
+++ b/web/template/admin/admin_tabs/edit-course.gohtml
@@ -12,6 +12,9 @@
                     <div x-cloak x-show="(new URL(document.location)).searchParams.get('copied')!==null" class="p-4 text-sm text-green-700 bg-green-100 rounded-lg dark:bg-green-200 dark:text-green-800" role="alert">
                         Course was copied successfully.
                     </div>
+                    <div x-cloak x-show="(new URL(document.location)).searchParams.get('created')!==null" class="p-4 text-sm text-green-700 bg-green-100 rounded-lg dark:bg-green-200 dark:text-green-800" role="alert">
+                        Course was created successfully.
+                    </div>
                 </div>
                 <label class="hidden" for="courseID">CourseID<input id="courseID" type="text" class="hidden"
                                                                     value="{{$course.Model.ID}}"></label>

--- a/web/template/partial/course/manage/semester-selection.gohtml
+++ b/web/template/partial/course/manage/semester-selection.gohtml
@@ -16,6 +16,8 @@
                x-model="year"
                name="year"
                class="w-32"
+               @change="if(year<2000)return; yearW = (year%1000) + 1"
+               @keyup="if(year<2000)return; yearW = (year%1000) + 1"
                :class="year === '' ? 'border-red-500 focus:border-red-500' : ''"
                placeholder="2022"
                type="number">
@@ -28,8 +30,8 @@
                        name="yearW"
                        class="w-16"
                        :class="yearW === '' ? 'border-red-500 focus:border-red-500' : ''"
-                       placeholder="24"
-                       type="number">
+                       type="text"
+                       readonly disabled>
             </div>
         </template>
     </div>

--- a/web/ts/create-course.ts
+++ b/web/ts/create-course.ts
@@ -1,92 +1,59 @@
 import { StatusCodes } from "http-status-codes";
 import { postData, showMessage } from "./global";
 
-export class CreateCourse {
-    private courseIDInput: HTMLInputElement;
-    private loadFromTUMOnlineBtn: HTMLButtonElement;
-    private courseNameInput: HTMLInputElement;
-    private semesterInput: HTMLInputElement;
-    private yearInput: HTMLInputElement;
-    private yearWInput: HTMLInputElement; // for the '/21' part
-    private slugInput: HTMLInputElement;
-    private tumOnlineInfo: HTMLSpanElement;
-    private enrolledRadio: HTMLInputElement;
-
-    constructor() {
-        this.loadFromTUMOnlineBtn = document.getElementById("loadCourseInfoBtn") as HTMLButtonElement;
-        this.loadFromTUMOnlineBtn.addEventListener("click", () => this.loadCourseInfo());
-        this.courseIDInput = document.getElementById("courseID") as HTMLInputElement;
-        this.courseNameInput = document.getElementById("name") as HTMLInputElement;
-        this.semesterInput = document.getElementById("semester") as HTMLInputElement;
-        this.yearInput = document.getElementById("year") as HTMLInputElement;
-        this.yearWInput = document.getElementById("yearW") as HTMLInputElement;
-        this.slugInput = document.getElementById("slug") as HTMLInputElement;
-        this.tumOnlineInfo = document.getElementById("TUMOnlineInfo") as HTMLSpanElement;
-        this.enrolledRadio = document.getElementById("enrolled") as HTMLInputElement;
-        document.getElementById("createCourseBtn")?.addEventListener("click", (e: Event) => {
-            e.preventDefault();
-            this.createCourse();
-            return false;
-        });
-    }
-
-    private loadCourseInfo(): void {
-        if (this.loadFromTUMOnlineBtn.disabled) {
-            return;
-        }
-        postData("/api/courseInfo", { courseID: this.courseIDInput.value }).then((data) => {
-            if (data.status != StatusCodes.OK) {
-                showMessage(
-                    "The course with this ID was not found in TUMOnline. Please verify the ID or reach out to us.",
-                );
-            } else {
-                data.text().then((data) => {
-                    const json = JSON.parse(data);
-                    const teachingTerm = json["teachingTerm"].Split(" ");
-
-                    this.semesterInput.value = teachingTerm[0];
-                    if (teachingTerm[0] === "Wintersemester") {
-                        const yearPair = teachingTerm[1].Split("/"); // Wintersemester year format: 2022/23
-                        this.yearInput.value = yearPair[0];
-                        this.yearWInput.value = yearPair[1];
-                    } else {
-                        this.yearInput.value = teachingTerm[1];
-                    }
-
-                    this.courseNameInput.value = json["courseName"];
-                    this.tumOnlineInfo.innerText =
-                        "Currently there are " +
-                        json["numberAttendees"] +
-                        " students enrolled in this course. Please verify that this looks right.";
-                    this.enrolledRadio.removeAttribute("disabled");
-                });
-            }
-        });
-    }
-
-    private createCourse(): void {
-        const f = new FormData(document.getElementById("createCourseForm") as HTMLFormElement);
-        let teachingTerm;
-        if (f.get("semester") === "Wintersemester") {
-            teachingTerm = `${f.get("semester")} ${f.get("year")}/${f.get("yearW")}`;
+export function loadCourseInfo(
+    id: string,
+): Promise<{ title: string; semester: string; year: number; yearW: number; numberAttendees: number } | any> {
+    return fetch("/api/courseInfo", { method: "POST", body: JSON.stringify({ courseID: id }) }).then((data) => {
+        if (data.status != StatusCodes.OK) {
+            showMessage("The course with this ID was not found in TUMOnline. Please verify the ID or reach out to us.");
+            return null;
         } else {
-            teachingTerm = `${f.get("semester")} ${f.get("year")}`;
+            return data.json().then((data) => {
+                const years = data["teachingTerm"].split(" ")[1].split("/");
+                return {
+                    title: data["courseName"],
+                    semester: data["teachingTerm"].split(" ")[0],
+                    year: parseInt(years[0]),
+                    yearW: parseInt(years[1]),
+                    numberAttendees: data["numberAttendees"],
+                };
+            });
         }
-        postData("/api/createCourse", {
-            courseID: f.get("courseID"),
-            name: f.get("name"),
-            teachingTerm: teachingTerm,
-            slug: f.get("slug"),
-            access: f.get("access"),
-            enVOD: f.get("enVOD") === "on",
-            enDL: f.get("enDL") === "on",
-            enChat: f.get("enChat") === "on",
-        }).then((data) => {
-            if (data.status != StatusCodes.OK) {
-                data.text().then((t) => showMessage(t));
-            } else {
-                window.location.href = "/admin";
-            }
-        });
+    });
+}
+
+export function createCourse(
+    id: string,
+    semester: string,
+    year: number,
+    yearW: number,
+    name: string,
+    slug: string,
+): void {
+    let teachingTerm;
+    if (semester === "Wintersemester") {
+        teachingTerm = `${semester} ${year}/${yearW}`;
+    } else {
+        teachingTerm = `${semester} ${year}`;
     }
+    postData("/api/createCourse", {
+        courseID: id,
+        name: name,
+        teachingTerm: teachingTerm,
+        slug: slug,
+        // defaults:
+        access: "loggedin",
+        enVOD: true,
+        enDL: false,
+        enChat: false,
+    }).then((data) => {
+        if (data.status !== StatusCodes.CREATED) {
+            data.text().then((t) => showMessage(t));
+        } else {
+            data.json().then((resp) => {
+                window.location.href = "/admin/course/" + resp["id"] + "?created";
+            });
+        }
+    });
 }

--- a/web/ts/edit-course.ts
+++ b/web/ts/edit-course.ts
@@ -11,6 +11,9 @@ export class LectureList {
     static lectures: Lecture[] = [];
 
     static init(initialState: Lecture[]) {
+        if (initialState === null) {
+            initialState = [];
+        }
         // load initial state into lecture objects
         initialState.forEach((lecture) => {
             let l = new Lecture();


### PR DESCRIPTION
There were some front-end parsing issues when loading the course from TUMOnline by its id. While fixing it I decided to remove the settings for the course when creating it. They can be set after creating it. 

Also I made the second part of the semester fixed when creating a wintersemester course because it should not be changeable. Instead it automatically adjusts when you edit the main semester. 

Lastly, users are now redirected to the course they just created

Demo:

https://user-images.githubusercontent.com/44805696/191533033-bc201c54-621c-4650-aae2-f2eab6b181ee.mp4

