### PR TITLE
fix downloads for students

### DIFF
--- a/api/download.go
+++ b/api/download.go
@@ -22,6 +22,11 @@ type downloadRoutes struct {
 	dao.DaoWrapper
 }
 
+var dlErr = tools.RequestError{
+	Status:        http.StatusForbidden,
+	CustomMessage: "user not allowed to get file",
+}
+
 func (r downloadRoutes) download(c *gin.Context) {
 	foundContext, exists := c.Get("TUMLiveContext")
 	if !exists {
@@ -74,18 +79,28 @@ func (r downloadRoutes) download(c *gin.Context) {
 	case "download":
 		fallthrough
 	default:
-		if !tumLiveContext.User.IsAdminOfCourse(course) {
-			if !course.DownloadsEnabled || !(course.Visibility == "hidden" || course.Visibility == "public") ||
-				!tumLiveContext.User.IsEligibleToWatchCourse(course) || !tumLiveContext.User.IsAdminOfCourse(course) {
-				_ = c.Error(tools.RequestError{
-					Status:        http.StatusForbidden,
-					CustomMessage: "user not allowed to get file",
-				})
+		if tumLiveContext.User.IsAdminOfCourse(course) {
+			sendDownloadFile(c, file, tumLiveContext)
+			return
+		}
+		if !course.DownloadsEnabled {
+			_ = c.Error(dlErr)
+			return
+		}
+		if course.Visibility == "loggedin" || course.Visibility == "enrolled" {
+			if tumLiveContext.User == nil {
+				_ = c.Error(dlErr)
 				return
 			}
+			if course.Visibility == "enrolled" {
+				if !tumLiveContext.User.IsEligibleToWatchCourse(course) {
+					_ = c.Error(dlErr)
+					return
+				}
+			}
 		}
-		log.Info(fmt.Sprintf("Download request, user: %d, file: %d[%s]", tumLiveContext.User.ID, file.ID, file.Path))
-		sendDownloadFile(c, file)
+
+		sendDownloadFile(c, file, tumLiveContext)
 	}
 }
 
@@ -99,7 +114,8 @@ func sendImageContent(c *gin.Context, file model.File) {
 	c.Data(http.StatusOK, "image/jpg", image)
 }
 
-func sendDownloadFile(c *gin.Context, file model.File) {
+func sendDownloadFile(c *gin.Context, file model.File, tumLiveContext tools.TUMLiveContext) {
+	log.Info(fmt.Sprintf("Download request, user: %d, file: %d[%s]", tumLiveContext.User.ID, file.ID, file.Path))
 	f, err := os.Open(file.Path)
 	if err != nil {
 		_ = c.Error(tools.RequestError{

--- a/api/download.go
+++ b/api/download.go
@@ -115,7 +115,11 @@ func sendImageContent(c *gin.Context, file model.File) {
 }
 
 func sendDownloadFile(c *gin.Context, file model.File, tumLiveContext tools.TUMLiveContext) {
-	log.Info(fmt.Sprintf("Download request, user: %d, file: %d[%s]", tumLiveContext.User.ID, file.ID, file.Path))
+	var uid uint = 0
+	if tumLiveContext.User != nil {
+		uid = tumLiveContext.User.ID
+	}
+	log.Info(fmt.Sprintf("Download request, user: %d, file: %d[%s]", uid, file.ID, file.Path))
 	f, err := os.Open(file.Path)
 	if err != nil {
 		_ = c.Error(tools.RequestError{

--- a/api/stream.go
+++ b/api/stream.go
@@ -115,7 +115,7 @@ func (r streamRoutes) getThumbs(c *gin.Context) {
 		})
 		return
 	}
-	sendDownloadFile(c, file)
+	sendDownloadFile(c, file, tumLiveContext)
 }
 
 // livestreams returns all streams that are live


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Students can't download lectures currently. Also, the current code is very hard to read. 

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
This PR should make the function more understandable and allows students to download their lectures.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- Lecturer
- Students
- Admin
- 1 VoD

1. Test downloading a video that has downloads enabled with all users and visibilities. It should work whenever a user is allowed to see the course.
2. Test downloading a video that has downloads disabled with all users and visibilities. It should only work if the user is allowed to manage the course.
