### PR TITLE
Fix missing branding configuration in pop-out chat

### DIFF
--- a/web/popup.go
+++ b/web/popup.go
@@ -20,6 +20,7 @@ func (r mainRoutes) PopUpChat(c *gin.Context) {
 	var data ChatData
 
 	tumLiveContext := foundContext.(tools.TUMLiveContext)
+	data.IndexData = NewIndexData()
 	data.IndexData.TUMLiveContext = foundContext.(tools.TUMLiveContext)
 	data.IsAdminOfCourse = tumLiveContext.UserIsAdmin()
 	data.IsPopUp = true


### PR DESCRIPTION
### Motivation and Context
Currently, the branding configuration isn't included in the pop-out chat. This leads to certain problems,
such as the title of the page is incorrect. `| ...` vs `TUM-Live | ...`

### Description
Add branding configuration to pop-out chat handler function.

### Steps for Testing
1. Navigate to a Livestream
2. Title should be `TUM-Live | ...`

### Screenshots
**Before:**
<img width="248" alt="Screenshot 2023-02-09 at 10 04 26" src="https://user-images.githubusercontent.com/29633518/217767137-3572f26a-36f4-4639-a68c-504cef154409.png">

**After:**
<img width="259" alt="Screenshot 2023-02-09 at 10 05 23" src="https://user-images.githubusercontent.com/29633518/217767166-8d4790d8-3ace-49e4-9ff3-c22ad7cef6c7.png">
