### PR TITLE
Remove `paused` button

### DIFF
--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -401,13 +401,6 @@
                     {{/* Lecture hall is set, means no self-stream*/}}
                     {{if $stream.LiveNow}}
                         {{if $stream.LectureHallID}}
-                            <button @click="fetch(`/api/stream/${streamID}/pause?pause=${!paused}`).then(paused=!paused)"
-                                    href="#"
-                                    :title="paused?'End Pause (turns on video and audio)':'Pause lecture (turns off video and audio)'"
-                                    class="bg-green-500 text-center lg:w-32 md:w-24 md:inline-block block w-full text-white font-bold hover:bg-green-600 dark:hover:bg-green-600 rounded cursor-pointer p-2">
-                                <span x-show="!paused"><i class="fas fa-pause mr-1"></i>Pause</span>
-                                <span x-show="paused"><i class="fas fa-play mr-1"></i>Resume</span>
-                            </button>
                             <button @click="window.location.href='?restart=1'"
                                     title="Issues with the stream? Restart it."
                                     class="bg-indigo-500 text-center lg:w-32 md:w-24 md:inline-block block w-full text-white font-bold hover:bg-indigo-600 dark:hover:bg-indigo-600 rounded cursor-pointer p-2">


### PR DESCRIPTION
### Motivation and Context
For admins we forgot to remove a `paused` element and therefore Alpine throws an error for livestreams.

<img width="575" alt="image" src="https://user-images.githubusercontent.com/29633518/210718006-7a5419fe-d7e4-4c8b-93de-25eb80f15af8.png">
 

### Description
Remove paused button.

### Steps for Testing
Prerequisites:
- 1 Admin or AdminOfCourse
- 1 Livestream (Not a VOD)

1. Log in
2. Navigate to a Livestream
3. No error should be thrown
4. 🕺
