### PR TITLE
include flatpickr.min.js in edit-course.gohtml

### DIFF
--- a/web/template/admin/admin_tabs/edit-course.gohtml
+++ b/web/template/admin/admin_tabs/edit-course.gohtml
@@ -1,5 +1,6 @@
 {{define "edit-course"}}
     <link rel="stylesheet" href="/static/node_modules/flatpickr/dist/flatpickr.min.css">
+    <script src="/static/node_modules/flatpickr/dist/flatpickr.min.js"></script>
     <script src="/static/node_modules/chart.js/dist/chart.min.js"></script>
     {{- /*gotype: github.com/joschahenningsen/TUM-Live/web.AdminPageData*/ -}}
     {{$course := .IndexData.TUMLiveContext.Course}}


### PR DESCRIPTION
for some reason the css but not the javascript is included for flatpickr

btw. is there a reason for why the codebase uses spaces instead of tabs? I think it would be friendlier for contributors to not have tab sizes forced upon them.