### PR TITLE
Remove 'paused' banner

### DIFF
--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -44,10 +44,6 @@
                  class="grow w-full h-full">
 
                 <!-- info messages -->
-                <div class="bg-indigo-700 bg-opacity-20 border-t-4 border-indigo-700 w-full font-semibold text-2 rounded-t display-none"
-                     x-show="paused" x-cloak>
-                    <i class="fas fa-info-circle"></i> This lecture is currently paused.
-                </div>
                 <div x-data="{ showliveended: false }"
                      class="bg-red-700 bg-opacity-20 p-2 w-full font-semibold text-2"
                      x-show="showliveended" @streamended.window="showliveended=true" x-cloak>


### PR DESCRIPTION
### Motivation and Context
Pause doesn't exist anymore.

### Description
This PR removes the 'paused' banner.

### Steps for Testing
Prerequisites:
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. The console should not print an error message. (Screenshot)

### Screenshots
<img width="843" alt="Screenshot 2022-11-14 at 06 33 05" src="https://user-images.githubusercontent.com/29633518/201586524-47b8c524-5173-4c59-8376-e9190e539842.png">

