### PR TITLE
fix ui of lecture hall settings

### DIFF
--- a/web/template/partial/course/manage/lecture-hall-settings.gohtml
+++ b/web/template/partial/course/manage/lecture-hall-settings.gohtml
@@ -1,5 +1,5 @@
 {{define "source-settings"}}
-    <div x-cloak class="" x-data="{halls: [], changed: false}"
+    <div x-cloak x-data="{halls: [], changed: false}"
          x-init="fetch(`/api/lecture-halls-by-id?id=${document.getElementById('courseID').value}`).then(r=>r.json()).then(d=>halls=d)">
         <template x-if="halls !== null && halls.length > 0">
             <template x-for="hall in halls">

--- a/web/template/partial/course/manage/lecture-hall-settings.gohtml
+++ b/web/template/partial/course/manage/lecture-hall-settings.gohtml
@@ -1,14 +1,14 @@
 {{define "source-settings"}}
-    <div x-cloak class="form-container-body" x-data="{halls: [], changed: false}"
+    <div x-cloak class="" x-data="{halls: [], changed: false}"
          x-init="fetch(`/api/lecture-halls-by-id?id=${document.getElementById('courseID').value}`).then(r=>r.json()).then(d=>halls=d)">
         <template x-if="halls !== null && halls.length > 0">
             <template x-for="hall in halls">
                 <div x-data="{selected_preset: undefined, selected_preset_name: ''}" class="ml-2"
                         x-init="selected_preset = hall.presets.find(e => e.PresetID==hall.selected_preset_id); selected_preset_name = selected_preset in window ? '' : selected_preset.Name"
                         @reinit.window="selected_preset = hall.presets.find(e => e.PresetID==hall.selected_preset_id); selected_preset_name = selected_preset in window ? '' : selected_preset.Name">
-                    <div class="flex justify-between">
-                        <p class="font-semibold px-1 my-auto dark:text-white" x-text="hall.lecture_hall_name"></p>
-                        <select class="text-black dark:bg-secondary dark:text-white bg-gray-100 p-2"
+                    <div class="flex justify-between mt-2">
+                        <p class="font-semibold px-1 my-auto dark:text-white w-full" x-text="hall.lecture_hall_name"></p>
+                        <select class="tl-select mx-2"
                                 id="sourceModeBulkSelect"
                                 @change="changed=true;"
                                 x-model.number="hall.source_mode">


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In #713 an issue was introduced that made the lecture hall settings section overflow if there are too many presets.

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
This PR removes the class that introduces `display: grid` which doesn't work here. 
Also the `select` for the source settings is now styled properly.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Have a look at the Lecture hall settings and verify that it looks alright with a few presets.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->

Before: 
![image](https://user-images.githubusercontent.com/44805696/197385642-25d6fad2-a478-49ed-ba85-ed02e5a2421f.png)

After: 
![image](https://user-images.githubusercontent.com/44805696/197385661-58e8aa37-bda8-4d95-87c7-d59c3f6a3187.png)
