### PR TITLE
Only consider recordings for hiding watched streams

### DIFF
--- a/web/course.go
+++ b/web/course.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"github.com/joschahenningsen/TUM-Live/model"
 	"github.com/joschahenningsen/TUM-Live/tools"
+	log "github.com/sirupsen/logrus"
 	"html/template"
 	"net/http"
-
-	log "github.com/sirupsen/logrus"
 
 	"github.com/getsentry/sentry-go"
 	sentrygin "github.com/getsentry/sentry-go/gin"
@@ -171,17 +170,19 @@ func (r mainRoutes) CoursePage(c *gin.Context) {
 
 	// watchedStateData is used by the client to track the which VoDs are watched.
 	type watchedStateData struct {
-		ID      uint   `json:"streamID"`
-		Month   string `json:"month"`
-		Watched bool   `json:"watched"`
+		ID        uint   `json:"streamID"`
+		Month     string `json:"month"`
+		Watched   bool   `json:"watched"`
+		Recording bool   `json:"recording"`
 	}
 
 	var clientWatchState = make([]watchedStateData, 0)
 	for _, s := range streamsWithWatchState {
 		clientWatchState = append(clientWatchState, watchedStateData{
-			ID:      s.Model.ID,
-			Month:   s.Start.Month().String(),
-			Watched: s.Watched,
+			ID:        s.Model.ID,
+			Month:     s.Start.Month().String(),
+			Watched:   s.Watched,
+			Recording: s.Recording,
 		})
 	}
 	// Create JSON encoded info about which streamsWithWatchState are watched. Used by the client to track the watched status.

--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -77,7 +77,7 @@
     <div class="m-auto flex flex-wrap pb-3 md:h-5/6 md:grid md:grid-rows-6 md:grid-cols-5 md:gap-4 md:pb-0">
         <!-- VoD -->
         <div {{if .IndexData.TUMLiveContext}}x-init="watchedTracker.init({{.WatchedData}})"
-             x-data="watchedTracker = new global.WatchedTracker" {{end}}class="w-full md:row-span-6 md:col-span-3">
+             x-data="watchedTracker = new global.WatchedTracker()" {{end}}class="w-full md:row-span-6 md:col-span-3">
             <div x-data="{asc: $persist(false), mirror: () => { global.mirror($el.querySelector('.vod-list'), ['.vod-list-month', '.vod-list-video']); }
                     {{if .IndexData.TUMLiveContext.User}}, filterWatched: $persist(false), watchedAll: watchedTracker.userWatchedAll(), watchedCount: watchedTracker.countWatched(){{end}}}"
                  class="bg-white h-full border dark:bg-secondary dark:border-gray-800 rounded-lg

--- a/web/ts/course-overview.ts
+++ b/web/ts/course-overview.ts
@@ -4,8 +4,8 @@ import { postData, showMessage } from "./global";
 type UserStream = {
     streamID: number;
     month: string;
-    progress: number;
     watched: boolean;
+    recording: boolean;
 };
 
 export function watchedTracker(): { m: WatchedTracker } {
@@ -35,7 +35,9 @@ export class WatchedTracker {
     }
 
     userWatchedMonth(month: string): boolean {
-        const unwatchedStreamIndex = this.streams?.filter((s) => s.month === month).findIndex((s) => !s.watched);
+        const unwatchedStreamIndex = this.streams
+            ?.filter((s) => s.month === month && s.recording)
+            .findIndex((s) => !s.watched);
         return unwatchedStreamIndex === -1;
     }
 
@@ -44,6 +46,6 @@ export class WatchedTracker {
     }
 
     userWatchedAll(): boolean {
-        return this.streams?.findIndex((s) => !s.watched) === -1;
+        return this.streams?.findIndex((s) => !s.watched && s.recording) === -1;
     }
 }


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We also load future streams into the VoD list. This breaks the behavior of hiding months or showing the `All VoDs watched` message.

### Description
By also checking whether a stream is a recording this should be fixed, as the recordings are what the user sees in VoD list.
I am not sure why also get future lectures but this should work regardless of what other lectures we load.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Livestream with VoDs and upcoming streams
- Any account will do

1. Log in
2. Navigate to the course page of a stream with some VoDs
3. Check that the most recent month that should have additional future lectures is hidden
4. Check that `All VoDs watched` appears when all VoDs are marked as watched.

