### PR TITLE
Revert "Include Timestamp in URL (#633)"

### DIFF
--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -356,9 +356,11 @@
 <script>
     {{if $stream.Recording}}
     watch.initPlayer(true, false, false, {{.IndexData.TUMLiveContext.User.GetPlaybackSpeeds.GetEnabled}}, {{$stream.LiveNow}}, {{$stream.GetThumbIdForSource .Version}}, {{$stream.ThumbInterval}}, {{$stream.Model.ID}});
-    watch.watchProgress({{$stream.Model.ID}}, {{ .Progress.Progress }}, {{not (empty .IndexData.TUMLiveContext.User)}});
     {{else}}
     watch.initPlayer(true, false, false, {{.IndexData.TUMLiveContext.User.GetPlaybackSpeeds.GetEnabled}}, {{$stream.LiveNow}});
+    {{end}}
+    {{if and $stream.Recording .IndexData.TUMLiveContext.User}}
+    watch.watchProgress({{$stream.Model.ID}}, {{ .Progress.Progress }});
     {{end}}
     {{if $stream.Silences}}
     watch.skipSilence({{$stream.GetSilencesJson}});

--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -1,4 +1,4 @@
-import { getQueryParam, postData } from "./global";
+import { postData } from "./global";
 import { VideoSections } from "./video-sections";
 import { StatusCodes } from "http-status-codes";
 import videojs from "video.js";
@@ -201,9 +201,8 @@ export const skipSilence = function (options) {
  * Saves and retrieves the watch progress of the user as a fraction of the total watch time
  * @param streamID The ID of the currently watched stream
  * @param lastProgress The last progress fetched from the database
- * @param loggedIn: User logged in?
  */
-export const watchProgress = function (streamID: number, lastProgress: number, loggedIn: boolean) {
+export const watchProgress = function (streamID: number, lastProgress: number) {
     const player = videojs("my-video");
     player.ready(() => {
         let duration;
@@ -211,13 +210,23 @@ export const watchProgress = function (streamID: number, lastProgress: number, l
         let iOSReady = false;
         let intervalMillis = 10000;
 
-        // check if query contains parameter 't' and set timestamp accordingly
-        const queryT = Number(getQueryParam("t"));
-        if (!isNaN(queryT)) {
-            player.currentTime(queryT);
-            if (videojs.browser.IS_IOS) {
-                iOSReady = setTimeOnIOS(iOSReady, queryT);
-            }
+        // Fetch the user's video progress from the database and set the time in the player
+        player.on("loadedmetadata", () => {
+            duration = player.duration();
+            player.currentTime(lastProgress * duration);
+        });
+
+        // iPhone/iPad need to set the progress again when they actually play the video. That's why loadedmetadata is
+        // not sufficient here.
+        // See https://stackoverflow.com/questions/28823567/how-to-set-currenttime-in-video-js-in-safari-for-ios.
+        if (videojs.browser.IS_IOS) {
+            player.on("canplaythrough", () => {
+                // Can be executed multiple times during playback
+                if (!iOSReady) {
+                    player.currentTime(lastProgress * duration);
+                    iOSReady = true;
+                }
+            });
         }
 
         const reportProgress = () => {
@@ -233,46 +242,31 @@ export const watchProgress = function (streamID: number, lastProgress: number, l
             });
         };
 
-        // check if user is logged-in, if so proceed
-        if (loggedIn !== null && loggedIn !== undefined && loggedIn) {
-            if (isNaN(queryT)) {
-                // Fetch the user's video progress from the database and set the time in the player
-                player.on("loadedmetadata", () => {
-                    duration = player.duration();
-                    player.currentTime(lastProgress * duration);
-                });
+        // Triggered when user presses play
+        player.on("play", () => {
+            // See https://developer.mozilla.org/en-US/docs/Web/API/setInterval#ensure_that_execution_duration_is_shorter_than_interval_frequency
+            (function reportNextProgress() {
+                timer = setTimeout(function () {
+                    reportProgress();
+                    reportNextProgress();
+                }, intervalMillis);
+            })();
+        });
 
-                if (videojs.browser.IS_IOS) {
-                    iOSReady = setTimeOnIOS(iOSReady, lastProgress * duration);
-                }
+        // Triggered on pause and skipping the video
+        player.on("pause", () => {
+            clearInterval(timer);
+            // "Bug" on iOS: The video is automatically paused at the beginning
+            if (!iOSReady && videojs.browser.IS_IOS) {
+                return;
             }
+            reportProgress();
+        });
 
-            // Triggered when user presses play
-            player.on("play", () => {
-                // See https://developer.mozilla.org/en-US/docs/Web/API/setInterval#ensure_that_execution_duration_is_shorter_than_interval_frequency
-                (function reportNextProgress() {
-                    timer = setTimeout(function () {
-                        reportProgress();
-                        reportNextProgress();
-                    }, intervalMillis);
-                })();
-            });
-
-            // Triggered on pause and skipping the video
-            player.on("pause", () => {
-                clearInterval(timer);
-                // "Bug" on iOS: The video is automatically paused at the beginning
-                if (!iOSReady && videojs.browser.IS_IOS) {
-                    return;
-                }
-                reportProgress();
-            });
-
-            // Triggered when the video has no time left
-            player.on("ended", () => {
-                clearInterval(timer);
-            });
-        }
+        // Triggered when the video has no time left
+        player.on("ended", () => {
+            clearInterval(timer);
+        });
     });
 };
 
@@ -442,7 +436,6 @@ export function jumpTo(hours: number, minutes: number, seconds: number) {
 
 type SeekLoggerLogFunction = (position: number) => void;
 const SEEK_LOGGER_DEBOUNCE_TIMEOUT = 4000;
-
 export class SeekLogger {
     readonly streamID: number;
     log: SeekLoggerLogFunction;
@@ -507,21 +500,6 @@ function debounce(func, timeout) {
         clearTimeout(timer);
         timer = setTimeout(() => func.apply(this, args), timeout);
     };
-}
-
-// iPhone/iPad need to set the progress again when they actually play the video. That's why loadedmetadata is
-// not sufficient here.
-// See https://stackoverflow.com/questions/28823567/how-to-set-currenttime-in-video-js-in-safari-for-ios.
-// Returns updated iOSReady value
-function setTimeOnIOS(iOSReady: boolean, seconds: number): boolean {
-    player.on("canplaythrough", () => {
-        // Can be executed multiple times during playback
-        if (!iOSReady) {
-            player.currentTime(seconds);
-            return true;
-        }
-    });
-    return false;
 }
 
 // Register the plugin with video.js.

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -268,10 +268,6 @@ export type Section = {
     fileID?: number;
 };
 
-export function getQueryParam(name: string): string {
-    return new URL(window.location.href).searchParams.get(name) ?? undefined;
-}
-
 window.onload = function () {
     initHiddenCourses();
 };


### PR DESCRIPTION
This reverts commit 9cc04a4c6503e03ff86381fbae8a30d289101a97.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #752. Something in #633 broke the player upon loading on all ios and ipad os devices.
We can restore the feature after we found the issue. 
