### PR TITLE
Also fetch students for upcoming courses

### DIFF
--- a/mock_dao/courses.go
+++ b/mock_dao/courses.go
@@ -121,9 +121,9 @@ func (mr *MockCoursesDaoMockRecorder) GetAllCoursesForSemester(year, term, ctx i
 }
 
 // GetAllCoursesWithTUMIDForSemester mocks base method.
-func (m *MockCoursesDao) GetAllCoursesWithTUMIDForSemester(ctx context.Context, year int, term string) ([]model.Course, error) {
+func (m *MockCoursesDao) GetAllCoursesWithTUMIDFromSemester(ctx context.Context, year int, term string) ([]model.Course, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllCoursesWithTUMIDForSemester", ctx, year, term)
+	ret := m.ctrl.Call(m, "GetAllCoursesWithTUMIDFromSemester", ctx, year, term)
 	ret0, _ := ret[0].([]model.Course)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -132,7 +132,7 @@ func (m *MockCoursesDao) GetAllCoursesWithTUMIDForSemester(ctx context.Context, 
 // GetAllCoursesWithTUMIDForSemester indicates an expected call of GetAllCoursesWithTUMIDForSemester.
 func (mr *MockCoursesDaoMockRecorder) GetAllCoursesWithTUMIDForSemester(ctx, year, term interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllCoursesWithTUMIDForSemester", reflect.TypeOf((*MockCoursesDao)(nil).GetAllCoursesWithTUMIDForSemester), ctx, year, term)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllCoursesWithTUMIDFromSemester", reflect.TypeOf((*MockCoursesDao)(nil).GetAllCoursesWithTUMIDFromSemester), ctx, year, term)
 }
 
 // GetAvailableSemesters mocks base method.

--- a/tools/tum/campus-online-base.go
+++ b/tools/tum/campus-online-base.go
@@ -28,10 +28,11 @@ func GetCourseInformation(courseID string, token string) (CourseInfo, error) {
 	return courseInfo, nil
 }
 
+// FetchCourses updates the enrollments of all relevant courses
 func FetchCourses(daoWrapper dao.DaoWrapper) func() {
 	return func() {
 		y, t := GetCurrentSemester()
-		courses, err := daoWrapper.CoursesDao.GetAllCoursesWithTUMIDForSemester(context.Background(), y, t)
+		courses, err := daoWrapper.CoursesDao.GetAllCoursesWithTUMIDFromSemester(context.Background(), y, t)
 		if err != nil {
 			log.WithError(err).Error("Could not get courses with TUM online identifier:", err)
 			return


### PR DESCRIPTION
We currently have some revision courses that are scheduled for the upcoming semester (starting October 1st.). The enrollments for these courses are currently not automatically updated. This fixes the issue by always fetching students for courses in this **and** the upcoming semester. 