### PR TITLE
Add class 'Time'

### DIFF
--- a/api/bookmarks.go
+++ b/api/bookmarks.go
@@ -113,20 +113,7 @@ func (r bookmarkRoutes) GetByStreamID(c *gin.Context) {
 		return
 	}
 
-	response := []gin.H{}
-	for _, bookmark := range bookmarks {
-		response = append(response, gin.H{
-			"ID":                bookmark.ID,
-			"hours":             bookmark.Hours,
-			"minutes":           bookmark.Minutes,
-			"seconds":           bookmark.Seconds,
-			"description":       bookmark.Description,
-			"friendlyTimestamp": bookmark.TimestampAsString(),
-		})
-
-	}
-
-	c.JSON(http.StatusOK, response)
+	c.JSON(http.StatusOK, bookmarks)
 }
 
 type UpdateBookmarkRequest struct {

--- a/api/bookmarks_test.go
+++ b/api/bookmarks_test.go
@@ -99,18 +99,7 @@ func TestBookmarks(t *testing.T) {
 	t.Run("GET/api/bookmarks", func(t *testing.T) {
 		baseUrl := "/api/bookmarks"
 
-		bookmark := testutils.Bookmark
 		bookmarks := []model.Bookmark{testutils.Bookmark}
-		response := []gin.H{
-			{
-				"ID":                bookmark.ID,
-				"hours":             bookmark.Hours,
-				"minutes":           bookmark.Minutes,
-				"seconds":           bookmark.Seconds,
-				"description":       bookmark.Description,
-				"friendlyTimestamp": bookmark.TimestampAsString(),
-			},
-		}
 
 		gomino.TestCases{
 			"not logged in": {
@@ -187,7 +176,7 @@ func TestBookmarks(t *testing.T) {
 				Url:              fmt.Sprintf("%s?streamID=%d", baseUrl, testutils.StreamFPVLive.ID),
 				Middlewares:      testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextStudent)),
 				ExpectedCode:     http.StatusOK,
-				ExpectedResponse: response,
+				ExpectedResponse: bookmarks,
 			},
 		}.Run(t, testutils.Equal)
 	})

--- a/api/stream.go
+++ b/api/stream.go
@@ -277,21 +277,7 @@ func (r streamRoutes) getVideoSections(c *gin.Context) {
 		log.WithError(err).Error("Can't get video sections")
 	}
 
-	response := []gin.H{}
-	for _, section := range sections {
-		response = append(response, gin.H{
-			"ID":                section.ID,
-			"startHours":        section.StartHours,
-			"startMinutes":      section.StartMinutes,
-			"startSeconds":      section.StartSeconds,
-			"description":       section.Description,
-			"friendlyTimestamp": section.TimestampAsString(),
-			"streamID":          section.StreamID,
-			"fileID":            section.FileID,
-		})
-
-	}
-	c.JSON(http.StatusOK, response)
+	c.JSON(http.StatusOK, sections)
 }
 
 // RegenerateThumbs regenerates the thumbnails for a stream.

--- a/api/stream_test.go
+++ b/api/stream_test.go
@@ -276,19 +276,6 @@ func TestStreamVideoSections(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	t.Run("GET/api/stream/:streamID/sections", func(t *testing.T) {
 		// generate same response as in handler
-		response := []gin.H{}
-		for _, section := range testutils.StreamFPVLive.VideoSections {
-			response = append(response, gin.H{
-				"ID":                section.ID,
-				"startHours":        section.StartHours,
-				"startMinutes":      section.StartMinutes,
-				"startSeconds":      section.StartSeconds,
-				"description":       section.Description,
-				"friendlyTimestamp": section.TimestampAsString(),
-				"streamID":          section.StreamID,
-				"fileID":            section.FileID,
-			})
-		}
 
 		url := fmt.Sprintf("/api/stream/%d/sections", testutils.StreamFPVLive.ID)
 		gomino.TestCases{
@@ -330,7 +317,7 @@ func TestStreamVideoSections(t *testing.T) {
 				},
 				Middlewares:      testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextStudent)),
 				ExpectedCode:     http.StatusOK,
-				ExpectedResponse: response,
+				ExpectedResponse: testutils.StreamFPVLive.VideoSections,
 			}}.
 			Method(http.MethodGet).
 			Url(url).

