### PR TITLE
Info Pages Admin UI

### DIFF
--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -97,10 +97,6 @@
         @apply text-gray-500 dark:hover:text-white hover:text-black hover:underline;
     }
 
-    .btn:disabled {
-        @apply dark:text-gray-400 dark:hover:bg-gray-600 dark:bg-gray-600 text-gray-500 hover:bg-gray-200 bg-gray-200;
-    }
-
     .form-container {
         @apply mx-auto w-full md:w-4/5 my-2 md:my-10 shadow rounded-lg border bg-white dark:border-gray-800 dark:bg-secondary-light;
     }
@@ -113,12 +109,20 @@
         @apply py-2 px-5 grid gap-3;
     }
 
+    .form-container-footer {
+        @apply text-3 border-t py-2 px-5 dark:border-gray-800;
+    }
+
     .form-container-body h2 {
         @apply text-sm text-5;
     }
 
     .btn {
-        @apply text-center transition-colors bg-gray-500 text-white hover:text-white hover:bg-gray-600 dark:bg-gray-800 dark:hover:bg-primary dark:text-white w-full p-2 cursor-pointer rounded shadow-sm font-bold;
+        @apply p-2 cursor-pointer rounded shadow-sm text-center text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 font-bold rounded-lg text-sm px-5 py-2.5 dark:bg-gray-800 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:focus:ring-gray-700;
+    }
+
+    .btn:disabled {
+        @apply text-center text-gray-900 bg-white border border-gray-300 focus:outline-none focus:ring-4 focus:ring-gray-200 font-bold rounded-lg px-5 py-2.5 dark:bg-white dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:focus:ring-gray-700
     }
 
     .primary {

--- a/web/template/admin/admin_tabs/info-pages.gohtml
+++ b/web/template/admin/admin_tabs/info-pages.gohtml
@@ -1,5 +1,5 @@
 {{define "info-pages"}}
-    <h2 class="text-2xl text-1 my-auto mt-4 font-medium">Maintenance</h2>
+    <h2 class="text-2xl text-1 my-auto mt-4 font-medium">Info Pages</h2>
     {{- /*gotype: github.com/joschahenningsen/TUM-Live/[]model.Text*/ -}}
     <div class="grid gap-2 pt-5">
         {{range $i, $text := .}}

--- a/web/template/admin/admin_tabs/info-pages.gohtml
+++ b/web/template/admin/admin_tabs/info-pages.gohtml
@@ -1,54 +1,95 @@
 {{define "info-pages"}}
+    <h2 class="text-2xl text-1 my-auto mt-4 font-medium">Maintenance</h2>
     {{- /*gotype: github.com/joschahenningsen/TUM-Live/[]model.Text*/ -}}
-    <div class="dark:bg-secondary bg-white p-4 shadow rounded my-6 overflow-x-auto">
-        <h2 class="text-2xl font-bold text-1 mb-3">Texts</h2>
-        <div class="grid gap-2">
-            {{range $i, $text := .}}
-                {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.Text*/ -}}
-                <div x-data="{editOpen: false, oldName: '{{$text.Name}}', name:'', oldContent: `{{$text.RawContent}}`, newContent: ''}"
-                     x-init="newContent=oldContent;name=oldName"
-                     class="border dark:border-gray-800 rounded-lg h-fit"
-                     :class="editOpen && 'shadow'">
-                    <div class="flex p-3 rounded-lg" :class="editOpen && 'outline outline-2 outline-blue-500/50'">
-                        <label for="content-{{$i}}" class="hidden">{{$text.Name}}</label>
-                        <input x-model="name"
-                               class="flex border-0 text-3 text-lg my-auto p-0 w-1/2 rounded-lg disabled:bg-transparent"
-                               :disabled="!editOpen">
-                        <div class="flex my-auto ml-auto space-x-3">
-                            <div x-show="oldContent !== newContent || oldName !== name"
-                                 class="flex my-auto px-2 py-1 border border-amber-200 bg-amber-200/50 rounded">
-                                <i class="fa fa-triangle-exclamation mr-1"></i>
-                                <span class="text-xs font-light text-3">Unsaved Changes</span>
+    <div class="grid gap-2 pt-5">
+        {{range $i, $text := .}}
+            {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.Text*/ -}}
+            <div x-data="{editOpen: false, oldName: '{{$text.Name}}', name:'', oldContent: `{{$text.RawContent}}`, newContent: ''}"
+                 x-init="newContent=oldContent;name=oldName">
+                <form class="form-container my-0"
+                      @submit.prevent="await admin.updateText({{$text.ID}}, name, newContent).then(() => {
+                                    oldContent = newContent;
+                                    oldName = name;
+                                })"
+                      @reset.prevent="newContent = oldContent">
+                    <div class="form-container-title">
+                        <div class="flex items-center justify-between">
+                            <label for="content-{{$i}}">{{$text.Name}}</label>
+                            <div class="flex items-center">
+                                <div x-show="oldContent !== newContent || oldName !== name"
+                                     class="flex px-2 py-1 h-fit border border-amber-200 bg-amber-200/50 rounded-full">
+                                    <i class="fa fa-triangle-exclamation mr-1"></i>
+                                    <span class="text-xs font-light text-3">Unsaved Changes</span>
+                                </div>
+                                <button type="button" class="text-4 text-lg ml-2" @click="editOpen = !editOpen">
+                                    <i class="fa" :class="editOpen ? 'fa-chevron-up' : 'fa-chevron-down'"></i>
+                                </button>
                             </div>
