### PR TITLE
Change output directory to $PROJECT_DIR/bin

### DIFF
--- a/.idea/runConfigurations/run_tumlive_go.xml
+++ b/.idea/runConfigurations/run_tumlive_go.xml
@@ -6,6 +6,7 @@
     <package value="github.com/joschahenningsen/TUM-Live/cmd/tumlive" />
     <directory value="$PROJECT_DIR$" />
     <filePath value="$PROJECT_DIR$/cmd/tumlive/tumlive.go" />
+    <output_directory value="$PROJECT_DIR$/bin" />
     <method v="2" />
   </configuration>
 </component>


### PR DESCRIPTION
### Motivation and Context
I'm not sure about other systems but on MacOS the binary is placed @ `/Users/matthias/Library/Caches/go-build` and 
is not replaced upon rebuild. That means, that each build results in a separate binary. (And MacOS asking permission for the _"new"_ app to use networking)

I argue that a `bin` folder in the project's root is a cleaner approach since it replaces the one binary stored in there. 


### Description
Update `.idea/runConfigurations/run/run_tumlive_go.xml`, so that the output directory is the `bin` folder.


### Steps for Testing
1. Build project
2. Check if there is a binary in the `bin` folder
