### PR TITLE
log course opt-in in audits

### DIFF
--- a/api/courses.go
+++ b/api/courses.go
@@ -230,6 +230,7 @@ func (r coursesRoutes) updateSourceSettings(c *gin.Context) {
 }
 
 func (r coursesRoutes) activateCourseByToken(c *gin.Context) {
+	tlctx := c.MustGet("TUMLiveContext").(tools.TUMLiveContext)
 	t := c.Param("token")
 	if t == "" {
 		_ = c.Error(tools.RequestError{
@@ -258,6 +259,10 @@ func (r coursesRoutes) activateCourseByToken(c *gin.Context) {
 			Err:           err,
 		})
 		return
+	}
+	err = r.AuditDao.Create(&model.Audit{User: tlctx.User, Type: model.AuditCourseCreate, Message: fmt.Sprintf("opted in by token, %s:'%s'", course.Name, course.Slug)})
+	if err != nil {
+		log.WithError(err).Error("create opt in audit failed")
 	}
 }
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When a lecturer opts in we currently don't know when this happened or who it was. This would be very helpful.

### Description
This PR adds audit creation to the opt in endpoint.

### Steps for Testing

Code review should be enough.

<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- a course that is not yet opted in
- a admin user who can view audits

1. open the opt in link for the course
2. click `enable streaming`
3. log in as admin (if not yet logged in)
4. find action in audits

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->

n/a