### PR TITLE
fix live watch page when chat is disabled

### DIFF
--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -23,13 +23,14 @@ export class Watch {
     }
 
     private resizeChat() {
-        if (this.chat !== undefined && this.player !== undefined) {
-            /* :md breakpoint */
-            if (window.innerWidth > 768) {
-                this.chat.style.height = `${this.player.getBoundingClientRect().height}px`;
-            } else {
-                this.chat.style.height = "640px";
-            }
+        if (this.chat == null || this.player == null) {
+            return;
+        }
+        /* :md breakpoint */
+        if (window.innerWidth > 768) {
+            this.chat.style.height = `${this.player.getBoundingClientRect().height}px`;
+        } else {
+            this.chat.style.height = "640px";
         }
     }
 }


### PR DESCRIPTION
closes #703 

We can use `==` instead of `===` to catch both, `null` and `undefined`