### PR TITLE
Fix duplicated handler

### DIFF
--- a/web/router.go
+++ b/web/router.go
@@ -191,7 +191,7 @@ func getDefaultStaticBrandingFiles() []staticFile {
 		{Name: "logo.svg", Path: "assets/img/logo.svg"},
 		{Name: "manifest.json", Path: "assets/manifest.json"},
 		{Name: "favicon.ico", Path: "assets/favicon.ico"},
-		{Name: "icons-512.png", Path: "assets/img/icons-192.png"},
+		{Name: "icons-192.png", Path: "assets/img/icons-192.png"},
 		{Name: "icons-512.png", Path: "assets/img/icons-512.png"},
 	}
 }


### PR DESCRIPTION
### Motivation and Context
I just set up a new dev environment and noticed that TUM-Live wouldn't start due to a duplicated handler.

### Description
Set the correct handler name to remove duplicates.

### Steps for Testing

1. Try `run-dev` in goland.
2. See, if the TUM-Live starts.

