### PR TITLE
Fix @-ing others

### DIFF
--- a/web/template/partial/stream/chat/chat.gohtml
+++ b/web/template/partial/stream/chat/chat.gohtml
@@ -8,8 +8,8 @@
     {{$userName := ""}}
     {{$userId := 0}}
     {{if .IndexData.TUMLiveContext.User}}
-        {{$userName := .IndexData.TUMLiveContext.User.Name}}
-        {{$userId := .IndexData.TUMLiveContext.User.ID}}
+        {{$userName = .IndexData.TUMLiveContext.User.Name}}
+        {{$userId = .IndexData.TUMLiveContext.User.ID}}
     {{end}}
     <div x-cloak
          x-data="watch.initChat({{.IsAdminOfCourse}}, {{$stream.ID}}, '{{$startTime}}', '{{$liveNowTimestamp}}', {{$userId}}, '{{$userName}}', {{not (or $isComingUp $liveNow .IsPopUp)}});"
@@ -26,8 +26,8 @@
          x-on:polloptionresult.window="e => c.onPollOptionResult(e);"
          x-on:wsrealtimeconnectionchange.window="e => c.disconnected = !e.detail.status;"
          @chatpopupmessageupdate.window="e => initPromise.next(() => c.onPopUpMessagesUpdated(e));"
-         @chatupdategrayedout.window = "e => c.onGrayedOutUpdated(e);"
-         @chatupdatefocus.window = "e => c.onFocusUpdated(e);"
+         @chatupdategrayedout.window="e => c.onGrayedOutUpdated(e);"
+         @chatupdatefocus.window="e => c.onFocusUpdated(e);"
          @disconnected.window="c.disconnected = true;"
          @connected.window="c.disconnected = false;"
          @reorder="c.sortMessages()"
@@ -119,7 +119,7 @@
                     <div class="flex align-middle justify-between px-3 dark:border-gray-600"
                          :class="showPoll && 'border-b pb-2'">
                         <span class="text-xs uppercase font-semibold my-auto">Active Poll</span>
-                        <button @click="showPoll = !showPoll" class = "text-xs">
+                        <button @click="showPoll = !showPoll" class="text-xs">
                             <i class="fa-solid" :class="showPoll ? 'fa-chevron-up' : 'fa-chevron-down'"></i>
                         </button>
                     </div>
@@ -153,7 +153,7 @@
                     <div class="flex align-middle justify-between px-3 dark:border-secondary-light"
                          :class="showPoll && 'border-b pb-2'">
                         <span class="relative text-xs uppercase font-semibold my-auto">Active Poll</span>
-                        <button @click="showPoll = !showPoll" class = "text-xs">
+                        <button @click="showPoll = !showPoll" class="text-xs">
                             <i class="fa-solid" :class="showPoll ? 'fa-chevron-up' : 'fa-chevron-down'"></i>
                         </button>
                     </div>
@@ -231,7 +231,7 @@
                     <div :class="(c.users.isValid() || c.poll.showCreateUI || c.emojis.isValid()) && 'border-t dark:border-gray-800'">
                         <!-- create poll dialog -->
                         <template x-if="c.poll.showCreateUI">
-                            <div class = 'px-2 pb-2'>
+                            <div class='px-2 pb-2'>
                                 <div class="flex justify-end p-1">
                                     <button class="flex bg-transparent border-0 font-semibold py-1 px-2 rounded hover:dark:bg-gray-600 hover:bg-gray-200 my-auto"
                                             @click="c.poll.showCreateUI = !c.poll.showCreateUI; c.poll.reset();"
@@ -257,7 +257,7 @@
                                     <template x-for="(pollOption, index) in c.poll.options" :key="index">
                                         <div class="flex-1 bg-gray-200 dark:bg-gray-600 rounded-lg flex border-2 border-transparent w-full lg:mr-2 my-2">
                                             <input :id="$id('poll-answer')"
-                                                    placeholder="Write a Poll-Answer ..." maxlength="240"
+                                                   placeholder="Write a Poll-Answer ..." maxlength="240"
                                                    x-model="pollOption.answer"
                                                    class="bg-transparent w-full py-2 px-4 border-0 text-sm font-normal placeholder:text-sm focus:outline-none">
 
@@ -360,7 +360,9 @@
                                     type="submit"
                                     {{if not (.IndexData.TUMLiveContext.User)}} disabled {{end}}
                                     :disabled="c.current.isEmpty() || c.disconnected">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="" class="bi bi-send-fill rotate-45 fill-blue-500 hover:fill-blue-600 dark:fill-indigo-600 hover:dark:fill-indigo-700" viewBox="0 0 16 16">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill=""
+                                     class="bi bi-send-fill rotate-45 fill-blue-500 hover:fill-blue-600 dark:fill-indigo-600 hover:dark:fill-indigo-700"
+                                     viewBox="0 0 16 16">
                                     <path d="M15.964.686a.5.5 0 0 0-.65-.65L.767 5.855H.766l-.452.18a.5.5 0 0 0-.082.887l.41.26.001.002 4.995 3.178 3.178 4.995.002.002.26.41a.5.5 0 0 0 .886-.083l6-15Zm-1.833 1.89L6.637 10.07l-.215-.338a.5.5 0 0 0-.154-.154l-.338-.215 7.494-7.494 1.178-.471-.47 1.178Z"/>
                                 </svg>
                             </button>


### PR DESCRIPTION
### Motivation and Context
@-ing doesn't work at the moment. Usernames aren't highlighted anymore. This PR fixes that.


### Description
Update gohtml template: use `=` instead of `:=`. 
Explanation: `:=` didn't overwrite the default values.

### Steps for Testing
- 1 Accounts
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. @ the other accounts. Names should be highlighted again.
