### PR TITLE
Fix description markdown

### DIFF
--- a/api/courses.go
+++ b/api/courses.go
@@ -90,7 +90,7 @@ type coursesRoutes struct {
 
 const (
 	WorkerHTTPPort = "8060"
-	CutOffLength   = 100
+	CutOffLength   = 256
 )
 
 type uploadVodReq struct {
@@ -644,8 +644,7 @@ func (r coursesRoutes) updateDescription(c *gin.Context) {
 	}
 	wsMsg := gin.H{
 		"description": gin.H{
-			"full":      stream.GetDescriptionHTML(),
-			"truncated": tools.Truncate(stream.GetDescriptionHTML(), 100),
+			"full": stream.GetDescriptionHTML(),
 		},
 	}
 	if msg, err := json.Marshal(wsMsg); err == nil {

--- a/api/courses.go
+++ b/api/courses.go
@@ -645,7 +645,7 @@ func (r coursesRoutes) updateDescription(c *gin.Context) {
 	wsMsg := gin.H{
 		"description": gin.H{
 			"full":      stream.GetDescriptionHTML(),
-			"truncated": tools.Truncate(stream.GetDescriptionHTML(), 150),
+			"truncated": tools.Truncate(stream.GetDescriptionHTML(), 100),
 		},
 	}
 	if msg, err := json.Marshal(wsMsg); err == nil {

--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -414,3 +414,8 @@ a.fc-event, a.fc-event:hover {
 .overflow-wrap-anywhere {
     overflow-wrap: anywhere;
 }
+
+.video-description ul {
+    list-style-type: disc;
+    margin-left: 16px;
+}

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -282,22 +282,34 @@
         {{end}}
 
         <!-- Video description -->
-        <div x-data="{ less: {{len .Description}}>{{.CutOffLength}}, full: `{{.Description}}`, prev: `{{.TruncatedDescription}}` }"
-             class="video-description flex-grow p-5 basis-full lg:order-none order-5"
-             x-show="full.length"
-        >
-            <div class="flex justify-between border-b mb-3 dark:border-gray-800 lg:justify-start">
+        {{$less := gt (len .Description) .CutOffLength}}
+        <div x-data="{ less: {{$less}}, toggleDesc: false }"
+             {{/* Update less on update */}}
+             @descriptionupdate.window="toggleDesc = less = $event.detail.description.full.length > {{.CutOffLength}};"
+             class="video-description flex-grow p-5 basis-full lg:order-none order-5">
+            <div class="flex justify-between border-b mb-1 dark:border-gray-800 lg:justify-start">
                 <h3 class="text-4 font-semibold">Description</h3>
-                <button x-show="full.length>{{.CutOffLength}}"
-                        class="text-5 text-xs rounded h-fit w-fit font-semibold px-2 py-1 my-auto uppercase lg:ml-2"
-                        @click="less = !less" x-text="less ? 'show more' : 'show less'">
-                </button>
             </div>
-
-            <div class="text-3 text-sm"
-                 x-html="less ? prev : full"
-                 @descriptionupdate.window="full=$el.innerHTML=$event.detail.description.full;prev=
-                     $el.innerHTML=$event.detail.description.truncated;less=full.length>{{.CutOffLength}};">
+            <div>
+                <div class="rounded-lg bg-gray-50 hover:bg-gray-100 text-3 text-sm">
+                    <button @click="toggleDesc = !toggleDesc;"
+                         :disabled="!less"
+                         class="hover:cursor-pointer p-2 w-full text-left">
+                        <span x-cloak x-show="toggleDesc"
+                              @descriptionupdate.window="$el.innerHTML=$event.detail.description.truncated">
+                            {{.TruncatedDescription}}
+                        </span>
+                        <span x-cloak x-show="!toggleDesc"
+                              @descriptionupdate.window="$el.innerHTML=$event.detail.description.full">
+                            {{.Description}}
+                        </span>
+                    </button>
+                    <template x-if="less">
+                        <button class="font-semibold m-1 py-1 px-2 rounded-full hover:bg-gray-200"
+                                x-text="toggleDesc ? 'Show more' : 'Show less'"
+                                @click="toggleDesc = !toggleDesc;"></button>
+                    </template>
+                </div>
             </div>
         </div>
 

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -291,7 +291,7 @@
                 <h3 class="text-4 font-semibold">Description</h3>
             </div>
             <div>
-                <div class="rounded-lg bg-gray-50 hover:bg-gray-100 text-3 text-sm">
+                <div class="rounded-lg bg-gray-50 hover:bg-gray-100 dark:bg-gray-800 hover:dark:bg-secondary text-3 text-sm">
                     <button @click="toggleDesc = !toggleDesc;"
                          :disabled="!less"
                          class="hover:cursor-pointer p-2 w-full text-left">
@@ -305,7 +305,7 @@
                         </span>
                     </button>
                     <template x-if="less">
-                        <button class="font-semibold m-1 py-1 px-2 rounded-full hover:bg-gray-200"
+                        <button class="font-semibold m-1 py-1 px-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
                                 x-text="toggleDesc ? 'Show more' : 'Show less'"
                                 @click="toggleDesc = !toggleDesc;"></button>
                     </template>

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -283,7 +283,7 @@
 
         <!-- Video description -->
         {{$less := gt (len .Description) .CutOffLength}}
-        <div x-data="{ less: {{$less}}, toggleDesc: false }"
+        <div x-data="{ less: {{$less}}, toggleDesc: true }"
              {{/* Update less on update */}}
              @descriptionupdate.window="toggleDesc = less = $event.detail.description.full.length > {{.CutOffLength}};"
              class="video-description flex-grow p-5 basis-full lg:order-none order-5">
@@ -294,12 +294,10 @@
                 <div class="rounded-lg bg-gray-50 hover:bg-gray-100 dark:bg-gray-800 hover:dark:bg-secondary text-3 text-sm">
                     <button @click="toggleDesc = !toggleDesc;"
                          :disabled="!less"
-                         class="hover:cursor-pointer p-2 w-full text-left">
-                        <span x-cloak x-show="toggleDesc"
-                              @descriptionupdate.window="$el.innerHTML=$event.detail.description.truncated">
-                            {{.TruncatedDescription}}
-                        </span>
-                        <span x-cloak x-show="!toggleDesc"
+                         class="p-2 w-full text-left"
+                        :class="less && 'hover:cursor-pointer'">
+                        <span class="block overflow-y-clip"
+                                :class="(less && toggleDesc) ? 'h-8' : 'h-auto'"
                               @descriptionupdate.window="$el.innerHTML=$event.detail.description.full">
                             {{.Description}}
                         </span>

--- a/web/watch.go
+++ b/web/watch.go
@@ -98,10 +98,8 @@ func (r mainRoutes) WatchPage(c *gin.Context) {
 	data.CutOffLength = api.CutOffLength
 	if strings.HasPrefix(data.Version, "unit-") {
 		data.Description = data.Unit.GetDescriptionHTML()
-		data.TruncatedDescription = template.HTML(tools.Truncate(string(data.Unit.GetDescriptionHTML()), data.CutOffLength))
 	} else {
 		data.Description = template.HTML(data.IndexData.TUMLiveContext.Stream.GetDescriptionHTML())
-		data.TruncatedDescription = template.HTML(tools.Truncate(data.IndexData.TUMLiveContext.Stream.GetDescriptionHTML(), data.CutOffLength))
 	}
 	if c.Query("video_only") == "1" {
 		err := templateExecutor.ExecuteTemplate(c.Writer, "video_only.gohtml", data)
@@ -118,20 +116,19 @@ func (r mainRoutes) WatchPage(c *gin.Context) {
 
 // WatchPageData contains all the metadata that is related to the watch page.
 type WatchPageData struct {
-	IsAdminOfCourse      bool // is current user admin or lecturer who created this course
-	IsHighlightPage      bool
-	AlertsEnabled        bool // whether the alert config is set
-	Version              string
-	Unit                 *model.StreamUnit
-	Presets              []model.CameraPreset
-	Progress             model.StreamProgress
-	IndexData            IndexData
-	Description          template.HTML
-	TruncatedDescription template.HTML
-	CutOffLength         int    // The maximum length for the preview of a description.
-	DVR                  string // ?dvr if dvr is enabled, empty string otherwise
-	LectureHallName      string
-	ChatData             ChatData
+	IsAdminOfCourse bool // is current user admin or lecturer who created this course
+	IsHighlightPage bool
+	AlertsEnabled   bool // whether the alert config is set
+	Version         string
+	Unit            *model.StreamUnit
+	Presets         []model.CameraPreset
+	Progress        model.StreamProgress
+	IndexData       IndexData
+	Description     template.HTML
+	CutOffLength    int    // The maximum length for the preview of a description.
+	DVR             string // ?dvr if dvr is enabled, empty string otherwise
+	LectureHallName string
+	ChatData        ChatData
 }
 
 // Prepare populates the data for the watch page.


### PR DESCRIPTION
### Motivation and Context
- Fixes #729 

### Description
- Increase cutoff length to 256
- Remove truncated variables but keep `truncateHtml` function
- Update UI (a bit)
- Add list css

### Steps for Testing
1. Log in as admin
2. Navigate to a Livestream
3. Update description with lists, etc.
4. Should be changed

### Screenshots

https://user-images.githubusercontent.com/29633518/199230476-800fc3af-7474-44a4-9f05-51384568ddc7.mov


