### PR TITLE
Use correct timestamp when switching camera options in Beta stream

### DIFF
--- a/web/template/partial/stream/actions.gohtml
+++ b/web/template/partial/stream/actions.gohtml
@@ -34,7 +34,7 @@
                         {{if $stream.PlaylistUrlPRES}}
                             <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600"
                                title="Presentation only"
-                               href="/w/{{$course.Slug}}/{{$stream.Model.ID}}/PRES">
+                               :href="global.keepQuery('/w/{{$course.Slug}}/{{$stream.Model.ID}}/PRES')">
                                 <i class="fas fa-edit text-4 hover:text-1 w-8"></i>
                                 <span class="font-light text-sm">Presentation only</span>
                             </a>
@@ -43,7 +43,7 @@
                         {{if $stream.PlaylistUrlCAM}}
                             <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600"
                                title="Camera only"
-                               href="/w/{{$course.Slug}}/{{$stream.Model.ID}}/CAM">
+                               :href="global.keepQuery('/w/{{$course.Slug}}/{{$stream.Model.ID}}/CAM')">
                                 <i class="text-lg fas fa-camera text-4 hover:text-1 w-8"></i>
                                 <span class="font-light text-sm">Camera only</span>
                             </a>
@@ -52,7 +52,7 @@
                         {{if and $stream.PlaylistUrlCAM $stream.PlaylistUrlPRES}}
                             <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600"
                                title="Split-view"
-                               href="/w/{{$course.Slug}}/{{$stream.Model.ID}}/SPLIT">
+                               :href="global.keepQuery('/w/{{$course.Slug}}/{{$stream.Model.ID}}/SPLIT')">
                                 <i class="text-lg fa-solid fa-table-columns text-4 hover:text-1 w-8"></i>
                                 <span class="font-light text-sm">Splitview</span>
                             </a>
@@ -61,7 +61,7 @@
                         {{if $stream.PlaylistUrl}}
                             <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600"
                                title="Combined view"
-                               href="/w/{{$course.Slug}}/{{$stream.Model.ID}}">
+                               :href="global.keepQuery('/w/{{$course.Slug}}/{{$stream.Model.ID}}')">
                                 <i class="text-lg fas fa-object-group text-4 hover:text-1 w-8"></i>
                                 <span class="font-light text-sm">Combined view</span>
                             </a>

--- a/web/template/partial/stream/actions.gohtml
+++ b/web/template/partial/stream/actions.gohtml
@@ -32,36 +32,36 @@
                          class="w-full my-auto mx-2 bg-white border rounded-lg shadow h-fit dark:bg-secondary-light dark:border-gray-600 py-3 lg:my-0">
                         {{/* Switch video to presentation */}}
                         {{if $stream.PlaylistUrlPRES}}
-                            <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600"
+                            <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600"
                                title="Presentation only"
-                               :href="global.keepQuery('/w/{{$course.Slug}}/{{$stream.Model.ID}}/PRES')">
+                               @click="watch.switchView('/w/{{$course.Slug}}/{{$stream.Model.ID}}/PRES')">
                                 <i class="fas fa-edit text-4 hover:text-1 w-8"></i>
                                 <span class="font-light text-sm">Presentation only</span>
                             </a>
                         {{end}}
                         {{/* Switch video to camera */}}
                         {{if $stream.PlaylistUrlCAM}}
-                            <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600"
+                            <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600"
                                title="Camera only"
-                               :href="global.keepQuery('/w/{{$course.Slug}}/{{$stream.Model.ID}}/CAM')">
+                               @click="watch.switchView('/w/{{$course.Slug}}/{{$stream.Model.ID}}/CAM')">
                                 <i class="text-lg fas fa-camera text-4 hover:text-1 w-8"></i>
                                 <span class="font-light text-sm">Camera only</span>
                             </a>
                         {{end}}
                         {{/* Switch video to split view */}}
                         {{if and $stream.PlaylistUrlCAM $stream.PlaylistUrlPRES}}
-                            <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600"
+                            <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600"
                                title="Split-view"
-                               :href="global.keepQuery('/w/{{$course.Slug}}/{{$stream.Model.ID}}/SPLIT')">
+                               @click="watch.switchView('/w/{{$course.Slug}}/{{$stream.Model.ID}}/SPLIT')">
                                 <i class="text-lg fa-solid fa-table-columns text-4 hover:text-1 w-8"></i>
                                 <span class="font-light text-sm">Splitview</span>
                             </a>
                         {{end}}
                         {{/* Switch video to camera and presentation */}}
                         {{if $stream.PlaylistUrl}}
-                            <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-600"
+                            <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600"
                                title="Combined view"
-                               :href="global.keepQuery('/w/{{$course.Slug}}/{{$stream.Model.ID}}')">
+                               @click="watch.switchView('/w/{{$course.Slug}}/{{$stream.Model.ID}}')">
                                 <i class="text-lg fas fa-object-group text-4 hover:text-1 w-8"></i>
                                 <span class="font-light text-sm">Combined view</span>
                             </a>

--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -582,11 +582,11 @@ export function attachCurrentTimeEvent(videoSection: VideoSectionList) {
             let timer;
             (function checkTimestamp() {
                 timer = setTimeout(() => {
-                    hightlight(players[j], videoSection);
+                    highlight(players[j], videoSection);
                     checkTimestamp();
                 }, 500);
             })();
-            players[j].on("seeked", () => hightlight(players[j], videoSection));
+            players[j].on("seeked", () => highlight(players[j], videoSection));
         });
     }
 }
@@ -599,7 +599,7 @@ export function currentTimeToHMS() {
     return { h, m, s };
 }
 
-function hightlight(player, videoSection) {
+function highlight(player, videoSection) {
     const currentTime = player.currentTime();
     videoSection.currentHighlightIndex = videoSection.list.findIndex((section, i, list) => {
         const next = list[i + 1];

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -262,7 +262,16 @@ export function getQueryParam(name: string): string {
     return new URL(window.location.href).searchParams.get(name) ?? undefined;
 }
 
-// TypeScript Mapping of model.VideoSection
+/**
+ * Append current query params to given URL
+ */
+export function keepQuery(url: string): string {
+    return window.location.search.length > 0 ? url + window.location.search : url;
+}
+
+/**
+ * TypeScript Mapping of model.VideoSection
+ */
 export type Section = {
     ID?: number;
     description: string;


### PR DESCRIPTION
### Motivation and Context
- ?dvr is removed when switching between camera options.
- Solves #847 

### Description
Keep query when switching between camera options and append `t=<timestamp>`. 

### Steps for Testing
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Turn on Beta Stream
4. Skip somewhere
5. Switch camera option
6. `?dvr&t=<timestamp>` should be in the URL
7. Jumps to correct timestamp
8. 🕺
