### PR TITLE
Add additional Makefile targets and phony targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: all
 all: npm_dependencies go_dependencies bundle
 
 VERSION := $(shell git rev-parse --short origin/HEAD)
@@ -9,7 +10,7 @@ npm_dependencies:
 
 .PHONY: go_dependencies
 go_dependencies:
-	go get ./...;
+	go get ./...
 
 .PHONY: bundle
 bundle:
@@ -34,7 +35,7 @@ run_web:
 
 .PHONY: run
 run:
-	go run cmd/tumlive/tumlive.go;
+	go run cmd/tumlive/tumlive.go
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -2,21 +2,40 @@ all: npm_dependencies go_dependencies bundle
 
 VERSION := $(shell git rev-parse --short origin/HEAD)
 
+.PHONY: npm_dependencies
 npm_dependencies:
 	cd web; \
-	npm i --no-dev;
+	npm i --no-dev
 
+.PHONY: go_dependencies
 go_dependencies:
-	go get ./...
+	go get ./...;
 
+.PHONY: bundle
 bundle:
 	go build -o main -ldflags="-X 'main.VersionTag=$(VERSION)'" cmd/tumlive/tumlive.go
 
+.PHONY: clean
 clean:
 	rm -fr web/node_modules
 
+.PHONY: install
 install:
 	mv main /bin/tum-live
 
+.PHONY: mocks
 mocks:
 	go generate ./...
+
+.PHONY: run_web
+run_web:
+	cd web; \
+	npm i --dev
+
+.PHONY: run
+run:
+	go run cmd/tumlive/tumlive.go;
+
+.PHONY: test
+test:
+	go test -race ./...

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -2,15 +2,31 @@ all: build
 
 VERSION := $(shell git rev-parse --short origin/HEAD)
 
+.PHONY: protoGen
 protoGen:
 	cd api; \
 	protoc ./api.proto --go-grpc_out=../.. --go_out=../..
 
+.PHONY: build
 build: deps
-	go build -o main -ldflags="-X 'main.VersionTag=$(VERSION)'" cmd/worker/worker.go;
+	go build -o main -ldflags="-X 'main.VersionTag=$(VERSION)'" cmd/worker/worker.go
 
+.PHONY: deps
 deps:
-	go get ./...;
+	go get ./...
 
+.PHONY: install
 install:
 	mv main /bin/worker
+
+.PHONY: clean
+clean:
+	rm -f main
+
+.PHONY: test
+test:
+	go test -race ./...
+
+.PHONY: run
+run:
+	go run cmd/worker/worker.go;

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -31,3 +31,4 @@ test:
 .PHONY: run
 run:
 	go run cmd/worker/worker.go
+

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -1,3 +1,4 @@
+.PHONY: all
 all: build
 
 VERSION := $(shell git rev-parse --short origin/HEAD)
@@ -29,4 +30,4 @@ test:
 
 .PHONY: run
 run:
-	go run cmd/worker/worker.go;
+	go run cmd/worker/worker.go


### PR DESCRIPTION
### Motivation and Context
As I try to rely on a terminal based workflow, I found that the current Makefiles do not support everything that is needed for daily development. Therefore I added some more targets which I think are useful.

I saw that no `.PHONY` is used which is kinda bad practice as we don't really name the targets after file names, see https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html.

<!-- If it fixes an open issue, please link to the issue here. -->

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Execute all the targets locally.
