### PR TITLE
fix wrong calendar events

### DIFF
--- a/dao/lecture_halls.go
+++ b/dao/lecture_halls.go
@@ -83,12 +83,12 @@ func (d lectureHallsDao) GetStreamsForLectureHallIcal(userId uint) ([]CalendarRe
 	err := DB.Model(&model.Stream{}).
 		Joins("LEFT JOIN lecture_halls ON lecture_halls.id = streams.lecture_hall_id").
 		Joins("JOIN courses ON courses.id = streams.course_id").
-		Joins("JOIN course_admins ON courses.id = course_admins.course_id").
+		Joins("LEFT JOIN course_admins ON courses.id = course_admins.course_id").
 		Select("streams.id as stream_id, streams.created_at as created, "+
 			"lecture_halls.name as lecture_hall_name, "+
 			"streams.start, streams.end, courses.name as course_name").
 		Where("(streams.start BETWEEN DATE_SUB(NOW(), INTERVAL 1 MONTH) and DATE_ADD(NOW(), INTERVAL 3 MONTH)) "+
-			"AND (courses.user_id = ? OR 0 = ? OR course_admins.user_id = ?)", userId, userId, userId).
+			"AND (courses.user_id = ? OR 0 = ? OR course_admins.user_id = ?) AND courses.deleted_at IS NULL", userId, userId, userId).
 		Group("streams.id").
 		Scan(&res).Error
 	return res, err


### PR DESCRIPTION
We have two issues with our calendar:

- events of deleted courses are still shown. This is mainly a problem with opt-in courses where the streams exist but the course is marked as deleted.
- streams of courses that don't have lecturers are not shown to admins.

This PR fixes both issues in the SQL query