### PR TITLE
fix stream stop ui

### DIFF
--- a/web/template/admin/admin_tabs/schedule.gohtml
+++ b/web/template/admin/admin_tabs/schedule.gohtml
@@ -3,7 +3,7 @@
     <div x-init="admin.addScheduleListener()" class="flex flex-col lg:flex-row w-full pt-4 relative">
         <div id="calendar" class="w-full"></div>
         <div id="popoverContent"
-             class="cursor-auto absolute transform -translate-x-1/2 -translate-y-1/2 left-1/2 top-1/2 p-4 bg-white dark:bg-secondary-lighter rounded z-10 border dark:border-gray-500 border-gray-300 hidden"></div>
+             class="cursor-auto absolute transform -translate-x-1/2 -translate-y-1/2 left-1/2 top-1/2 p-4 bg-white dark:bg-secondary-lighter rounded z-40 border dark:border-gray-500 border-gray-300 hidden"></div>
     </div>
     {{- /*gotype: github.com/joschahenningsen/TUM-Live/web.IndexData*/ -}}
 {{end}}


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Currently the stream stop ui (popup) is hidden behind the player. 

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
This issue is fixed by setting the z index of the popup higher than the one of the player.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Lecturer
- 1 Livestream

1. Navigate to a Livestream
2. Click stop button and verify that the ui is visible.
