### PR TITLE
allow deselecting lecture halls in calendar

### DIFF
--- a/api/courses_test.go
+++ b/api/courses_test.go
@@ -1765,7 +1765,7 @@ func TestActivateToken(t *testing.T) {
 					}
 					configGinCourseRouter(r, wrapper)
 				},
-				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler),
+				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextUserNil)),
 				ExpectedCode: http.StatusBadRequest,
 			},
 			"can not un-delete course": {
@@ -1786,7 +1786,7 @@ func TestActivateToken(t *testing.T) {
 					}
 					configGinCourseRouter(r, wrapper)
 				},
-				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler),
+				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextUserNil)),
 				ExpectedCode: http.StatusInternalServerError,
 			},
 			"success": {
@@ -1812,7 +1812,7 @@ func TestActivateToken(t *testing.T) {
 					}
 					configGinCourseRouter(r, wrapper)
 				},
-				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler),
+				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextUserNil)),
 				ExpectedCode: http.StatusOK,
 			}}.
 			Method(http.MethodPost).

--- a/api/courses_test.go
+++ b/api/courses_test.go
@@ -1809,6 +1809,11 @@ func TestActivateToken(t *testing.T) {
 								Return(nil)
 							return coursesMock
 						}(),
+						AuditDao: func() dao.AuditDao {
+							auditDao := mock_dao.NewMockAuditDao(ctrl)
+							auditDao.EXPECT().Create(gomock.Any()).Return(nil)
+							return auditDao
+						}(),
 					}
 					configGinCourseRouter(r, wrapper)
 				},

