### PR TITLE
Disable chat replay in popout chat

### DIFF
--- a/web/template/partial/stream/chat/chat.gohtml
+++ b/web/template/partial/stream/chat/chat.gohtml
@@ -49,7 +49,7 @@
             <div class="my-auto space-x-2 ml-auto">
                 <button class="text-5 text-xs rounded font-semibold px-2 py-1 my-auto uppercase"
                         :class="c.chatReplayActive ? 'bg-gray-300 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600' : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-700'"
-                        x-show="{{not (or $isComingUp $liveNow)}}"
+                        x-show="{{not (or $isComingUp $liveNow .IsPopUp)}}"
                         title="(De-)Activate Chat Replay"
                         @click="c.chatReplayActive = !c.chatReplayActive;"
                         x-init="

--- a/web/template/partial/stream/chat/chat.gohtml
+++ b/web/template/partial/stream/chat/chat.gohtml
@@ -12,7 +12,7 @@
         {{$userId := .IndexData.TUMLiveContext.User.ID}}
     {{end}}
     <div x-cloak
-         x-data="watch.initChat({{.IsAdminOfCourse}}, {{$stream.ID}}, '{{$startTime}}', '{{$liveNowTimestamp}}', {{$userId}}, '{{$userName}}', {{not (or $isComingUp $liveNow)}});"
+         x-data="watch.initChat({{.IsAdminOfCourse}}, {{$stream.ID}}, '{{$startTime}}', '{{$liveNowTimestamp}}', {{$userId}}, '{{$userName}}', {{not (or $isComingUp $liveNow .IsPopUp)}});"
          x-init="await Promise.all([c.loadMessages(), c.poll.load()]); $nextTick(() => { watch.scrollToBottom(); window.dispatchEvent(new CustomEvent('chatinitialized')); })"
          x-on:chatmessage.window="e => c.onMessage(e);"
          x-on:chatreply.window="e => c.onReply(e);"

--- a/web/template/popup-chat.gohtml
+++ b/web/template/popup-chat.gohtml
@@ -9,8 +9,7 @@
     {{template "headImports" .IndexData.VersionTag}}
     <script src="/static/assets/ts-dist/watch.bundle.js?v={{.IndexData.VersionTag}}"></script>
 </head>
-<body x-data="{show: true}"
-      x-init="watch.startWebsocket()"
+<body x-init="watch.startWebsocket()"
       class="bg-white dark:bg-secondary h-screen overflow-hidden">
 <input type="hidden" id="streamID" value="{{.IndexData.TUMLiveContext.Stream.Model.ID}}">
 {{template "chat" .}}


### PR DESCRIPTION
## Changes
- Resolves #702 
- Disable chat replay in popout chat 

## Why 
For the replay feature a valid `player` object is needed which doesn't exist in the popout chat. The result is a buggy chat
window (https://live.rbg.tum.de/w/WiSe22ERA/19560/chat/popup).