### PR TITLE
Housekeeping of chat and player UI

### DIFF
--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -270,9 +270,24 @@ input[type='checkbox']:checked + label {
     box-shadow: 0 0 0 1px #ffffff60 !important;
 }
 
-.theater-mode {
+/* formerly .theater-mode */
+.h-16\/9 {
     height: calc((9 / 16) * 100vw) !important;
     max-height: calc(100vh - 200px) !important;
+}
+
+.h-16\/6 {
+    height: calc((6 / 16) * 100vw) !important;
+}
+
+@media (min-width: 1024px) {
+    .lg\:h-16\/9 {
+        height: calc((9 / 16) * 100vw) !important;
+        max-height: calc(100vh - 200px) !important;
+    }
+    .lg\:h-16\/6 {
+        height: calc((6 / 16) * 100vw) !important;
+    }
 }
 
 /* don't ask */

--- a/web/template/partial/stream/chat/chat.gohtml
+++ b/web/template/partial/stream/chat/chat.gohtml
@@ -215,7 +215,7 @@
 
         <!-- Messages -->
         <div id="chatBox"
-             class="grid gap-y-8 content-start h-full w-full overflow-y-scroll overflow-x-hidden px-4 py-2 z-30">
+             class="grid gap-y-8 content-start h-full w-full overflow-y-scroll overflow-x-hidden px-4 pt-2 pb-5 z-30">
             {{template "messageTemplate" .}}
         </div>
 

--- a/web/template/partial/stream/chat/chat_message.gohtml
+++ b/web/template/partial/stream/chat/chat_message.gohtml
@@ -19,108 +19,84 @@
                 </span>
             </div>
 
-            <div x-data="{ showMobileAction: false }"
-                    class="relative group p-2 rounded
-                {{if .IsPopUp}}
-                    hover:bg-gray-100 dark:hover:bg-gray-700
-                {{else}}
-                    lg:hover:bg-gray-100 lg:dark:hover:bg-gray-700
-                {{end}}">
+            <div class="relative group p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-600">
                 <div class="flex justify-between">
                     <span class="chatMsg w-5/6 overflow-wrap-anywhere my-auto" x-html="m.message"></span>
-                    <button @click="showMobileAction=!showMobileAction"
-                            @click.outside="showMobileAction = false;"
-                            class ="lg:hidden">
-                        <i class="text-3 fa-solid fa-ellipsis-vertical"></i>
-                    </button>
                 </div>
 
                 <!-- message-date -->
                 <span class="absolute right-2 bottom-2 hidden lg:group-hover:inline text-xs text-5 font-light"
                       x-text="watch.messageDateToString(m.CreatedAt)"></span>
-
-                <!-- hover menu  -->
-                <div x-cloak
-                     x-show="c.admin || m.visible"
-                     class="absolute text-4 bg-white dark:bg-secondary border rounded p-1 dark:border-0 lg:flex lg:space-x-1 z-40
-                         {{if .IsPopUp}}
-                            -top-7 right-2 bottom-auto group-hover:flex text-sm hidden
-                         {{else}}
-                            lg:-top-7 lg:right-2 lg:bottom-auto lg:group-hover:flex lg:flex lg:hidden text-sm h-fit top-full right-0 my-auto
-                         {{end}}"
-                         :class="showMobileAction ? 'grid' : 'hidden'">
-                    <button x-cloak
-                            x-show="m.visible"
-                            @click="watch.likeMessage(m.ID); m.liked=!m.liked;"
-                            :class="m.liked ? 'bg-gray-200 dark:bg-gray-600 hover:bg-transparent' : 'hover:bg-gray-200 dark:hover:bg-gray-600'"
-                            class="flex justify-between px-2 py-1 rounded"
-                            :title="m.liked?'Unlike':'Like'">
-                        <i class="fas fa-thumbs-up my-auto lg:mx-auto"></i>
-                        <span x-show="!{{.IsPopUp}}" class = "lg:hidden">Like</span>
-                    </button>
-                    <button x-cloak
-                            x-show="m.visible"
-                            @click="c.current.replyTo === m.ID ? c.current.replyTo=0: c.current.replyTo=m.ID; $refs.chatInput.focus()"
-                            title="Reply"
-                            class="flex justify-between px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600"
-                            :class="c.current.replyTo === m.ID && 'hidden'">
-                        <i class="fa fas fa-reply my-auto lg:mx-auto"></i>
-                        <span x-show="!{{.IsPopUp}}" class = "lg:hidden">Reply</span>
-                    </button>
-
-                    <!-- admin stuff -->
-                    <button x-show="c.admin"
-                            @click="watch.deleteMessage(m.ID)"
-                            title="Delete Message"
-                            class="flex justify-between px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600">
-                        <i class="fas fa-ban text-danger my-auto lg:mx-auto"></i>
-                        <span x-show="!{{.IsPopUp}}" class = "lg:hidden">Delete</span>
-                    </button>
-                    {{if $moderatedChat}}
-                        <button x-show="c.admin && !m.visible"
-                                @click="watch.approveMessage(m.ID)"
-                                title="Approve Message"
-                                class="flex justify-between px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600">
-                            <i class="fa-solid fa-spell-check my-auto lg:mx-auto"></i>
-                            <span x-show="!{{.IsPopUp}}" class = "lg:hidden">Approve</span>
-                        </button>
-                    {{end}}
-                    <button x-show="c.admin && !m.resolved"
-                            @click="watch.resolveMessage(m.ID)"
-                            title="Resolve Message"
-                            class="flex justify-between px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600">
-                        <i class="fas fa-check text-success my-auto lg:mx-auto"></i>
-                        <span x-show="!{{.IsPopUp}}" class = "ml-2 lg:hidden">Resolve</span>
-                    </button>
-                </div>
             </div>
 
             <!-- like count & open reply button -->
-            <template x-if="m.likes > 0 || m.replies.length > 0 || m.resolved">
-                <div class="flex space-x-2 align-middle">
+            <div class="flex justify-between items-center">
+                <div class="flex space-x-2 align-middle items-center">
+                    <div class="flex">
+                        <button type="button" title="Like message"
+                                @click="watch.likeMessage(m.ID); m.liked=!m.liked;"
+                                class="flex px-2 h-8 rounded-full text-5 hover:bg-gray-200 dark:hover:bg-gray-600">
+                            <i class="fas fa-thumbs-up m-auto"></i>
+                            <template x-if="m.likes > 0">
+                                <span class="m-auto ml-2" x-text="m.likes"></span>
+                            </template>
+                        </button>
+                    </div>
                     <template x-if="m.resolved">
-                        <div class="flex text-xs h-5 w-5 bg-green-100/50 rounded-full border border-success shadow-sm my-auto dark:bg-transparent dark:shadow-0">
-                            <i class="fa-solid fa-check text-success m-auto"></i>
-                        </div>
-                    </template>
-                    <template x-if="m.likes > 0">
-                        <div class="flex">
-                            <div class="flex text-xs border text-5 px-2 rounded-full h-5 shadow-sm dark:border-gray-600 dark:shadow-0">
-                                <i class="fas fa-thumbs-up m-auto"></i>
-                                <span class="m-auto ml-1" x-text="m.likes"></span>
-                            </div>
-                        </div>
+                        <i class="fa-solid fa-check-double text-success"></i>
                     </template>
                     <template x-if="m.replies.length > 0">
                         <button
-                                class="text-5 uppercase text-xs hover:bg-gray-200 dark:hover:bg-gray-600 px-2 rounded"
+                                class="text-5 uppercase text-xs hover:bg-gray-200 dark:hover:bg-gray-600 px-2 h-8 rounded-full"
                                 @click="showReplies=!showReplies">
                             <span>replies</span>
+                            <span x-text="`(${m.replies.length})`"></span>
                             <i class="fa-solid ml-1" :class="showReplies ? 'fa-chevron-up' : 'fa-chevron-down'"></i>
                         </button>
                     </template>
+                    <button @click="c.current.replyTo === m.ID ? c.current.replyTo=0: c.current.replyTo=m.ID; $refs.chatInput.focus()"
+                            title="Reply"
+                            :class="c.current.replyTo === m.ID && 'hidden'">
+                        <span class="font-semibold text-xs text-4">Reply</span>
+                    </button>
                 </div>
-            </template>
+                <template x-if="c.admin">
+                    <div x-data="{showAdminTools: false}" class="relative">
+                        <button type="button" title="Admin tools"
+                                @click="showAdminTools=true;"
+                                class="text-amber-400 uppercase text-sm hover:bg-gray-200 dark:hover:bg-gray-600 w-8 h-8 rounded-full">
+                            <i class="fa-solid fa-bolt"></i>
+                        </button>
+                        <div x-cloak x-show="showAdminTools"
+                             @click.outside="showAdminTools = false;"
+                             class="absolute right-0 bottom-full py-2 z-50 w-32 bg-white dark:bg-secondary-light
+                                border dark:border-gray-600 shadow rounded-lg">
+                            <button @click="watch.deleteMessage(m.ID)"
+                                    title="Delete Message"
+                                    class="flex items-center w-full px-2 py-1 hover:bg-gray-200 dark:hover:bg-gray-600">
+                                <i class="fas fa-ban text-danger mr-2"></i>
+                                <span class="text-4 font-light">Delete</span>
+                            </button>
+                            {{if $moderatedChat}}
+                                <button @click="watch.approveMessage(m.ID)"
+                                        title="Approve Message"
+                                        class="flex items-center w-full px-2 py-1 hover:bg-gray-200 dark:hover:bg-gray-600">
+                                    <i class="fa-solid fa-spell-check mr-2"></i>
+                                    <span class="text-4 font-light">Approve</span>
+                                </button>
+                            {{end}}
+                            <template x-if="!m.resolved">
+                                <button @click="watch.resolveMessage(m.ID)"
+                                        title="Resolve Message"
+                                        class="flex items-center w-full px-2 py-1 hover:bg-gray-200 dark:hover:bg-gray-600">
+                                    <i class="fas fa-check text-success mr-2"></i>
+                                    <span class="text-4 font-light">Resolve</span>
+                                </button>
+                            </template>
+                        </div>
+                    </div>
+                </template>
+            </div>
 
             <!-- replies -->
             <div x-cloak x-show="showReplies"

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -27,7 +27,8 @@
 <div id="watchPageMainWrapper" class="lg:px-5 lg:pb-1">
     <input type="hidden" id="streamID" value="{{$stream.Model.ID}}">
     <div class="flex flex-wrap shadow border bg-white dark:bg-secondary dark:shadow-0 dark:border-0">
-        <div x-data="{ 'chatEnabled': {{and $course.ChatEnabled $stream.ChatEnabled}} }" id="watchWrapper"
+        <div id="watchWrapper"
+             x-data="{ 'chatEnabled': {{and $course.ChatEnabled $stream.ChatEnabled}} }"
              class="relative basis-full lg:order-none order-1 sticky top-0 lg:relative z-40"
              :class="showChat && chatEnabled ? 'lg:basis-3/4 lg:h-16/6 h-16/9' : 'lg:basis-full h-16/9'">
             <noscript>
@@ -148,7 +149,7 @@
 
         <!-- stream info container -->
         <!-- Title, course name, actions -->
-        <div class="basis-full relative p-5 lg:order-none order-2">
+        <div class="basis-full relative order-2 p-5 lg:order-none">
             <div class="flex justify-between align-middle border-b dark:border-gray-800 pb-2 lg:border-0">
                 <!-- title and course-name -->
                 <div class="grid mb-auto shrink">
@@ -288,7 +289,8 @@
 
         <!-- Video description -->
         {{$less := gt (len .Description) .CutOffLength}}
-        <div x-data="{ less: {{$less}}, toggleDesc: true }"
+        {{if gt (len .Description) 0}}
+            <div x-data="{ less: {{$less}}, toggleDesc: true }"
                 {{/* Update less on update */}}
              @descriptionupdate.window="toggleDesc = less = $event.detail.description.full.length > {{.CutOffLength}};"
              class="video-description flex-grow p-5 basis-full lg:order-none order-5">
@@ -315,6 +317,7 @@
                 </div>
             </div>
         </div>
+        {{end}}
 
         <!-- Modal when stopping a stream -->
         <div class="inline-block" x-data="{ 'showModal': false }"

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -17,7 +17,7 @@
       x-on:pausestart.window="paused=true"
       x-on:pauseend.window="paused=false"
       @keypress.shift.window="(e) => watch.onShift(e)"
-      x-init="new watch.Watch(); watch.startWebsocket(); seekLogger.attach();">
+      x-init="watch.startWebsocket(); seekLogger.attach();">
 {{template "header" .IndexData.TUMLiveContext}}
 <div id="shortcuts-help-modal" class="hidden flex absolute top-0 h-screen w-screen z-50 backdrop-blur-sm">
     <div class="m-auto" @click.outside="watch.toggleShortcutsModal();">
@@ -28,14 +28,16 @@
     <input type="hidden" id="streamID" value="{{$stream.Model.ID}}">
     <div class="flex flex-wrap shadow border bg-white dark:bg-secondary dark:shadow-0 dark:border-0">
         <div x-data="{ 'chatEnabled': {{and $course.ChatEnabled $stream.ChatEnabled}} }" id="watchWrapper"
-             :class="showChat && chatEnabled ? 'lg:basis-3/4' : 'lg:basis-full'"
-             class="basis-full lg:order-none order-1 sticky top-0 lg:relative z-40">
-            <noscript><p class="vjs-no-js">
-                    To view this video please enable JavaScript.
-                </p></noscript>
+             class="relative basis-full lg:order-none order-1 sticky top-0 lg:relative z-40"
+             :class="showChat && chatEnabled ? 'lg:basis-3/4 lg:h-16/6 h-16/9' : 'lg:basis-full h-16/9'">
+            <noscript>
+                <p class="vjs-no-js">To view this video please enable JavaScript.</p>
+            </noscript>
             <div id="watchContent"
                  x-data="{ contextMenu: { shown: false, locX: 0, locY: 0 }, videoStatsShown: false }"
-                 class="grow w-full relative">
+                 class="grow w-full h-full">
+
+                <!-- info messages -->
                 <div class="bg-indigo-700 bg-opacity-20 border-t-4 border-indigo-700 w-full font-semibold text-2 rounded-t display-none"
                      x-show="paused" x-cloak>
                     <i class="fas fa-info-circle"></i> This lecture is currently paused.
@@ -45,9 +47,11 @@
                      x-show="showliveended" @streamended.window="showliveended=true" x-cloak>
                     <i class="fas fa-info-circle"></i> This livestream has ended.
                 </div>
+
+                <!-- player -->
                 <video-js
                         id="my-video"
-                        class="video-js w-full vjs-theater-mode theater-mode"
+                        class="video-js w-full h-full"
                         controls
                         preload="auto"
                         x-on:contextmenu="contextMenu = watch.contextMenuHandler($event, contextMenu)"
@@ -134,8 +138,9 @@
         {{if and $course.ChatEnabled $stream.ChatEnabled}}
             <div x-show="showChat"
                  :class="showChat ? 'lg:basis-1/4' : 'lg:basis-0'"
-                 class="z-20 basis-full order-3 border rounded p-1 mx-5 bg-gray-100 dark:bg-gray-800 dark:border-0 lg:border-0 lg:shadow lg:order-none lg:mx-0 lg:p-0 lg:bg-transparent">
-                <div id="chat-box" class="bg-white rounded lg:bg-transparent md:rounded-0 dark:bg-secondary">
+                 class="z-20 basis-full order-3 border rounded p-1 mx-5 bg-gray-100 dark:bg-gray-800 dark:border-0 lg:h-16/6 h-96
+                        lg:border-0 lg:shadow lg:order-none lg:mx-0 lg:p-0 lg:bg-transparent">
+                <div id="chat-box" class="bg-white rounded lg:bg-transparent md:rounded-0 dark:bg-secondary h-full">
                     {{template "chat" .ChatData}}
                 </div>
             </div>
@@ -284,7 +289,7 @@
         <!-- Video description -->
         {{$less := gt (len .Description) .CutOffLength}}
         <div x-data="{ less: {{$less}}, toggleDesc: true }"
-             {{/* Update less on update */}}
+                {{/* Update less on update */}}
              @descriptionupdate.window="toggleDesc = less = $event.detail.description.full.length > {{.CutOffLength}};"
              class="video-description flex-grow p-5 basis-full lg:order-none order-5">
             <div class="flex justify-between border-b mb-1 dark:border-gray-800 lg:justify-start">
@@ -293,11 +298,11 @@
             <div>
                 <div class="rounded-lg bg-gray-50 hover:bg-gray-100 dark:bg-gray-800 hover:dark:bg-secondary text-3 text-sm">
                     <button @click="toggleDesc = !toggleDesc;"
-                         :disabled="!less"
-                         class="p-2 w-full text-left"
-                        :class="less && 'hover:cursor-pointer'">
+                            :disabled="!less"
+                            class="p-2 w-full text-left"
+                            :class="less && 'hover:cursor-pointer'">
                         <span class="block overflow-y-clip"
-                                :class="(less && toggleDesc) ? 'h-8' : 'h-auto'"
+                              :class="(less && toggleDesc) ? 'h-8' : 'h-auto'"
                               @descriptionupdate.window="$el.innerHTML=$event.detail.description.full">
                             {{.Description}}
                         </span>

--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -3,38 +3,6 @@ import { NewChatMessage } from "./chat/NewChatMessage";
 import { getPlayer } from "./TUMLiveVjs";
 import { Realtime } from "./socket";
 
-export class Watch {
-    private readonly player: HTMLElement;
-    private chat: HTMLElement;
-
-    constructor() {
-        this.player = document.getElementById("watchContent");
-        this.chat = document.getElementById("chat-box");
-        this.attachListener();
-        this.resizeChat();
-    }
-
-    private attachListener() {
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        const that = this;
-        window.addEventListener("resize", function () {
-            that.resizeChat();
-        });
-    }
-
-    private resizeChat() {
-        if (this.chat == null || this.player == null) {
-            return;
-        }
-        /* :md breakpoint */
-        if (window.innerWidth > 768) {
-            this.chat.style.height = `${this.player.getBoundingClientRect().height}px`;
-        } else {
-            this.chat.style.height = "640px";
-        }
-    }
-}
-
 let currentChatChannel = "";
 const retryInt = 5000; //retry connecting to websocket after this timeout
 


### PR DESCRIPTION
### Motivation and Context
- When the chat was opened the player height wasn't optimal. 
- The like count of chat messages looked like a button.
- The hover menu causes problems mobile and in the popout chat.

### Description
- Remove ts height adjusting of chat and add css class to solve that problem.
- Change the Like-display to a Like-button.
- Remove hover menu and add "Admin Tool"-Button
- Hide description if empty

### Steps for Testing
- 1 Lecturer
- 2 Students
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Write, Like. Approve, Delete as you wish!
4. Make sure to test the mobile and popout version.

### Screenshots
<img width="1643" alt="image" src="https://user-images.githubusercontent.com/29633518/200504952-605be35c-00b3-47b5-a493-51249d83bc0b.png">

https://user-images.githubusercontent.com/29633518/200505524-cdbbede1-2aa8-431a-89d4-f4287c3592d3.mov


