### PR TITLE
Add katex to pop-out

### DIFF
--- a/web/template/popup-chat.gohtml
+++ b/web/template/popup-chat.gohtml
@@ -8,6 +8,12 @@
     <title>{{.IndexData.Branding.Title}} | {{$course.Name}}: {{$stream.Name}}</title>
     {{template "headImports" .IndexData.VersionTag}}
     <script src="/static/assets/ts-dist/watch.bundle.js?v={{.IndexData.VersionTag}}"></script>
+    {{if $stream.ChatEnabled}}
+        <link rel="stylesheet" href="/static/node_modules/katex/dist/katex.min.css">
+        <script defer src="/static/node_modules/katex/dist/katex.js"></script>
+        <script defer src="/static/node_modules/katex/dist/contrib/auto-render.min.js"></script>
+        <script defer src="/static/node_modules/katex/dist/contrib/copy-tex.min.js"></script>
+    {{end}}
 </head>
 <body x-init="watch.startWebsocket()"
       class="bg-white dark:bg-secondary h-screen overflow-hidden">


### PR DESCRIPTION
### Motivation and Context
Latex doesn't work in the popout chat. The dependencies are missing.

### Description
Add dependencies.

### Steps for Testing
- 1 Lecturer
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Pop out chat
4. Write latex

### Screenshots
<img width="507" alt="image" src="https://user-images.githubusercontent.com/29633518/203034706-4d1c88c0-de1e-4f62-8565-35c0f72f5207.png">
