### PR TITLE
Use a different flag for golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,3 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --new-from-rev=HEAD~1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args:  --new-from-rev=HEAD~1
+          args: --new-from-rev=HEAD~1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          only-new-issues: true
+          args:  --new-from-rev=HEAD~1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,8 @@ linters-settings:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  new: true
+  new-from-rev: HEAD
   exclude-rules:
     # Exclude some linters from running on tests files.
     - path: _test\.go


### PR DESCRIPTION
### Motivation and Context
The flag I used to prevent the CI from showing old issues did not work as expected and might be broken in general. Apparently, it is only applied to PRs which doesn't really make sense imo.

- https://github.com/golangci/golangci-lint-action/issues/531
- https://github.com/golangci/golangci-lint-action/issues/523

### Description
Add the flag directly instead of the wrapper. I used the recommendation from the [FAQ](https://golangci-lint.run/usage/faq/).

### Steps for Testing
CI should pass after merge.