--- a/api/lecture_halls.go
+++ b/api/lecture_halls.go
@@ -37,7 +37,7 @@ func configGinLectureHallApiRouter(router *gin.Engine, daoWrapper dao.DaoWrapper
 	adminsOfCourse.Use(tools.AdminOfCourse)
 	adminsOfCourse.POST("/switchPreset/:lectureHallID/:presetID/:streamID", routes.switchPreset)
 
-	router.GET("/api/hall/all.ics", routes.lectureHallIcal)
+	router.GET("/api/schedule.ics", routes.lectureHallIcal)
 }
 
 type lectureHallRoutes struct {

--- a/api/lecture_halls.go
+++ b/api/lecture_halls.go
@@ -216,14 +216,17 @@ func (r lectureHallRoutes) lectureHallIcal(c *gin.Context) {
 		return
 	}
 	lectureHallsStr := strings.Split(c.Request.Form.Get("lecturehalls"), ",")
-	lectureHalls := make([]uint, len(lectureHallsStr))
-	for i, l := range lectureHallsStr {
+	lectureHalls := make([]uint, 0, len(lectureHallsStr))
+	for _, l := range lectureHallsStr {
+		if l == "" {
+			continue
+		}
 		a, err := strconv.Atoi(l)
 		if err != nil {
 			_ = c.Error(tools.RequestError{Status: http.StatusBadRequest, CustomMessage: "Lecture Hall ID must be a number.", Err: err})
 			return
 		}
-		lectureHalls[i] = uint(a)
+		lectureHalls = append(lectureHalls, uint(a))
 	}
 	tumLiveContext := foundContext.(tools.TUMLiveContext)
 	// pass 0 to db query to get all lectures if user is not logged in or admin

--- a/dao/lecture_halls.go
+++ b/dao/lecture_halls.go
@@ -19,7 +19,7 @@ type LectureHallsDao interface {
 	GetAllLectureHalls() []model.LectureHall
 	GetLectureHallByPartialName(name string) (model.LectureHall, error)
 	GetLectureHallByID(id uint) (model.LectureHall, error)
-	GetStreamsForLectureHallIcal(userId uint) ([]CalendarResult, error)
+	GetStreamsForLectureHallIcal(userId uint, lectureHalls []uint) ([]CalendarResult, error)
 
 	UnsetDefaults(lectureHallID string) error
 
@@ -78,7 +78,7 @@ func (d lectureHallsDao) GetLectureHallByID(id uint) (model.LectureHall, error) 
 // GetStreamsForLectureHallIcal returns an instance of []calendarResult for the ical export.
 // if a user id is given, only streams of the user are returned. All streams are returned otherwise.
 // streams that happened more than on month ago and streams that are more than 3 months in the future are omitted.
-func (d lectureHallsDao) GetStreamsForLectureHallIcal(userId uint) ([]CalendarResult, error) {
+func (d lectureHallsDao) GetStreamsForLectureHallIcal(userId uint, lectureHalls []uint) ([]CalendarResult, error) {
 	var res []CalendarResult
 	err := DB.Model(&model.Stream{}).
 		Joins("LEFT JOIN lecture_halls ON lecture_halls.id = streams.lecture_hall_id").
@@ -88,7 +88,8 @@ func (d lectureHallsDao) GetStreamsForLectureHallIcal(userId uint) ([]CalendarRe
 			"lecture_halls.name as lecture_hall_name, "+
 			"streams.start, streams.end, courses.name as course_name").
 		Where("(streams.start BETWEEN DATE_SUB(NOW(), INTERVAL 1 MONTH) and DATE_ADD(NOW(), INTERVAL 3 MONTH)) "+
-			"AND (courses.user_id = ? OR 0 = ? OR course_admins.user_id = ?) AND courses.deleted_at IS NULL", userId, userId, userId).
+			"AND (courses.user_id = ? OR 0 = ? OR course_admins.user_id = ?) AND courses.deleted_at IS NULL "+
+			"AND (streams.lecture_hall_id IN ? OR (0 in ? AND streams.lecture_hall_id is null))", userId, userId, userId, lectureHalls, lectureHalls).
 		Group("streams.id").
 		Scan(&res).Error
 	return res, err

--- a/mock_dao/courses.go
+++ b/mock_dao/courses.go
@@ -120,7 +120,7 @@ func (mr *MockCoursesDaoMockRecorder) GetAllCoursesForSemester(year, term, ctx i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllCoursesForSemester", reflect.TypeOf((*MockCoursesDao)(nil).GetAllCoursesForSemester), year, term, ctx)
 }
 
-// GetAllCoursesWithTUMIDForSemester mocks base method.
+// GetAllCoursesWithTUMIDFromSemester mocks base method.
 func (m *MockCoursesDao) GetAllCoursesWithTUMIDFromSemester(ctx context.Context, year int, term string) ([]model.Course, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllCoursesWithTUMIDFromSemester", ctx, year, term)
@@ -129,8 +129,8 @@ func (m *MockCoursesDao) GetAllCoursesWithTUMIDFromSemester(ctx context.Context,
 	return ret0, ret1
 }
 
-// GetAllCoursesWithTUMIDForSemester indicates an expected call of GetAllCoursesWithTUMIDForSemester.
-func (mr *MockCoursesDaoMockRecorder) GetAllCoursesWithTUMIDForSemester(ctx, year, term interface{}) *gomock.Call {
+// GetAllCoursesWithTUMIDFromSemester indicates an expected call of GetAllCoursesWithTUMIDFromSemester.
+func (mr *MockCoursesDaoMockRecorder) GetAllCoursesWithTUMIDFromSemester(ctx, year, term interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllCoursesWithTUMIDFromSemester", reflect.TypeOf((*MockCoursesDao)(nil).GetAllCoursesWithTUMIDFromSemester), ctx, year, term)
 }

--- a/mock_dao/lecture_halls.go
+++ b/mock_dao/lecture_halls.go
@@ -121,7 +121,7 @@ func (mr *MockLectureHallsDaoMockRecorder) GetLectureHallByPartialName(name inte
 }
 
 // GetStreamsForLectureHallIcal mocks base method.
-func (m *MockLectureHallsDao) GetStreamsForLectureHallIcal(userId uint) ([]dao.CalendarResult, error) {
+func (m *MockLectureHallsDao) GetStreamsForLectureHallIcal(userId uint, lectureHalls []string) ([]dao.CalendarResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStreamsForLectureHallIcal", userId)
 	ret0, _ := ret[0].([]dao.CalendarResult)

--- a/mock_dao/lecture_halls.go
+++ b/mock_dao/lecture_halls.go
@@ -121,18 +121,18 @@ func (mr *MockLectureHallsDaoMockRecorder) GetLectureHallByPartialName(name inte
 }
 
 // GetStreamsForLectureHallIcal mocks base method.
-func (m *MockLectureHallsDao) GetStreamsForLectureHallIcal(userId uint, lectureHalls []string) ([]dao.CalendarResult, error) {
+func (m *MockLectureHallsDao) GetStreamsForLectureHallIcal(userId uint, lectureHalls []uint) ([]dao.CalendarResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStreamsForLectureHallIcal", userId)
+	ret := m.ctrl.Call(m, "GetStreamsForLectureHallIcal", userId, lectureHalls)
 	ret0, _ := ret[0].([]dao.CalendarResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetStreamsForLectureHallIcal indicates an expected call of GetStreamsForLectureHallIcal.
-func (mr *MockLectureHallsDaoMockRecorder) GetStreamsForLectureHallIcal(userId interface{}) *gomock.Call {
+func (mr *MockLectureHallsDaoMockRecorder) GetStreamsForLectureHallIcal(userId, lectureHalls interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStreamsForLectureHallIcal", reflect.TypeOf((*MockLectureHallsDao)(nil).GetStreamsForLectureHallIcal), userId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStreamsForLectureHallIcal", reflect.TypeOf((*MockLectureHallsDao)(nil).GetStreamsForLectureHallIcal), userId, lectureHalls)
 }
 
 // SaveLectureHall mocks base method.

--- a/mock_dao/users.go
+++ b/mock_dao/users.go
@@ -96,7 +96,7 @@ func (mr *MockUsersDaoMockRecorder) CreateRegisterLink(ctx, user interface{}) *g
 // CreateUser mocks base method.
 func (m *MockUsersDao) CreateUser(ctx context.Context, user *model.User) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getCreateUserHandlers", ctx, user)
+	ret := m.ctrl.Call(m, "CreateUser", ctx, user)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -104,7 +104,7 @@ func (m *MockUsersDao) CreateUser(ctx context.Context, user *model.User) error {
 // CreateUser indicates an expected call of CreateUser.
 func (mr *MockUsersDaoMockRecorder) CreateUser(ctx, user interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getCreateUserHandlers", reflect.TypeOf((*MockUsersDao)(nil).CreateUser), ctx, user)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockUsersDao)(nil).CreateUser), ctx, user)
 }
 
 // DeleteResetKey mocks base method.

--- a/web/template/admin/admin.gohtml
+++ b/web/template/admin/admin.gohtml
@@ -242,7 +242,7 @@
                 {{else if and (eq $curUser.Role 1) (eq .Page "serverStats")}}
                     {{template "stats" .IndexData}}
                 {{else if and (or (eq $curUser.Role 1) (eq $curUser.Role 2)) (eq .Page "schedule")}}
-                    {{template "schedule" .IndexData}}
+                    {{template "schedule" .LectureHalls}}
                 {{else if and (eq $curUser.Role 1) (eq .Page "serverNotifications")}}
                     {{template "server-notifications-admin-list" .ServerNotifications}}
                 {{else if and (or (eq $curUser.Role 1) (eq $curUser.Role 2)) (eq .Page "createCourse")}}

--- a/web/template/admin/admin_tabs/schedule.gohtml
+++ b/web/template/admin/admin_tabs/schedule.gohtml
@@ -5,14 +5,16 @@
         <div id="popoverContent"
              class="cursor-auto absolute transform -translate-x-1/2 -translate-y-1/2 left-1/2 top-1/2 p-4 bg-white dark:bg-secondary-lighter rounded z-10 border dark:border-gray-500 border-gray-300 hidden"></div>
     </div>
-    <div x-data="{ lectureHalls: [0, {{range .}}{{.Model.ID}}, {{end}}] }" x-init="$watch('lectureHalls', v=>admin.refetchCalendar(lectureHalls))">
-        <label>
+    <div x-data="{ lectureHalls: [0, {{range .}}{{.Model.ID}}, {{end}}] }"
+         x-init="$watch('lectureHalls', v=>admin.refetchCalendar(lectureHalls))"
+         class="text-3">
+        <label class="mr-4">
             <input type="checkbox" checked @change="e=>{if ($el.checked){lectureHalls.push(0)}else{lectureHalls=lectureHalls.filter(i=>i!==0)}}">
             Selfstreaming
         </label>
         {{range .}}
             {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.LectureHall*/ -}}
-            <label>
+            <label class="mr-4">
                 <input type="checkbox" checked @change="e=>{if ($el.checked){lectureHalls.push({{.Model.ID}})}else{lectureHalls=lectureHalls.filter(i=>i!=={{.Model.ID}})}}">
                 {{.Name}}
             </label>

--- a/web/template/admin/admin_tabs/schedule.gohtml
+++ b/web/template/admin/admin_tabs/schedule.gohtml
@@ -1,6 +1,6 @@
 {{define "schedule"}}
     <link href="static/node_modules/fullcalendar/main.min.css" rel="stylesheet"/>
-    <div x-init="admin.addScheduleListener()" class="flex flex-col lg:flex-row w-full pt-4 relative">
+    <div x-init="admin.addScheduleListener([0, {{range .}}{{.Model.ID}}, {{end}}])" class="flex flex-col lg:flex-row w-full pt-4 relative">
         <div id="calendar" class="w-full"></div>
         <div id="popoverContent"
              class="cursor-auto absolute transform -translate-x-1/2 -translate-y-1/2 left-1/2 top-1/2 p-4 bg-white dark:bg-secondary-lighter rounded z-10 border dark:border-gray-500 border-gray-300 hidden"></div>

--- a/web/template/admin/admin_tabs/schedule.gohtml
+++ b/web/template/admin/admin_tabs/schedule.gohtml
@@ -5,5 +5,17 @@
         <div id="popoverContent"
              class="cursor-auto absolute transform -translate-x-1/2 -translate-y-1/2 left-1/2 top-1/2 p-4 bg-white dark:bg-secondary-lighter rounded z-10 border dark:border-gray-500 border-gray-300 hidden"></div>
     </div>
-    {{- /*gotype: github.com/joschahenningsen/TUM-Live/web.IndexData*/ -}}
+    <div x-data="{ lectureHalls: [0, {{range .}}{{.Model.ID}}, {{end}}] }" x-init="$watch('lectureHalls', v=>admin.refetchCalendar(lectureHalls))">
+        <label>
+            <input type="checkbox" checked @change="e=>{if ($el.checked){lectureHalls.push(0)}else{lectureHalls=lectureHalls.filter(i=>i!==0)}}">
+            Selfstreaming
+        </label>
+        {{range .}}
+            {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.LectureHall*/ -}}
+            <label>
+                <input type="checkbox" checked @change="e=>{if ($el.checked){lectureHalls.push({{.Model.ID}})}else{lectureHalls=lectureHalls.filter(i=>i!=={{.Model.ID}})}}">
+                {{.Name}}
+            </label>
+         {{end}}
+    </div>
 {{end}}

--- a/web/ts/edit-course.ts
+++ b/web/ts/edit-course.ts
@@ -446,28 +446,26 @@ export function saveLectureHall(streamIds: number[], lectureHall: string) {
 }
 
 // Used by schedule.ts
-export function saveLectureDescription(e: Event, cID: number, lID: number) {
+export function saveLectureDescription(e: Event, cID: number, lID: number): Promise<boolean> {
     e.preventDefault();
     const input = (document.getElementById("lectureDescriptionInput" + lID) as HTMLInputElement).value;
-    postData("/api/course/" + cID + "/updateDescription/" + lID, { name: input }).then((res) => {
-        if (res.status == StatusCodes.OK) {
-            document.getElementById("descriptionSubmitBtn" + lID).classList.add("invisible");
-        } else {
-            res.text().then((t) => showMessage(t));
+    return putData("/api/course/" + cID + "/updateDescription/" + lID, { name: input }).then((res) => {
+        if (res.status !== StatusCodes.OK) {
+            return false;
         }
+        return true;
     });
 }
 
 // Used by schedule.ts
-export function saveLectureName(e: Event, cID: number, lID: number) {
+export function saveLectureName(e: Event, cID: number, lID: number): Promise<boolean> {
     e.preventDefault();
     const input = (document.getElementById("lectureNameInput" + lID) as HTMLInputElement).value;
-    postData("/api/course/" + cID + "/renameLecture/" + lID, { name: input }).then((res) => {
-        if (res.status == StatusCodes.OK) {
-            document.getElementById("nameSubmitBtn" + lID).classList.add("invisible");
-        } else {
-            res.text().then((t) => showMessage(t));
+    return postData("/api/course/" + cID + "/renameLecture/" + lID, { name: input }).then((res) => {
+        if (res.status !== StatusCodes.OK) {
+            return false;
         }
+        return true;
     });
 }
 

--- a/web/ts/schedule.ts
+++ b/web/ts/schedule.ts
@@ -16,7 +16,7 @@ export function addScheduleListener(lectureHalls: number[]) {
     });
 }
 
-export function refetchCalendar(lecturehalls: number[]){
+export function refetchCalendar(lecturehalls: number[]) {
     opts.events.url = "/api/schedule.ics?lecturehalls=" + lecturehalls.join(",");
     calendar.removeAllEventSources();
     calendar.addEventSource(opts.events);
@@ -74,8 +74,8 @@ const opts = {
         })"
                     class="w-full flex flex-row border-b-2 focus-within:border-gray-300 border-gray-500">
                     <label for="lectureDescriptionInput${
-            streamInfo["streamID"]
-        }" class="hidden">Lecture description</label>
+                        streamInfo["streamID"]
+                    }" class="hidden">Lecture description</label>
                     <textarea id="lectureDescriptionInput${streamInfo["streamID"]}"
                         rows="3"
                         onfocus="admin.focusDescriptionInput(this, ${streamInfo["streamID"]})"
@@ -86,8 +86,8 @@ const opts = {
                         class="fas fa-check ml-2 invisible text-4 hover:text-1"></button>
                 </form>
             <a class="text-3 hover:text-black dark:hover:text-white" href="/admin/course/${
-            streamInfo["courseID"]
-        }#lecture-li-${streamInfo["streamID"]}">Edit <i class="fas fa-external-link-alt"></i></a>
+                streamInfo["courseID"]
+            }#lecture-li-${streamInfo["streamID"]}">Edit <i class="fas fa-external-link-alt"></i></a>
             `;
         document.getElementsByClassName("fc-timegrid").item(0)?.classList.add("filter", "blur-xxs");
         popover.classList.remove("hidden");

--- a/web/ts/schedule.ts
+++ b/web/ts/schedule.ts
@@ -58,7 +58,9 @@ const opts = {
                 <div class="text-2">
                     <div class="flex"><p>${new Date(streamInfo["start"]).toLocaleString()}</p></div>
                 </div>
-                <form x-data="{showSubmit:false}" @submit="admin.saveLectureName(event, ${streamInfo["courseID"]}, ${streamInfo["streamID"]}).then((r)=>showSubmit=!r)"
+                <form x-data="{showSubmit:false}" @submit="admin.saveLectureName(event, ${streamInfo["courseID"]}, ${
+            streamInfo["streamID"]
+        }).then((r)=>showSubmit=!r)"
                     class="w-full flex flex-row mb-2 focus-within:border-gray-300 border-gray-500">
                     <label for="lectureNameInput${streamInfo["streamID"]}" class="hidden">Lecture title</label>
                     <input id="lectureNameInput${streamInfo["streamID"]}"
@@ -69,7 +71,9 @@ const opts = {
                     <button x-show="showSubmit" id="nameSubmitBtn${streamInfo["streamID"]}"
                         class="fas fa-check ml-2 text-gray-400 hover:text-purple-500"></button>
                 </form>
-                <form x-data="{showSubmit:false}" @submit="admin.saveLectureDescription(event, ${streamInfo["courseID"]}, ${streamInfo["streamID"]}).then((r)=>showSubmit=!r)"
+                <form x-data="{showSubmit:false}" @submit="admin.saveLectureDescription(event, ${
+                    streamInfo["courseID"]
+                }, ${streamInfo["streamID"]}).then((r)=>showSubmit=!r)"
                     class="w-full flex flex-row focus-within:border-gray-300 border-gray-500">
                     <label for="lectureDescriptionInput${
                         streamInfo["streamID"]

--- a/web/ts/schedule.ts
+++ b/web/ts/schedule.ts
@@ -4,38 +4,52 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import iCalendarPlugin from "@fullcalendar/icalendar";
 
+let calendar: Calendar;
+
 export function addScheduleListener() {
     document.addEventListener("DOMContentLoaded", function () {
         const calendarEl = document.getElementById("calendar");
         // Init fullcallendar
-        const calendar = new Calendar(calendarEl, {
-            plugins: [dayGridPlugin, timeGridPlugin, iCalendarPlugin],
-            headerToolbar: { center: "timeGridDay,timeGridWeek" },
-            initialView: "timeGridDay",
-            nowIndicator: true,
-            firstDay: 1,
-            height: "85vh",
-            allDaySlot: false,
-            events: {
-                url: "/api/hall/all.ics",
-                format: "ics",
-            },
-            eventDidMount: function (e) {
-                // manipulate dom element on event rendering -> inject events location
-                e.el.title = e.event.title;
-                const eventLocation = e.event.extendedProps.location;
-                if (eventLocation !== null && eventLocation !== undefined && eventLocation !== "") {
-                    e.el.title = e.el.title + " Location: " + eventLocation;
-                    const locationElem = document.createElement("i");
-                    locationElem.innerHTML = "&#183;" + eventLocation;
-                    e.el.getElementsByClassName("fc-event-time")[0].appendChild(locationElem);
-                }
-            },
-            eventClick: function (data) {
-                // load some extra info on click
-                const popover = document.getElementById("popoverContent");
-                const streamInfo = JSON.parse(Get("/api/stream/" + data.event.extendedProps.description));
-                popover.innerHTML = `
+        calendar = new Calendar(calendarEl, opts);
+        calendar.render();
+    });
+}
+
+export function refetchCalendar(lecturehalls: number[]){
+    opts.events.url = "/api/schedule.ics?lecturehalls=" + lecturehalls.join(",");
+    calendar.removeAllEvents();
+    calendar.addEventSource(opts.events);
+    calendar.refetchEvents();
+}
+
+const opts = {
+    plugins: [dayGridPlugin, timeGridPlugin, iCalendarPlugin],
+    headerToolbar: { center: "timeGridDay,timeGridWeek" },
+    initialView: "timeGridDay",
+    nowIndicator: true,
+    firstDay: 1,
+    height: "85vh",
+    allDaySlot: false,
+    events: {
+        url: "/api/schedule.ics",
+        format: "ics",
+    },
+    eventDidMount: function (e) {
+        // manipulate dom element on event rendering -> inject events location
+        e.el.title = e.event.title;
+        const eventLocation = e.event.extendedProps.location;
+        if (eventLocation !== null && eventLocation !== undefined && eventLocation !== "") {
+            e.el.title = e.el.title + " Location: " + eventLocation;
+            const locationElem = document.createElement("i");
+            locationElem.innerHTML = "&#183;" + eventLocation;
+            e.el.getElementsByClassName("fc-event-time")[0].appendChild(locationElem);
+        }
+    },
+    eventClick: function (data) {
+        // load some extra info on click
+        const popover = document.getElementById("popoverContent");
+        const streamInfo = JSON.parse(Get("/api/stream/" + data.event.extendedProps.description));
+        popover.innerHTML = `
             <p class="flex text-1 text-lg">
                 <span class="grow">${streamInfo["course"]}</span>
                 <i id="closeBtn" class="transition-colors duration-200 hover:text-1 text-4 icon-close"></i>
@@ -48,42 +62,39 @@ export function addScheduleListener() {
                     <label for="lectureNameInput${streamInfo["streamID"]}" class="hidden">Lecture title</label>
                     <input id="lectureNameInput${streamInfo["streamID"]}"
                         onfocus="admin.focusNameInput(this, ${streamInfo["streamID"]})"
-                        class="grow border-none" type="text" value="${streamInfo["name"]}"
+                        class="tl-input grow border-none" type="text" value="${streamInfo["name"]}"
                         placeholder="Lecture 2: Dark-Patterns I"
                         autocomplete="off">
                     <button id="nameSubmitBtn${streamInfo["streamID"]}"
                         class="fas fa-check ml-2 invisible text-gray-400 hover:text-purple-500"></button>
                 </form>
                 <form onsubmit="admin.saveLectureDescription(event, ${streamInfo["courseID"]}, ${
-                    streamInfo["streamID"]
-                })"
+            streamInfo["streamID"]
+        })"
                     class="w-full flex flex-row border-b-2 focus-within:border-gray-300 border-gray-500">
                     <label for="lectureDescriptionInput${
-                        streamInfo["streamID"]
-                    }" class="hidden">Lecture description</label>
+            streamInfo["streamID"]
+        }" class="hidden">Lecture description</label>
                     <textarea id="lectureDescriptionInput${streamInfo["streamID"]}"
                         rows="3"
                         onfocus="admin.focusDescriptionInput(this, ${streamInfo["streamID"]})"
-                        class="grow border-none"
+                        class="tl-input grow border-none"
                         placeholder="Add a nice description, links, and more. You can use Markdown."
                         autocomplete="off">${streamInfo["description"]}</textarea>
                     <button id="descriptionSubmitBtn${streamInfo["streamID"]}"
                         class="fas fa-check ml-2 invisible text-4 hover:text-1"></button>
                 </form>
             <a class="text-3 hover:text-black dark:hover:text-white" href="/admin/course/${
-                streamInfo["courseID"]
-            }#lecture-li-${streamInfo["streamID"]}">Edit <i class="fas fa-external-link-alt"></i></a>
+            streamInfo["courseID"]
+        }#lecture-li-${streamInfo["streamID"]}">Edit <i class="fas fa-external-link-alt"></i></a>
             `;
-                document.getElementsByClassName("fc-timegrid").item(0)?.classList.add("filter", "blur-xxs");
-                popover.classList.remove("hidden");
-                document.getElementById("closeBtn").onclick = () => {
-                    document.getElementsByClassName("fc-timegrid").item(0)?.classList.remove("filter", "blur-xxs");
-                    popover.classList.add("hidden");
-                    this.render();
-                };
-                this.render();
-            },
-        });
-        calendar.render();
-    });
-}
+        document.getElementsByClassName("fc-timegrid").item(0)?.classList.add("filter", "blur-xxs");
+        popover.classList.remove("hidden");
+        document.getElementById("closeBtn").onclick = () => {
+            document.getElementsByClassName("fc-timegrid").item(0)?.classList.remove("filter", "blur-xxs");
+            popover.classList.add("hidden");
+            this.render();
+        };
+        this.render();
+    },
+};

--- a/web/ts/schedule.ts
+++ b/web/ts/schedule.ts
@@ -20,7 +20,6 @@ export function refetchCalendar(lecturehalls: number[]) {
     opts.events.url = "/api/schedule.ics?lecturehalls=" + lecturehalls.join(",");
     calendar.removeAllEventSources();
     calendar.addEventSource(opts.events);
-    calendar.refetchEvents();
 }
 
 const opts = {

--- a/web/ts/schedule.ts
+++ b/web/ts/schedule.ts
@@ -58,32 +58,30 @@ const opts = {
                 <div class="text-2">
                     <div class="flex"><p>${new Date(streamInfo["start"]).toLocaleString()}</p></div>
                 </div>
-                <form onsubmit="admin.saveLectureName(event, ${streamInfo["courseID"]}, ${streamInfo["streamID"]})"
-                    class="w-full flex flex-row border-b-2 focus-within:border-gray-300 border-gray-500">
+                <form x-data="{showSubmit:false}" @submit="admin.saveLectureName(event, ${streamInfo["courseID"]}, ${streamInfo["streamID"]}).then((r)=>showSubmit=!r)"
+                    class="w-full flex flex-row mb-2 focus-within:border-gray-300 border-gray-500">
                     <label for="lectureNameInput${streamInfo["streamID"]}" class="hidden">Lecture title</label>
                     <input id="lectureNameInput${streamInfo["streamID"]}"
-                        onfocus="admin.focusNameInput(this, ${streamInfo["streamID"]})"
+                        @change="showSubmit=true" @keyup="showSubmit=true"
                         class="tl-input grow border-none" type="text" value="${streamInfo["name"]}"
                         placeholder="Lecture 2: Dark-Patterns I"
                         autocomplete="off">
-                    <button id="nameSubmitBtn${streamInfo["streamID"]}"
-                        class="fas fa-check ml-2 invisible text-gray-400 hover:text-purple-500"></button>
+                    <button x-show="showSubmit" id="nameSubmitBtn${streamInfo["streamID"]}"
+                        class="fas fa-check ml-2 text-gray-400 hover:text-purple-500"></button>
                 </form>
-                <form onsubmit="admin.saveLectureDescription(event, ${streamInfo["courseID"]}, ${
-            streamInfo["streamID"]
-        })"
-                    class="w-full flex flex-row border-b-2 focus-within:border-gray-300 border-gray-500">
+                <form x-data="{showSubmit:false}" @submit="admin.saveLectureDescription(event, ${streamInfo["courseID"]}, ${streamInfo["streamID"]}).then((r)=>showSubmit=!r)"
+                    class="w-full flex flex-row focus-within:border-gray-300 border-gray-500">
                     <label for="lectureDescriptionInput${
                         streamInfo["streamID"]
                     }" class="hidden">Lecture description</label>
                     <textarea id="lectureDescriptionInput${streamInfo["streamID"]}"
                         rows="3"
-                        onfocus="admin.focusDescriptionInput(this, ${streamInfo["streamID"]})"
+                        @change="showSubmit=true" @keyup="showSubmit=true"
                         class="tl-input grow border-none"
                         placeholder="Add a nice description, links, and more. You can use Markdown."
                         autocomplete="off">${streamInfo["description"]}</textarea>
-                    <button id="descriptionSubmitBtn${streamInfo["streamID"]}"
-                        class="fas fa-check ml-2 invisible text-4 hover:text-1"></button>
+                    <button x-show="showSubmit" id="descriptionSubmitBtn${streamInfo["streamID"]}"
+                        class="fas fa-check ml-2 text-4 hover:text-1"></button>
                 </form>
             <a class="text-3 hover:text-black dark:hover:text-white" href="/admin/course/${
                 streamInfo["courseID"]

--- a/web/ts/schedule.ts
+++ b/web/ts/schedule.ts
@@ -6,10 +6,11 @@ import iCalendarPlugin from "@fullcalendar/icalendar";
 
 let calendar: Calendar;
 
-export function addScheduleListener() {
+export function addScheduleListener(lectureHalls: number[]) {
     document.addEventListener("DOMContentLoaded", function () {
         const calendarEl = document.getElementById("calendar");
         // Init fullcallendar
+        opts.events.url = "/api/schedule.ics?lecturehalls=" + lectureHalls.join(",");
         calendar = new Calendar(calendarEl, opts);
         calendar.render();
     });
@@ -17,7 +18,7 @@ export function addScheduleListener() {
 
 export function refetchCalendar(lecturehalls: number[]){
     opts.events.url = "/api/schedule.ics?lecturehalls=" + lecturehalls.join(",");
-    calendar.removeAllEvents();
+    calendar.removeAllEventSources();
     calendar.addEventSource(opts.events);
     calendar.refetchEvents();
 }


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

To have a quick glance about the events that are in a certain lecture hall it would be helpful if we were able to filter the events in the calendar.
fixes #732 

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
This PR adds a checkbox for each lecture hall below the calendar. If a checkbox is checked we pass the id to the api which then includes that lecture hall in the result. The changes (logic wise) are done in SQL.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- Lecturers
- An admin

1. generate events for different courses in different lecture halls.
2. view the schedule as lectuer and verify that 
  2.1 filtering by lecture hall works.
  2.2 The lecturer only sees their events.  
4. test that filtering also works for admins. 
