### PR TITLE
[VOD-Service]: Delete uploaded file after segmenting

### DIFF
--- a/vod-service/internal/vodService.go
+++ b/vod-service/internal/vodService.go
@@ -79,6 +79,12 @@ func (a *App) uploadHandler(w http.ResponseWriter, r *http.Request) {
 var fileNameIllegal = regexp.MustCompile(`[^a-zA-Z0-9_\\.]+`)
 
 func (a *App) packageFile(file, name string) {
+	defer func() {
+		err := os.Remove(file)
+		if err != nil {
+			log.Printf("Error cleaning up file: %v", err)
+		}
+	}()
 	name = fileNameIllegal.ReplaceAllString(name, "_")
 	// override eventually existing files
 	err := os.RemoveAll(a.config.outputDir + name)


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Forgot to delete the files uploaded to the vod service which will eventually cause storage exhaustion on our servers :smile: 

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->

This PR makes the VOD-Service remove files after packaging the hls stream. 