-                            <button type="button" class="text-4 text-lg my-auto" @click="editOpen = !editOpen">
-                                <template x-if="editOpen">
-                                    <i class="fa fa-chevron-up"></i>
-                                </template>
-                                <template x-if="!editOpen">
-                                    <i class="fa fa-chevron-down"></i>
-                                </template>
-                            </button>
                         </div>
                     </div>
-                    <div x-show="editOpen" class="border-b dark:border-gray-800">
+                    <div x-cloak="" x-show="editOpen" class="form-container-body">
+                        <textarea id="content-{{$i}}"
+                                  x-model="newContent"
+                                  rows="24"
+                                  class="p-2 resize-none font-normal outline-0 border-0 bg-transparent text-3">{{$text.RawContent}}</textarea>
+                    </div>
+                    <div x-cloak="" x-show="editOpen" class="flex items-center justify-end form-container-footer">
+                        <button id="save-{{$i}}"
+                                type="reset"
+                                class="btn h-fit mr-2"
+                                :disabled="newContent === oldContent">
+                            Reset
+                        </button>
+                        <button id="save-{{$i}}"
+                                type="submit"
+                                class="btn h-fit"
+                                :disabled="newContent === oldContent">
+                            Save
+                        </button>
+                    </div>
+                </form>
+
+                <!--
+                <div class="flex p-3 rounded-lg" :class="editOpen && 'outline outline-2 outline-blue-500/50'">
+                    <label for="content-{{$i}}" class="hidden">{{$text.Name}}</label>
+                    <input x-model="name"
+                           class="flex border-0 text-3 text-lg my-auto p-0 w-1/2 rounded-lg disabled:bg-transparent"
+                           :disabled="!editOpen">
+                    <div class="flex my-auto ml-auto space-x-3">
+                        <div x-show="oldContent !== newContent || oldName !== name"
+                             class="flex my-auto px-2 py-1 border border-amber-200 bg-amber-200/50 rounded">
+                            <i class="fa fa-triangle-exclamation mr-1"></i>
+                            <span class="text-xs font-light text-3">Unsaved Changes</span>
+                        </div>
+                        <button type="button" class="text-4 text-lg my-auto" @click="editOpen = !editOpen">
+                            <template x-if="editOpen">
+                                <i class="fa fa-chevron-up"></i>
+                            </template>
+                            <template x-if="!editOpen">
+                                <i class="fa fa-chevron-down"></i>
+                            </template>
+                        </button>
+                    </div>
+                </div>
+
+
+                <div x-show="editOpen" class="border-b dark:border-gray-800">
                         <textarea id="content-{{$i}}"
                                   x-model="newContent"
                                   rows="24"
                                   class="border-0 px-3 py-2 resize-none font-normal">{{$text.RawContent}}</textarea>
