### PR TITLE
Don't try streaming lectures of deleted courses

### DIFF
--- a/dao/streams.go
+++ b/dao/streams.go
@@ -114,8 +114,9 @@ func (d streamsDao) AddVodView(id string) error {
 func (d streamsDao) GetDueStreamsForWorkers() []model.Stream {
 	var res []model.Stream
 	DB.Model(&model.Stream{}).
+		Joins("JOIN courses c ON c.id = streams.course_id").
 		Where("lecture_hall_id IS NOT NULL AND start BETWEEN NOW() AND DATE_ADD(NOW(), INTERVAL 10 MINUTE)" +
-			"AND live_now = false AND recording = false AND (ended = false OR ended IS NULL)").
+			"AND live_now = false AND recording = false AND (ended = false OR ended IS NULL) AND c.deleted_at IS null").
 		Scan(&res)
 	return res
 }


### PR DESCRIPTION
Since we let people opt in to streaming, some courses exist where `course.deleted_at` is set (until opting in) but the streams are not deleted. Currently we would try to stream such lectures. 

fixes #390 