### PR TITLE
course admin: use entire width of page on mobile

### DIFF
--- a/.github/workflows/pr_closed.yml
+++ b/.github/workflows/pr_closed.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - name: Remove Testserver
         run: |
-          curl -X POST https://update.test.live.mm.rbg.tum.de/remove?num=${{ github.event.number }}&token=${{ secrets.TESTSERVER_UPDATER_SECRET }}
+          curl -X POST -H "Authorization: Token ${{ secrets.TESTSERVER_UPDATER_SECRET }}" https://update.test.live.mm.rbg.tum.de/remove?num=${{ github.event.number }}

--- a/.github/workflows/ts-deploy.yml
+++ b/.github/workflows/ts-deploy.yml
@@ -70,4 +70,4 @@ jobs:
           labels: ${{ steps.metaWorker.outputs.labels }}
       - name: Pull new Container
         run: |
-          curl -X POST -H "Content-Type: application/json" -H "Authorization: Token ${{ secrets.TESTSERVER_UPDATER_SECRET }}" -d '${{ toJSON(steps.meta.outputs) }}' https://update.test.live.mm.rbg.tum.de/add?num=${{ github.event.number }}&token=${{ secrets.TESTSERVER_UPDATER_SECRET }}
+          curl -X POST -H "Content-Type: application/json" -H "Authorization: Token ${{ secrets.TESTSERVER_UPDATER_SECRET }}" -d '${{ toJSON(steps.meta.outputs) }}' https://update.test.live.mm.rbg.tum.de/add?num=${{ github.event.number }}

--- a/.github/workflows/ts-deploy.yml
+++ b/.github/workflows/ts-deploy.yml
@@ -70,4 +70,4 @@ jobs:
           labels: ${{ steps.metaWorker.outputs.labels }}
       - name: Pull new Container
         run: |
-          curl -X POST -H "Content-Type: application/json" -d '${{ toJSON(steps.meta.outputs) }}' https://update.test.live.mm.rbg.tum.de/add?num=${{ github.event.number }}&token=${{ secrets.TESTSERVER_UPDATER_SECRET }}
+          curl -X POST -H "Content-Type: application/json" -H "Authorization: Token ${{ secrets.TESTSERVER_UPDATER_SECRET }}" -d '${{ toJSON(steps.meta.outputs) }}' https://update.test.live.mm.rbg.tum.de/add?num=${{ github.event.number }}&token=${{ secrets.TESTSERVER_UPDATER_SECRET }}

--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -102,7 +102,7 @@
     }
 
     .form-container {
-        @apply mx-auto w-4/5 my-10 shadow rounded-lg border bg-white dark:border-gray-800 dark:bg-secondary-light;
+        @apply mx-auto w-full md:w-4/5 my-2 md:my-10 shadow rounded-lg border bg-white dark:border-gray-800 dark:bg-secondary-light;
     }
 
     .form-container-title {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently lots of space is wasted with margin on mobile on the course admin page.

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
This pr removes the margin for small devices


### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Lecturer

1. Check that the course admin page looks nice on all screen sizes

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->

before | after
--- | ---
![image](https://user-images.githubusercontent.com/44805696/203560152-5f4ae130-9b1c-49f9-bb6d-86b66e8aa214.png) |![image](https://user-images.githubusercontent.com/44805696/203560276-264d2b08-be0d-48aa-84cb-f7e87b3c4c99.png)

