### PR TITLE
Fix Alpine Bookmarks Error

### DIFF
--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -66,6 +66,7 @@
         </div>
     </div>
 </div>
+{{if .IndexData.TUMLiveContext.User}}
 <div id="bookmarks-mobile" x-cloak="" x-show="showBookmarks"
      class="md:hidden flex absolute top-0 h-screen w-screen z-50 backdrop-brightness-50">
     <div @click.outside="showBookmarks = false"
@@ -73,6 +74,7 @@
         {{template "bookmarks-modal" $stream.ID}}
     </div>
 </div>
+{{end}}
 <div id="watchPageMainWrapper">
     <input type="hidden" id="streamID" value="{{$stream.Model.ID}}">
     <div class="flex flex-wrap shadow border bg-white dark:bg-secondary dark:shadow-0 dark:border-0">
@@ -300,11 +302,13 @@
         {{end}}
 
         <!-- Bookmarks -->
+        {{if .IndexData.TUMLiveContext.User}}
         <div id="bookmarks-desktop" x-cloak="" x-show="showBookmarks"
              :class="showBookmarks ? 'lg:basis-1/4' : 'lg:basis-0'"
              class="hidden md:block basis-full h-96 lg:h-16/6 px-5 md:px-2 md:pt-2 lg:order-none order-5">
             {{template "bookmarks-modal" $stream.ID}}
         </div>
+        {{end}}
 
         <!-- stream info container -->
         <!-- Title, course name, actions -->

--- a/web/ts/bookmarks.ts
+++ b/web/ts/bookmarks.ts
@@ -26,7 +26,7 @@ export class BookmarkList {
     }
 
     async fetch() {
-        this.list = await Bookmarks.get(this.streamId);
+        this.list = (await Bookmarks.get(this.streamId)) ?? [];
         this.list.forEach((b) => (b.update = updateBookmark));
     }
 }


### PR DESCRIPTION
### Motivation and Context
Currently, if not logged-in, Alpine throws an undefined error because the `GET` request returns the 
Login Page instead of the desired JSON content.

### Description
- Improve Bookmarks Typescript by `undefined` checks.
- Don't call `.fetch` when not logged-in

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Account
- 1 Livestream

1. Navigate to a Livestream (Not Logged-In)
2. There shouldn't be an error in the console
3. Now Login
4. Check if bookmarks still work
5. 🥳

### Screenshots
<img width="534" alt="image" src="https://user-images.githubusercontent.com/29633518/212621815-cc0f538e-eb77-4ce0-8d35-029bec6ed648.png">

