### PR TITLE
Fix chat misplacement

### DIFF
--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -406,3 +406,7 @@ a.fc-event, a.fc-event:hover {
 .tum-live-markdown a{
     border-bottom: 1px solid black;
 }
+
+.overflow-wrap-anywhere {
+    overflow-wrap: anywhere;
+}

--- a/web/template/partial/stream/chat/chat_message.gohtml
+++ b/web/template/partial/stream/chat/chat_message.gohtml
@@ -27,7 +27,7 @@
                     lg:hover:bg-gray-100 lg:dark:hover:bg-gray-700
                 {{end}}">
                 <div class="flex justify-between">
-                    <span class="chatMsg w-5/6 my-auto" x-html="m.message"></span>
+                    <span class="chatMsg w-5/6 overflow-wrap-anywhere my-auto" x-html="m.message"></span>
                     <button @click="showMobileAction=!showMobileAction"
                             @click.outside="showMobileAction = false;"
                             class ="lg:hidden">


### PR DESCRIPTION
### Motivation and Context
`<a>`-tags are not wrapped properly in the chat window. Therefore the chat becomes wider and moves below the player.
Can be seen at [Einführung in die Rechnerarchitektur](https://live.rbg.tum.de/w/WiSe22ERA/22918).

### Description
Since Tailwind-CSS doesn't provide the class, add `.overflow-wrap-anywhere` to the `main.css` file and apply it to the message container.

### Steps for Testing
1. Log in
2. Navigate to a Livestream that has the chat enabled
3. Post one of the following links:
    1. https://chat.whatsapp.com/DKIH69Z0RkTLSv8neUb5GP
    2. https://zulip.in.tum.de/#narrow/stream/1216-ERA---Allgemein/topic/Abonement.20der.20ERA.20Streams/near/694571
    3. Or any other long link
4. The chat should stay at its place 

### Screenshots
<img width="485" alt="image" src="https://user-images.githubusercontent.com/29633518/196601007-724df3db-e488-4b8e-bf00-9c8d774323d9.png">