### PR TITLE
Unsplit mobile and desktop action bar 

### DIFF
--- a/web/template/partial/stream/actions.gohtml
+++ b/web/template/partial/stream/actions.gohtml
@@ -90,7 +90,6 @@
             {{else}}
                 <a href="?dvr" class="relative m-auto text-4 hover:text-1" title="Turn beta stream on">
                     <i class="fa-solid fa-tower-broadcast"></i>
-                    <span class="align-super text-xs">Beta</span>
                 </a>
             {{end}}
         {{end}}

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -24,13 +24,13 @@
       @keypress.shift.window="(e) => watch.onShift(e)"
       x-init="watch.startWebsocket(); seekLogger.attach();">
 {{template "header" .IndexData.TUMLiveContext}}
-<div id="shortcuts-help-modal" class="hidden flex absolute top-0 h-screen w-screen z-50 backdrop-brightness-50">
+<div id="shortcuts-help-modal" class="hidden flex fixed top-0 h-screen w-screen z-50 backdrop-brightness-50">
     <div class="m-auto" @click.outside="watch.toggleShortcutsModal();">
         {{template "shortcuts"}}
     </div>
 </div>
 <div x-cloak x-show="showShare"
-     id="share-modal" class="flex absolute top-0 h-screen w-screen z-50 backdrop-brightness-50">
+     id="share-modal" class="flex fixed top-0 h-screen w-screen z-50 backdrop-brightness-50">
     <div class="m-auto lg:w-1/2 w-3/4" @click.outside="showShare=false">
         <div class="bg-white dark:bg-secondary-light border dark:border-gray-800 rounded-lg">
             <div class="flex justify-between items-center px-3 pt-3 pb-1">
@@ -291,8 +291,8 @@
         {{if and $course.ChatEnabled $stream.ChatEnabled}}
             <div x-show="showChat"
                  :class="showChat ? 'lg:basis-1/4' : 'lg:basis-0'"
-                 class="z-20 basis-full order-3 border rounded p-1 mx-5 bg-gray-100 dark:bg-gray-800 dark:border-0 lg:h-16/6 h-96
-                        lg:border-0 lg:shadow lg:order-none lg:mx-0 lg:p-0 lg:bg-transparent">
+                 class="z-20 basis-full order-5 border rounded lg:h-16/6 h-96
+                        lg:border-0 lg:shadow lg:order-none">
                 <div id="chat-box" class="bg-white rounded lg:bg-transparent md:rounded-0 dark:bg-secondary h-full">
                     {{template "chat" .ChatData}}
                 </div>
@@ -302,16 +302,16 @@
         <!-- Bookmarks -->
         <div id="bookmarks-desktop" x-cloak="" x-show="showBookmarks"
              :class="showBookmarks ? 'lg:basis-1/4' : 'lg:basis-0'"
-             class="hidden md:block basis-full h-96 lg:h-16/6 px-5 md:px-2 md:pt-2 lg:order-none order-5">
+             class="hidden md:block basis-full h-96 lg:h-16/6 px-5 md:px-2 md:pt-2 lg:order-none order-4">
             {{template "bookmarks-modal" $stream.ID}}
         </div>
 
         <!-- stream info container -->
         <!-- Title, course name, actions -->
         <div class="basis-full relative order-2 p-5 lg:order-none">
-            <div class="flex justify-between align-middle border-b dark:border-gray-800 pb-2 lg:border-0">
+            <div class="flex flex-col justify-between align-middle pb-2 md:flex-row">
                 <!-- title and course-name -->
-                <div class="grid mb-auto shrink">
+                <div class="pb-3 border-b dark:border-gray-600 grid shrink mb-auto lg:pb-0 lg:border-0">
                     <h1 class="font-bold text-4 text-lg grow lg:text-2xl"
                         @titleupdate.window="$el.innerText=$event.detail.title">
                         {{if $stream.Name}}
@@ -333,8 +333,8 @@
                 </div>
 
                 <!-- Desktop stream info-->
-                <div class="grid gap-3 shrink-0">
-                    <div class="space-x-2 text-lg text-4 hidden md:inline-flex shrink-0 my-auto">
+                <div class="grid pt-3 shrink-0 lg:pt-0">
+                    <div class="justify-center space-x-2 text-lg text-4 inline-flex shrink-0 my-auto">
                         {{if or (.IndexData.TUMLiveContext.User.IsAdminOfCourse .IndexData.TUMLiveContext.Course) .IndexData.IsAdmin}}
                             <a class="rounded-lg px-3 py-2 h-fit w-fit bg-gray-100 hover:bg-gray-200 dark:bg-secondary-light dark:hover:bg-gray-600"
                                href="/admin/course/{{$course.Model.ID}}#lecture-li-{{$stream.Model.ID}}"
