### PR TITLE
Share at timestamp

### DIFF
--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -131,7 +131,11 @@
 }
 
 .tl-input {
-    @apply w-full h-12 px-3 bg-gray-50 dark:bg-gray-600 dark:text-white rounded shadow-sm;
+    @apply w-full h-12 px-3 bg-gray-50 dark:bg-gray-600 dark:text-white rounded shadow-sm outline-0 border-0;
+}
+
+.tl-input:focus{
+    @apply outline-2 outline-blue-500 dark:outline-indigo-600 border-0;
 }
 
 .tl-choose-file::-webkit-file-upload-button {

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -38,7 +38,7 @@
                 <h3 class="text-3 text-sm font-semibold">Share</h3>
                 <button type="button" title="close share modal"
                         @click="showShare=false;">
-                    <i class="fa-solid fa-x text-3"></i>
+                    <i class="fa-solid fa-xmark text-3"></i>
                 </button>
             </div>
             <div class="pt-1 pb-3 px-3 mt-3">
@@ -48,8 +48,8 @@
                            class="bg-transparent outline-0 border-0 text-left text-5 grow" :value="share.url" disabled>
                     <button type="button" @click="share.copyURL()"
                             class="text-xs text-white rounded-full px-3 py-1 h-fit w-fit bg-blue-500 dark:bg-indigo-600 hover:bg-blue-600 dark:hover:bg-indigo-700">
-                        <i class="fa-solid fa-clipboard mr-2"></i>
-                        Copy
+                        <i class="fa-solid mr-2" :class="share.copied ? 'fa-check' : 'fa-clipboard'"></i>
+                        <span x-text="share.copied ? 'Copied' : 'Copy'"></span>
                     </button>
                 </div>
                 {{if not $stream.LiveNow}}

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -20,13 +20,49 @@
         <script defer src="/static/node_modules/katex/dist/contrib/copy-tex.min.js"></script>
     {{end}}
 </head>
-<body x-data="{'streamID': {{$stream.Model.ID}}, 'showChat': $persist(false).as('chatOpen'), seekLogger: new watch.SeekLogger('{{$stream.ID}}')}"
+<body x-data="{'streamID': {{$stream.Model.ID}}, 'showChat': $persist(false).as('chatOpen'), seekLogger: new watch.SeekLogger('{{$stream.ID}}'), showShare: false}"
       @keypress.shift.window="(e) => watch.onShift(e)"
       x-init="watch.startWebsocket(); seekLogger.attach();">
 {{template "header" .IndexData.TUMLiveContext}}
-<div id="shortcuts-help-modal" class="hidden flex absolute top-0 h-screen w-screen z-50 backdrop-blur-sm">
+<div id="shortcuts-help-modal" class="hidden flex absolute top-0 h-screen w-screen z-50 backdrop-brightness-50">
     <div class="m-auto" @click.outside="watch.toggleShortcutsModal();">
         {{template "shortcuts"}}
+    </div>
+</div>
+<div x-cloak x-show="showShare"
+     id="share-modal" class="flex absolute top-0 h-screen w-screen z-50 backdrop-brightness-50">
+    <div class="m-auto lg:w-1/2 w-3/4" @click.outside="showShare = false;">
+        <div x-data="{share: new watch.ShareURL()}"
+             class="bg-white dark:bg-secondary-light border dark:border-gray-800 rounded-lg">
+            <div class="flex justify-between items-center px-3 pt-3 pb-1">
+                <h3 class="text-3 text-sm font-semibold">Share</h3>
+                <button type="button" title="close share modal"
+                        @click="showShare=false;">
+                    <i class="fa-solid fa-x text-3"></i>
+                </button>
+            </div>
+            <div class="pt-1 pb-3 px-3 mt-3">
+                <span class="font-light text-xs mb-1 text-4">URL</span>
+                <div class = "flex items-center justify-between tl-input text-sm">
+                    <input id="share-url" type="text"
+                           class="bg-transparent outline-0 border-0 text-left text-5 grow" :value="share.url" disabled>
+                    <button type="button" @click="share.copyURL()"
+                            class="text-xs text-white rounded-full px-3 py-1 h-fit w-fit bg-blue-500 dark:bg-indigo-600 hover:bg-blue-600 dark:hover:bg-indigo-700">
+                        <i class="fa-solid fa-clipboard mr-2"></i>
+                        Copy
+                    </button>
+                </div>
+                {{if not $stream.LiveNow}}
+                    <div class="flex justify-start items-center pt-2">
+                        <input id="include-timestamp" type="checkbox" class="h-8 hover:cursor-pointer"
+                               x-model="share.includeTimestamp" @change="share.setTimestamp();share.setURL()">
+                        <label for="include-timestamp" class="font-light text-4 text-xs ml-2">Include Timestamp</label>
+                        <input x-cloak x-show="share.includeTimestamp" class="tl-input h-8 w-20 text-xs ml-2"
+                               type="text" x-model="share.timestamp" @input="share.setURL()">
+                    </div>
+                {{end}}
+            </div>
+        </div>
     </div>
 </div>
 <div id="watchPageMainWrapper" class="lg:px-5 lg:pb-1">
@@ -184,6 +220,12 @@
                             </a>
                         {{end}}
 
+                        <button @click="showShare = true;"
+                                class="rounded-lg px-4 py-2 h-fit w-fit bg-gray-100 hover:bg-gray-200 dark:bg-secondary-light dark:hover:bg-gray-600"
+                                :title="'Share'">
+                            <i class="fa-solid fa-share text-4"></i>
+                        </button>
+
                         <!-- Actions-->
                         {{template "actions" .}}
 
@@ -285,32 +327,32 @@
         {{$less := gt (len .Description) .CutOffLength}}
         {{if gt (len .Description) 0}}
             <div x-data="{ less: {{$less}}, toggleDesc: true }"
-                {{/* Update less on update */}}
-             @descriptionupdate.window="toggleDesc = less = $event.detail.description.full.length > {{.CutOffLength}};"
-             class="video-description flex-grow p-5 basis-full lg:order-none order-5">
-            <div class="flex justify-between border-b mb-1 dark:border-gray-800 lg:justify-start">
-                <h3 class="text-4 font-semibold">Description</h3>
-            </div>
-            <div>
-                <div class="rounded-lg bg-gray-50 hover:bg-gray-100 dark:bg-gray-800 hover:dark:bg-secondary text-3 text-sm">
-                    <button @click="toggleDesc = !toggleDesc;"
-                            :disabled="!less"
-                            class="p-2 w-full text-left"
-                            :class="less && 'hover:cursor-pointer'">
+                    {{/* Update less on update */}}
+                 @descriptionupdate.window="toggleDesc = less = $event.detail.description.full.length > {{.CutOffLength}};"
+                 class="video-description flex-grow p-5 basis-full lg:order-none order-5">
+                <div class="flex justify-between border-b mb-1 dark:border-gray-800 lg:justify-start">
+                    <h3 class="text-4 font-semibold">Description</h3>
+                </div>
+                <div>
+                    <div class="rounded-lg bg-gray-50 hover:bg-gray-100 dark:bg-gray-800 hover:dark:bg-secondary text-3 text-sm">
+                        <button @click="toggleDesc = !toggleDesc;"
+                                :disabled="!less"
+                                class="p-2 w-full text-left"
+                                :class="less && 'hover:cursor-pointer'">
                         <span class="block overflow-y-clip"
                               :class="(less && toggleDesc) ? 'h-8' : 'h-auto'"
                               @descriptionupdate.window="$el.innerHTML=$event.detail.description.full">
                             {{.Description}}
                         </span>
-                    </button>
-                    <template x-if="less">
-                        <button class="font-semibold m-1 py-1 px-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
-                                x-text="toggleDesc ? 'Show more' : 'Show less'"
-                                @click="toggleDesc = !toggleDesc;"></button>
-                    </template>
+                        </button>
+                        <template x-if="less">
+                            <button class="font-semibold m-1 py-1 px-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
+                                    x-text="toggleDesc ? 'Show more' : 'Show less'"
+                                    @click="toggleDesc = !toggleDesc;"></button>
+                        </template>
+                    </div>
                 </div>
             </div>
-        </div>
         {{end}}
 
         <!-- Modal when stopping a stream -->

--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -1,4 +1,4 @@
-import { postData } from "./global";
+import { getQueryParam, postData } from "./global";
 import { VideoSectionList } from "./video-sections";
 import { StatusCodes } from "http-status-codes";
 import videojs from "video.js";
@@ -210,10 +210,16 @@ export const watchProgress = function (streamID: number, lastProgress: number) {
         let iOSReady = false;
         let intervalMillis = 10000;
 
+        const t: number = +getQueryParam("t");
+
         // Fetch the user's video progress from the database and set the time in the player
         player.on("loadedmetadata", () => {
             duration = player.duration();
-            player.currentTime(lastProgress * duration);
+            if (t !== undefined && !videojs.browser.IS_IOS) {
+                player.currentTime(t);
+            } else {
+                player.currentTime(lastProgress * duration);
+            }
         });
 
         // iPhone/iPad need to set the progress again when they actually play the video. That's why loadedmetadata is

--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -199,6 +199,7 @@ export const skipSilence = function (options) {
 /**
  * @function watchProgress
  * Saves and retrieves the watch progress of the user as a fraction of the total watch time
+ * If query parameter 't' is specified, the timestamp given by 't' will be used.
  * @param streamID The ID of the currently watched stream
  * @param lastProgress The last progress fetched from the database
  */
@@ -209,17 +210,13 @@ export const watchProgress = function (streamID: number, lastProgress: number) {
         let timer;
         let iOSReady = false;
         let intervalMillis = 10000;
-
-        const t: number = +getQueryParam("t");
+        let jumpTo: number;
 
         // Fetch the user's video progress from the database and set the time in the player
         player.on("loadedmetadata", () => {
             duration = player.duration();
-            if (t !== undefined && !videojs.browser.IS_IOS) {
-                player.currentTime(t);
-            } else {
-                player.currentTime(lastProgress * duration);
-            }
+            jumpTo = +getQueryParam("t") || lastProgress * duration;
+            player.currentTime(jumpTo);
         });
 
         // iPhone/iPad need to set the progress again when they actually play the video. That's why loadedmetadata is
@@ -229,7 +226,7 @@ export const watchProgress = function (streamID: number, lastProgress: number) {
             player.on("canplaythrough", () => {
                 // Can be executed multiple times during playback
                 if (!iOSReady) {
-                    player.currentTime(lastProgress * duration);
+                    player.currentTime(jumpTo);
                     iOSReady = true;
                 }
             });

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -258,6 +258,10 @@ export function getLoginReferrer(): string {
     return document.referrer;
 }
 
+export function getQueryParam(name: string): string {
+    return new URL(window.location.href).searchParams.get(name) ?? undefined;
+}
+
 // TypeScript Mapping of model.VideoSection
 export type Section = {
     ID?: number;

--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -280,10 +280,13 @@ export class ShareURL {
     timestamp: string;
     openTime: number;
 
+    copied: boolean; // success indicator
+
     constructor() {
-        this.baseUrl = [location.protocol, "//", location.host, location.pathname].join("");
+        this.baseUrl = [location.protocol, "//", location.host, location.pathname].join(""); // get rid of query
         this.url = this.baseUrl;
         this.includeTimestamp = false;
+        this.copied = false;
 
         const player = getPlayer();
         player.ready(() => {
@@ -293,27 +296,31 @@ export class ShareURL {
         });
     }
 
-    show(b: boolean) {}
-
     copyURL() {
         copyToClipboard(this.url);
+        this.copied = true;
+        setTimeout(() => (this.copied = false), 3000);
     }
 
     setURL() {
-        const trim = this.timestamp.substring(0, 9);
-        const split = trim.split(":");
-        if (split.length != 3) {
-            this.url = this.baseUrl;
-        } else {
-            const h = +split[0];
-            const m = +split[1];
-            const s = +split[2];
-            if (isNaN(h) || isNaN(m) || isNaN(s) || h > 60 || m > 60 || s > 60 || h < 0 || m < 0 || s < 0) {
+        if (this.includeTimestamp) {
+            const trim = this.timestamp.substring(0, 9);
+            const split = trim.split(":");
+            if (split.length != 3) {
                 this.url = this.baseUrl;
             } else {
-                const inSeconds = s + 60 * m + 60 * 60 * h;
-                this.url = `${this.baseUrl}?t=${inSeconds}`;
+                const h = +split[0];
+                const m = +split[1];
+                const s = +split[2];
+                if (isNaN(h) || isNaN(m) || isNaN(s) || h > 60 || m > 60 || s > 60 || h < 0 || m < 0 || s < 0) {
+                    this.url = this.baseUrl;
+                } else {
+                    const inSeconds = s + 60 * m + 60 * 60 * h;
+                    this.url = `${this.baseUrl}?t=${inSeconds}`;
+                }
             }
+        } else {
+            this.url = this.baseUrl;
         }
     }
 

--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -2,6 +2,7 @@ import { scrollChat, shouldScroll, showNewMessageIndicator } from "./chat";
 import { NewChatMessage } from "./chat/NewChatMessage";
 import { getPlayer } from "./TUMLiveVjs";
 import { Realtime } from "./socket";
+import { copyToClipboard } from "./global";
 
 let currentChatChannel = "";
 const retryInt = 5000; //retry connecting to websocket after this timeout
@@ -268,5 +269,66 @@ export function toggleShortcutsModal() {
         } else {
             el.classList.add("hidden");
         }
+    }
+}
+
+export class ShareURL {
+    private baseUrl: string;
+
+    url: string;
+    includeTimestamp: boolean;
+    timestamp: string;
+    openTime: number;
+
+    constructor() {
+        this.baseUrl = [location.protocol, "//", location.host, location.pathname].join("");
+        this.url = this.baseUrl;
+        this.includeTimestamp = false;
+
+        const player = getPlayer();
+        player.ready(() => {
+            player.on("loadedmetadata", () => {
+                this.openTime = player.currentTime();
+            });
+        });
+    }
+
+    show(b: boolean) {}
+
+    copyURL() {
+        copyToClipboard(this.url);
+    }
+
+    setURL() {
+        const trim = this.timestamp.substring(0, 9);
+        const split = trim.split(":");
+        if (split.length != 3) {
+            this.url = this.baseUrl;
+        } else {
+            const h = +split[0];
+            const m = +split[1];
+            const s = +split[2];
+            if (isNaN(h) || isNaN(m) || isNaN(s) || h > 60 || m > 60 || s > 60 || h < 0 || m < 0 || s < 0) {
+                this.url = this.baseUrl;
+            } else {
+                const inSeconds = s + 60 * m + 60 * 60 * h;
+                this.url = `${this.baseUrl}?t=${inSeconds}`;
+            }
+        }
+    }
+
+    setTimestamp() {
+        const d = new Date(this.openTime * 1000);
+        const h = ShareURL.padZero(d.getUTCHours());
+        const m = ShareURL.padZero(d.getUTCMinutes());
+        const s = ShareURL.padZero(d.getSeconds());
+        this.timestamp = `${h}:${m}:${s}`;
+    }
+
+    private static padZero(i) {
+        if (i < 10) {
+            i = "0" + i;
+        }
+        return i;
     }
 }


### PR DESCRIPTION
### Motivation and Context
#777 removed the query parameter `t` since it caused problems on iOS/iPadOS devices. This PR adds this feature again, but this time the player should still work on iOS and iPadOS.


### Description
Add query `?t=1337` back to the watch page. Additionally, add a share dialog. (See screenshots)

### Steps for Testing
- 1 Account
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Copy the stream-link with the new share-dialog.
4. Head to another tab/browser. Paste link.
5. **Test on iOS/iPadOS and/or Safari with an without query parameter `t`**

### Screenshots
<div style='display:flex'>
<img width="320" alt="Screenshot 2022-11-29 at 12 33 08" src="https://user-images.githubusercontent.com/29633518/204518500-f16f492d-cfe2-4605-a5f3-f81d179b476a.png">
<img width="320" alt="Screenshot 2022-11-29 at 12 32 59" src="https://user-images.githubusercontent.com/29633518/204518510-2f16247d-4eda-40bb-be03-8eecf1cac37d.png">

</div>