-                    </div>
-                    <div x-show="editOpen" class="">
-                        <button id="save-{{$i}}"
-                                class="bg-gray-50 dark:bg-gray-600 rounded-b-lg text-center w-full py-2 hover:bg-transparent disabled:bg-transparent"
-                                :disabled="newContent === oldContent && name === oldName"
-                                @click="await admin.updateText({{$text.ID}}, name, newContent).then(() => {
+                </div>
+                <div x-show="editOpen" class="">
+                    <button id="save-{{$i}}"
+                            class="bg-gray-50 dark:bg-gray-600 rounded-b-lg text-center w-full py-2 hover:bg-transparent disabled:bg-transparent"
+                            :disabled="newContent === oldContent && name === oldName"
+                            @click="await admin.updateText({{$text.ID}}, name, newContent).then(() => {
                                     oldContent = newContent;
                                     oldName = name;
                                 })">
-                            <span class="font-semibold text-3 text-xs" x-text="`Save ${name}`"></span>
-                        </button>
-                    </div>
-                </div>
-            {{end}}
-        </div>
-    </div>
+                        <span class="font-semibold text-3 text-xs" x-text="`Save ${name}`"></span>
+                    </button>
+                </div> -->
+            </div>
+        {{end}}
 {{end}}

--- a/web/template/admin/admin_tabs/info-pages.gohtml
+++ b/web/template/admin/admin_tabs/info-pages.gohtml
@@ -48,48 +48,6 @@
                         </button>
                     </div>
                 </form>
-
-                <!--
-                <div class="flex p-3 rounded-lg" :class="editOpen && 'outline outline-2 outline-blue-500/50'">
-                    <label for="content-{{$i}}" class="hidden">{{$text.Name}}</label>
-                    <input x-model="name"
-                           class="flex border-0 text-3 text-lg my-auto p-0 w-1/2 rounded-lg disabled:bg-transparent"
-                           :disabled="!editOpen">
-                    <div class="flex my-auto ml-auto space-x-3">
-                        <div x-show="oldContent !== newContent || oldName !== name"
-                             class="flex my-auto px-2 py-1 border border-amber-200 bg-amber-200/50 rounded">
-                            <i class="fa fa-triangle-exclamation mr-1"></i>
-                            <span class="text-xs font-light text-3">Unsaved Changes</span>
-                        </div>
-                        <button type="button" class="text-4 text-lg my-auto" @click="editOpen = !editOpen">
-                            <template x-if="editOpen">
-                                <i class="fa fa-chevron-up"></i>
-                            </template>
-                            <template x-if="!editOpen">
-                                <i class="fa fa-chevron-down"></i>
-                            </template>
-                        </button>
-                    </div>
-                </div>
-
-
-                <div x-show="editOpen" class="border-b dark:border-gray-800">
-                        <textarea id="content-{{$i}}"
-                                  x-model="newContent"
-                                  rows="24"
-                                  class="border-0 px-3 py-2 resize-none font-normal">{{$text.RawContent}}</textarea>
-                </div>
-                <div x-show="editOpen" class="">
-                    <button id="save-{{$i}}"
-                            class="bg-gray-50 dark:bg-gray-600 rounded-b-lg text-center w-full py-2 hover:bg-transparent disabled:bg-transparent"
-                            :disabled="newContent === oldContent && name === oldName"
-                            @click="await admin.updateText({{$text.ID}}, name, newContent).then(() => {
-                                    oldContent = newContent;
-                                    oldName = name;
-                                })">
-                        <span class="font-semibold text-3 text-xs" x-text="`Save ${name}`"></span>
-                    </button>
-                </div> -->
             </div>
         {{end}}
 {{end}}


### PR DESCRIPTION
### Motivation and Context
Admin Info Page UI was outdated and bugged.

### Description
Update UI with `.form-container`s. See Screenshots.

_Info: Using button classes from #792_

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Admin
- Admin Edit-Info-Pages page

1. Log in
2. Head to "Info pages"

### Screenshots
<details>
  <summary>Before:</summary>
<img width="420" alt="image" src="https://user-images.githubusercontent.com/29633518/205695288-5dab6e77-5e42-465e-92a6-ece0d1a774d7.png">
</details>

<details>
  <summary>After:</summary>
<img width="420" alt="image" src="https://user-images.githubusercontent.com/29633518/205694986-df981f34-4434-4f2a-8535-bfa2c020ccf4.png">

I changed the title to `Info Pages`. 🫠
</details>