--- a/model/bookmark.go
+++ b/model/bookmark.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"gorm.io/gorm"
 )
 
@@ -14,11 +13,4 @@ type Bookmark struct {
 	Seconds     uint   `gorm:"not null" json:"seconds"`
 	UserID      uint   `gorm:"not null" json:"-"`
 	StreamID    uint   `gorm:"not null" json:"-"`
-}
-
-func (b Bookmark) TimestampAsString() string {
-	if b.Hours == 0 {
-		return fmt.Sprintf("%02d:%02d", b.Minutes, b.Seconds)
-	}
-	return fmt.Sprintf("%02d:%02d:%02d", b.Hours, b.Minutes, b.Seconds)
 }

--- a/model/video-section.go
+++ b/model/video-section.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"gorm.io/gorm"
 )
 
@@ -15,11 +14,4 @@ type VideoSection struct {
 
 	StreamID uint `gorm:"not null" json:"streamID"`
 	FileID   uint `gorm:"not null" json:"fileID"`
-}
-
-func (v VideoSection) TimestampAsString() string {
-	if v.StartHours == 0 {
-		return fmt.Sprintf("%02d:%02d", v.StartMinutes, v.StartSeconds)
-	}
-	return fmt.Sprintf("%02d:%02d:%02d", v.StartHours, v.StartMinutes, v.StartSeconds)
 }

--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -1,4 +1,4 @@
-import { getQueryParam, keepQuery, postData } from "./global";
+import { getQueryParam, keepQuery, postData, Time } from "./global";
 import { VideoSectionList } from "./video-sections";
 import { StatusCodes } from "http-status-codes";
 import videojs from "video.js";
@@ -557,7 +557,7 @@ export class OverlayIcon extends Component {
 export function jumpTo(hours: number, minutes: number, seconds: number) {
     for (let j = 0; j < players.length; j++) {
         players[j].ready(() => {
-            players[j].currentTime(toSeconds(hours, minutes, seconds));
+            players[j].currentTime(new Time(hours, minutes, seconds).toSeconds());
         });
     }
 }
@@ -609,14 +609,6 @@ export function attachCurrentTimeEvent(videoSection: VideoSectionList) {
     }
 }
 
