### PR TITLE
SplitView bigger resize handle

### DIFF
--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -209,9 +209,31 @@
 .gutter {
     @apply bg-gray-200 dark:bg-gray-600;
 
+    position: relative;
+    width: 2px!important;
+    overflow: visible;
+}
+
+.gutter.gutter-horizontal::before {
+    @apply bg-gray-200 dark:bg-gray-600;
+    content: "";
+    position: absolute;
+    display: block;
     background-repeat: no-repeat;
     background-position: 50%;
-    width: 2px!important;
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
+    height: 120px;
+    top: calc(50% - 60px);
+    z-index: 2;
+    left: -6px;
+    right: -6px;
+    border-radius: 4px;
+    opacity: 0;
+    transition: ease-in 0.3s;
+}
+
+.splitview-wrap:hover .gutter.gutter-horizontal::before {
+    opacity: 1;
 }
 
 .gutter.gutter-horizontal {

--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -210,8 +210,12 @@
     @apply bg-gray-200 dark:bg-gray-600;
 
     position: relative;
-    width: 2px!important;
     overflow: visible;
+}
+
+.gutter.gutter-horizontal {
+    width: 2px!important;
+    cursor: col-resize;
 }
 
 .gutter.gutter-horizontal::before {
@@ -229,15 +233,11 @@
     right: -6px;
     border-radius: 4px;
     opacity: 0;
-    transition: ease-in 0.3s;
+    transition: ease-in 0.1s;
 }
 
-.splitview-wrap:hover .gutter.gutter-horizontal::before {
+.splitview-wrap.mouse-moving .gutter.gutter-horizontal::before {
     opacity: 1;
-}
-
-.gutter.gutter-horizontal {
-    cursor: col-resize;
 }
 
 /* Chat */

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -99,7 +99,7 @@
                     <i class="fas fa-info-circle mr-3"></i> This livestream has ended.
                 </div>
                 {{if (eq .Version "SPLIT")}}
-                    <div x-data="{splitView: new watch.SplitView()}" @mouseleave="splitView.hideMenu()" class="group relative flex w-full h-full">
+                    <div x-data="{splitView: new watch.SplitView()}" @mouseleave="splitView.hideMenu()" class="splitview-wrap group relative flex w-full h-full">
                         <div class="hidden group-hover:flex absolute left-1 top-1 z-40">
                             <button x-cloak x-show="!splitView.showSplitMenu" @click="splitView.toggleMenu()"
                                     class="flex items-center justify-center w-8 h-8 rounded-full"

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -99,7 +99,13 @@
                     <i class="fas fa-info-circle mr-3"></i> This livestream has ended.
                 </div>
                 {{if (eq .Version "SPLIT")}}
-                    <div x-data="{splitView: new watch.SplitView()}" @mouseleave="splitView.hideMenu()" class="splitview-wrap group relative flex w-full h-full">
+                    <div
+                        x-data="{splitView: new watch.SplitView(), mouseMoving: false}"
+                        @mouseleave="splitView.hideMenu()"
+                        @update-mouse-moving.camel="(e) => mouseMoving = e.detail"
+                        :class="mouseMoving && 'mouse-moving'"
+                        class="splitview-wrap group relative flex w-full h-full"
+                    >
                         <div class="hidden group-hover:flex absolute left-1 top-1 z-40">
                             <button x-cloak x-show="!splitView.showSplitMenu" @click="splitView.toggleMenu()"
                                     class="flex items-center justify-center w-8 h-8 rounded-full"

--- a/web/ts/splitview.ts
+++ b/web/ts/splitview.ts
@@ -2,6 +2,8 @@ import { getPlayers } from "./TUMLiveVjs";
 import Split from "split.js";
 import { cloneEvents } from "./global";
 
+const mouseMovingTimeout = 2200;
+
 export class SplitView {
     private camPercentage: number;
     private players: any[];
@@ -9,8 +11,10 @@ export class SplitView {
     private gutterWidth = 10;
     private isFullscreen = false;
     private splitParent: HTMLElement;
+    private videoWrapper: HTMLElement;
 
     showSplitMenu: boolean;
+    mouseMoving: boolean;
 
     static Options = {
         FullPresentation: 0,
@@ -23,8 +27,11 @@ export class SplitView {
     constructor() {
         this.camPercentage = SplitView.Options.FocusPresentation;
         this.showSplitMenu = false;
+        this.mouseMoving = false;
         this.players = getPlayers();
         this.splitParent = document.querySelector("#video-pres-wrapper").parentElement;
+        this.videoWrapper = document.querySelector(".splitview-wrap");
+        this.detectMouseNotMoving();
 
         this.players[0].ready(() => {
             this.setTrackBarModes(0, "disabled");
@@ -46,6 +53,29 @@ export class SplitView {
             onDrag(sizes: number[]) {
                 that.updateControlBarSize(sizes);
             },
+        });
+    }
+
+    updateMouseMoving(isMoving: boolean) {
+        if (isMoving != this.mouseMoving) {
+            this.mouseMoving = isMoving;
+            this.videoWrapper.dispatchEvent(new CustomEvent("updateMouseMoving", { detail: this.mouseMoving }));
+        }
+    }
+
+    detectMouseNotMoving() {
+        let mouseNotMovingTimeout;
+        this.videoWrapper.addEventListener("mousemove", (e) => {
+            this.updateMouseMoving(true);
+
+            clearTimeout(mouseNotMovingTimeout);
+            mouseNotMovingTimeout = setTimeout(() => {
+                this.updateMouseMoving(false);
+            }, mouseMovingTimeout);
+        });
+        this.videoWrapper.addEventListener("mouseleave", (e) => {
+            clearTimeout(mouseNotMovingTimeout);
+            this.updateMouseMoving(false);
         });
     }
 


### PR DESCRIPTION
### Motivation and Context
Its quite hard to resize the splitview player as the bar is so thin.

### Description
Add a handle to the bar that fades in when you move your mouse over the video player.

### Steps for Testing
Prerequisites:
- 1 Lecturer
- 2 Students
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Check if handle fades in and out and if you are able to resize the players

### Screenshots
<img width="958" alt="Bildschirm­foto 2023-02-20 um 12 31 27" src="https://user-images.githubusercontent.com/17506411/220094915-3284b0f9-93bb-45bc-b9c8-84b6061b4211.png">

