### PR TITLE
Resume at 1x speed when caught up with live stream

### DIFF
--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -80,6 +80,14 @@ export const initPlayer = function (
     player.on("ratechange", function () {
         window.localStorage.setItem("rate", player.playbackRate());
     });
+
+    // When catching up to live, resume at normal speed
+    player.liveTracker.on("liveedgechange", function (evt) {
+        if (player.liveTracker.atLiveEdge() && player.playbackRate() > 1) {
+            player.playbackRate(1);
+        }
+    });
+
     player.ready(function () {
         player.airPlay({
             addButtonToControlBar: true,


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When watching a live stream a few minutes behind at e.g. 2x speed, you'll catch up to live at some point. Currently you'll land in a loop of loading and then watching at 2x speed, rinse and repeat. 

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
Instead of keeping the current (too fast) playback rate, the rate will be adjusted when we reach the current live time. This leads to no disruptions when watching.
This fixes #667.

When compared to someone that always watched at 1x speed, the one that caught up will end up with a delay of 10-20 seconds. I tried to reduce this by trying out different values for the [`trackingThreshold`](https://docs.videojs.com/livetracker), but that didn't appear to help.
It might also make sense to wait until we buffer and then set to 1x if at the live edge, however that will result in a small interruption.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Livestream

1. Change the `streams.playlist_url` in the database as described [here](https://github.com/joschahenningsen/TUM-Live/issues/667#issuecomment-1387440714) (thanks :))
2. Log in
3. Navigate to that Livestream
4. Switch to the beta stream
5. Seek back e.g. 30 seconds and set the playback rate to 2x
6. Wait until you've caught up with live
7. The playback rate should automatically switch back to 1x

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