-export function currentTimeToHMS() {
-    const ct = players[0]?.currentTime();
-    const h = Math.trunc(ct / (60 * 60));
-    const m = Math.trunc((ct % (60 * 60)) / 60);
-    const s = Math.trunc(ct - h * (60 * 60) - m * 60);
-    return { h, m, s };
-}
-
 export function switchView(baseUrl: string) {
     const isDVR = getQueryParam("dvr") === "";
 
@@ -634,16 +626,12 @@ function highlight(player, videoSection) {
     const currentTime = player.currentTime();
     videoSection.currentHighlightIndex = videoSection.list.findIndex((section, i, list) => {
         const next = list[i + 1];
-        const sectionSeconds = toSeconds(section.startHours, section.startMinutes, section.startSeconds);
+        const sectionSeconds = new Time(section.startHours, section.startMinutes, section.startSeconds).toSeconds();
         return next === undefined || next === null // if last element and no next exists
             ? sectionSeconds <= currentTime
             : sectionSeconds <= currentTime &&
-                  currentTime <= toSeconds(next.startHours, next.startMinutes, next.startSeconds) - 1;
+                  currentTime <= new Time(next.startHours, next.startMinutes, next.startSeconds).toSeconds() - 1;
     });
-}
-
-function toSeconds(hours: number, minutes: number, seconds: number): number {
-    return hours * 60 * 60 + minutes * 60 + seconds;
 }
 
 function debounce(func, timeout) {

--- a/web/ts/bookmarks.ts
+++ b/web/ts/bookmarks.ts
@@ -1,5 +1,5 @@
-import { Delete, getData, postData, putData } from "./global";
-import { currentTimeToHMS } from "./TUMLiveVjs";
+import { Delete, getData, postData, putData, Time } from "./global";
+import { getPlayers } from "./TUMLiveVjs";
 
 export class BookmarkList {
     private readonly streamId: number;
@@ -49,8 +49,15 @@ export class BookmarkDialog {
     }
 
     reset(): void {
-        const time = currentTimeToHMS();
-        this.request = { StreamID: this.streamId, Description: "", Hours: time.h, Minutes: time.m, Seconds: time.s };
+        const player = getPlayers()[0];
+        const time = Time.FromSeconds(player.currentTime()).toObject();
+        this.request = {
+            StreamID: this.streamId,
+            Description: "",
+            Hours: time.hours,
+            Minutes: time.minutes,
+            Seconds: time.seconds,
+        };
     }
 }
 

--- a/web/ts/bookmarks.ts
+++ b/web/ts/bookmarks.ts
@@ -27,7 +27,10 @@ export class BookmarkList {
 
     async fetch() {
         this.list = (await Bookmarks.get(this.streamId)) ?? [];
-        this.list.forEach((b) => (b.update = updateBookmark));
+        this.list.forEach((b) => {
+            b.update = updateBookmark;
+            b.friendlyTimestamp = new Time(b.hours, b.minutes, b.seconds).toString();
+        });
     }
 }
 

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -290,7 +290,11 @@ export class Time {
     }
 
     public toString() {
-        return `${Time.padZero(this.hours)}:${Time.padZero(this.minutes)}:${Time.padZero(this.seconds)}`;
+        let s = `${Time.padZero(this.minutes)}:${Time.padZero(this.seconds)}`;
+        if (this.hours > 0) {
+            s = `${Time.padZero(this.hours)}:` + s;
+        }
+        return s;
     }
 
     public toSeconds(): number {

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -297,6 +297,10 @@ export class Time {
         return s;
     }
 
+    public toStringWithLeadingZeros() {
+        return `${Time.padZero(this.hours)}:${Time.padZero(this.minutes)}:${Time.padZero(this.seconds)}`;
+    }
+
     public toSeconds(): number {
         return this.hours * 60 * 60 + this.minutes * 60 + this.seconds;
     }

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -269,6 +269,10 @@ export function keepQuery(url: string): string {
     return window.location.search.length > 0 ? url + window.location.search : url;
 }
 
+/**
+ * Time Utility Class
+ * Conversion of seconds to (hours, minutes, seconds) and vice versa.
+ */
 export class Time {
     private readonly hours: number;
     private readonly minutes: number;
@@ -285,12 +289,23 @@ export class Time {
         this.seconds = seconds;
     }
 
+    public toString() {
+        return `${Time.padZero(this.hours)}:${Time.padZero(this.minutes)}:${Time.padZero(this.seconds)}`;
+    }
+
     public toSeconds(): number {
         return this.hours * 60 * 60 + this.minutes * 60 + this.seconds;
     }
 
     public toObject() {
         return { hours: this.hours, minutes: this.minutes, seconds: this.seconds };
+    }
+
+    private static padZero(i: string | number) {
+        if (i < 10) {
+            i = "0" + i;
+        }
+        return i;
     }
 }
 

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -269,6 +269,31 @@ export function keepQuery(url: string): string {
     return window.location.search.length > 0 ? url + window.location.search : url;
 }
 
+export class Time {
+    private readonly hours: number;
+    private readonly minutes: number;
+    private readonly seconds: number;
+
+    static FromSeconds(seconds: number): Time {
+        const date = new Date(seconds * 1000);
+        return new Time(date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds());
+    }
+
+    constructor(hours = 0, minutes = 0, seconds = 0) {
+        this.hours = hours;
+        this.minutes = minutes;
+        this.seconds = seconds;
+    }
+
+    public toSeconds(): number {
+        return this.hours * 60 * 60 + this.minutes * 60 + this.seconds;
+    }
+
+    public toObject() {
+        return { hours: this.hours, minutes: this.minutes, seconds: this.seconds };
+    }
+}
+
 /**
  * TypeScript Mapping of model.VideoSection
  */

--- a/web/ts/video-sections.ts
+++ b/web/ts/video-sections.ts
@@ -1,4 +1,4 @@
-import { Delete, getData, postData, putData, Section } from "./global";
+import { Delete, getData, postData, putData, Section, Time } from "./global";
 
 export abstract class VideoSectionList {
     private streamId: number;
@@ -16,6 +16,9 @@ export abstract class VideoSectionList {
     async fetch() {
         VideoSections.get(this.streamId).then((list) => {
             this.list = list;
+            list.forEach(
+                (s) => (s.friendlyTimestamp = new Time(s.startHours, s.startMinutes, s.startSeconds).toString()),
+            );
         });
     }
 
@@ -131,11 +134,18 @@ export class VideoSectionsAdmin {
     async fetch() {
         VideoSections.get(this.streamId).then((list) => {
             this.existingSections = list;
+            list.forEach(
+                (s) => (s.friendlyTimestamp = new Time(s.startHours, s.startMinutes, s.startSeconds).toString()),
+            );
         });
     }
 
     pushNewSection() {
-        this.current.friendlyTimestamp = timeStringAsString(this.current);
+        this.current.friendlyTimestamp = new Time(
+            this.current.startHours,
+            this.current.startMinutes,
+            this.current.startSeconds,
+        ).toString();
         this.newSections.push({ ...this.current });
         this.resetCurrent();
         this.unsavedChanges = true;
@@ -171,28 +181,6 @@ export class VideoSectionsAdmin {
     }
 }
 
-function timeStringAsString(section: Section): string {
-    let s = "";
-
-    if (section.startHours > 0) {
-        s += section.startHours;
-        s += ":";
-    }
-    if (section.startMinutes < 10) {
-        s += `0${section.startMinutes}`;
-    } else {
-        s += section.startMinutes;
-    }
-    s += ":";
-    if (section.startSeconds < 10) {
-        s += `0${section.startSeconds}`;
-    } else {
-        s += section.startSeconds;
-    }
-
-    return s;
-}
-
 /**
  * Admin Page VideoSection Updater
  * @category admin-page
@@ -217,7 +205,11 @@ export class VideoSectionUpdater {
             this.section.startMinutes = this.request.StartMinutes;
             this.section.startSeconds = this.request.StartSeconds;
             this.section.description = this.request.Description;
-            this.section.friendlyTimestamp = timeStringAsString(this.section);
+            this.section.friendlyTimestamp = new Time(
+                this.section.startHours,
+                this.section.startMinutes,
+                this.section.startSeconds,
+            ).toString();
             this.show = false;
         });
     }

--- a/web/ts/watch.ts
+++ b/web/ts/watch.ts
@@ -2,7 +2,7 @@ import { scrollChat, shouldScroll, showNewMessageIndicator } from "./chat";
 import { NewChatMessage } from "./chat/NewChatMessage";
 import { getPlayers } from "./TUMLiveVjs";
 import { Realtime } from "./socket";
-import { copyToClipboard } from "./global";
+import { copyToClipboard, Time } from "./global";
 
 let currentChatChannel = "";
 const retryInt = 5000; //retry connecting to websocket after this timeout
@@ -318,7 +318,7 @@ export class ShareURL {
             if (shouldFetchPlayerTime || !this.timestamp) {
                 const player = getPlayers()[0];
                 await this.playerHasTime;
-                await this.setTimestamp(player.currentTime());
+                this.timestamp = Time.FromSeconds(player.currentTime()).toStringWithLeadingZeros();
                 await this.updateURLStateFromTimestamp();
             } else {
                 await this.updateURLStateFromTimestamp();
@@ -351,20 +351,5 @@ export class ShareURL {
                 this.timestampArgument = `?t=${inSeconds}`;
             }
         }
-    }
-
-    private async setTimestamp(time: number) {
-        const d = new Date(time * 1000);
-        const h = ShareURL.padZero(d.getUTCHours());
-        const m = ShareURL.padZero(d.getUTCMinutes());
-        const s = ShareURL.padZero(d.getSeconds());
-        this.timestamp = `${h}:${m}:${s}`;
-    }
-
-    private static padZero(i: string | number) {
-        if (i < 10) {
-            i = "0" + i;
-        }
-        return i;
     }
 }


### PR DESCRIPTION
### Motivation and Context
This PR is part of the watch page refactoring. Seconds to Hours/Minutes/Seconds is a common use case for TUM-Live, therefore wrap this into an easily reusable class. Furthermore utilize `Date` instead of custom solutions (See `currentTimeToHMS`).


### Description
- Add TypeScript class `Time`.
- Remove `friendlyTimestamp` from video sections and bookmarks
- Use `Time` in `ShareURL` class
- Update Tests

### Steps for Testing
- 1 Account
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Create Bookmarks
4. Click on Video Sections
5. Check if sharing still works
6. Check if the highlighting of video sections still works
7. Check if the admin side of things for video section still work
8. 🌟

(I added some sections to https://884.test.live.mm.rbg.tum.de/w/t2/6)
