### PR TITLE
Update camera selection menu position

### DIFF
--- a/web/template/partial/stream/actions.gohtml
+++ b/web/template/partial/stream/actions.gohtml
@@ -26,7 +26,7 @@
                     <i class="fa-solid fa-camera-rotate text-lg text-4 hover:text-1"></i>
                 </button>
                 <div x-cloak x-show="showSrcMenu"
-                     class="fixed flex h-full left-0 bottom-0 w-full lg:block lg:absolute lg:right-full lg:left-auto lg:w-56 lg:bottom-auto z-40"
+                     class="fixed flex left-0 bottom-0 h-full w-full z-40 lg:absolute lg:block lg:left-auto lg:bottom-full lg:right-full lg:h-auto lg:w-56"
                     :class="showSrcMenu && 'backdrop-brightness-50 lg:backdrop-brightness-100'">
                     <div @click.outside="showSrcMenu = false;"
                          class="w-full my-auto mx-2 bg-white border rounded-lg shadow h-fit dark:bg-secondary-light dark:border-gray-600 py-3 lg:my-0">


### PR DESCRIPTION
### Motivation and Context
- Solves #870 

### Description
Update CSS

### Steps for Testing
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Click on the camera selection button. The camera selection should now be on the top of the actions menu.
4. Check if the mobile version of the camera selection still works.

### Screenshots
<img width="331" alt="Screenshot 2023-01-09 at 07 18 33" src="https://user-images.githubusercontent.com/29633518/211250533-37fdde6e-27c7-4a2e-839c-e4db47efb7a6.png">

