### PR TITLE
Hide 'Chat Replay' when not on vod

### DIFF
--- a/web/template/partial/stream/chat/chat.gohtml
+++ b/web/template/partial/stream/chat/chat.gohtml
@@ -47,7 +47,7 @@
                 </div>
             {{end}}
             <div x-show="show" class="ml-auto my-auto">
-                <span class="font-semibold text-xs"
+                <span x-show="{{not (or $isComingUp $liveNow)}}" class="font-semibold text-xs"
                       :class="c.chatReplayActive ? 'dark:text-gray-200 text-black' : 'dark:text-gray-500 text-gray-500'">
                       Chat Replay
                 </span>


### PR DESCRIPTION
Currently only the button is hidden, not the text next to it:

![image](https://user-images.githubusercontent.com/44805696/191684218-76cf8cda-20c7-4564-9c58-1199a24c4d65.png)