@@ -372,43 +372,10 @@
                     </div>
                 </div>
             </div>
-
-            <!-- Mobile stream info -->
-            <div class="md:hidden flex justify-between mt-5 text-3">
-                <div class="flex">
-                    {{if or (.IndexData.TUMLiveContext.User.IsAdminOfCourse .IndexData.TUMLiveContext.Course) .IndexData.IsAdmin}}
-                        <a class="rounded-lg px-3 py-2 w-fit bg-gray-100 hover:bg-gray-200 dark:bg-secondary-light dark:hover:bg-gray-600 mr-2"
-                           href="/admin/course/{{$course.Model.ID}}#lecture-li-{{$stream.Model.ID}}"
-                           :title="'Edit course settings'">
-                            <i class="fa-solid fa-pen text-4"></i>
-                        </a>
-                    {{end}}
-
-                    {{if .IndexData.TUMLiveContext.User}}
-                        <button @click="showChat = false; showBookmarks = !showBookmarks"
-                                class="rounded-lg px-4 py-2 h-fit w-fit bg-gray-100 hover:bg-gray-200 dark:bg-secondary-light dark:hover:bg-gray-600 mr-2"
-                                :title="'New Bookmark'">
-                            <i class="fa-solid fa-bookmark text-4"></i>
-                        </button>
-                    {{end}}
-
-                    {{template "actions" .}}
-                </div>
-
-                {{if and $course.ChatEnabled $stream.ChatEnabled}}
-                    <!-- Mobile Open Chat -->
-                    <button @click="showBookmarks = false;showChat = !showChat;"
-                            title="Open Chat"
-                            :class="showChat ? 'bg-gray-200 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-secondary' : 'bg-gray-100 hover:bg-gray-200 dark:bg-secondary-light dark:hover:bg-gray-600'"
-                            class="rounded-lg px-3 py-2 w-fit">
-                        <i class="fa-solid fa-comments text-4"></i>
-                    </button>
-                {{end}}
-            </div>
         </div>
         {{if and .IsAdminOfCourse $stream.LiveNow}}
             <!-- Admin control buttons -->
-            <div class="w-full p-5 lg:order-none order-4">
+            <div class="w-full p-3 lg:order-none order-2 lg:p-5">
                 <h3 class="text-4 font-semibold border-b dark:border-gray-800 mb-3">Admin</h3>
                 <div class="md:space-x-2 lg:space-y-0 space-y-2 w-full">
                     {{/* Lecture hall is set, means no self-stream*/}}
@@ -436,7 +403,7 @@
                 </div>
             </div>
             {{if and .Presets $stream.LiveNow}}
-                <div class="w-full px-5 order-3">
+                <div class="p-3 w-full order-2 lg:p-5">
                     <h3 class="text-4 font-semibold border-b dark:border-gray-800 mb-3">Presets</h3>
                     <div class="w-full overflow-x-scroll scrollbarThin">
                         <div class="flex flex-row gap-x-2 pb-4 pl-2">
@@ -457,10 +424,10 @@
             {{end}}
         {{end}}
 
-        <div class="flex flex-col lg:flex-row basis-full order-5">
+        <div class="flex flex-col lg:flex-row basis-full order-4">
             <!-- Video Sections -->
             {{if $stream.VideoSections}}
-                <div class="lg:basis-1/2 p-5 order-5 lg:order-none">
+                <div class="p-2 order-4 lg:basis-1/2 lg:p-5 lg:order-none">
                     {{template "videosections" $stream}}
                 </div>
             {{end}}
@@ -473,7 +440,7 @@
             <div x-data="{ less: {{$less}}, toggleDesc: true }"
                     {{/* Update less on update */}}
                  @descriptionupdate.window="toggleDesc = less = $event.detail.description.full.length > {{.CutOffLength}};"
-                 class="video-description flex-grow p-5 lg:mx-2 basis-full lg:order-none order-4">
+                 class="video-description flex-grow p-3 order-2 basis-full lg:order-none lg:p-5 lg:mx-2">
                 <div class="flex justify-between border-b mb-1 dark:border-gray-800 lg:justify-start">
                     <h3 class="text-4 font-semibold">Description</h3>
                 </div>


### PR DESCRIPTION
### Motivation and Context
Currently a change to the action bar needs to be done at two places (mobile and desktop). That's unnecessary.

### Description
Remove separate mobile actions and align the "old" one properly with css.

### Steps for Testing
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3.  Action bar aligned? (Mobile and Desktop)
