### PR TITLE
fix saml sp selection

### DIFF
--- a/web/saml.go
+++ b/web/saml.go
@@ -163,7 +163,7 @@ func getSamlSpFromHost(samlSPs []*samlsp.Middleware, host string) *samlsp.Middle
 			return samlSP
 		}
 	}
-	return nil
+	return samlSPs[0]
 }
 
 // extractSamlField gets the value of the given field from the SAML response or an empty string if the field is not present.

--- a/web/saml.go
+++ b/web/saml.go
@@ -159,7 +159,6 @@ func configSaml(r *gin.Engine, daoWrapper dao.DaoWrapper) {
 func getSamlSpFromHost(samlSPs []*samlsp.Middleware, host string) *samlsp.Middleware {
 	for _, samlSP := range samlSPs {
 		if strings.Contains(samlSP.ServiceProvider.AcsURL.String(), strings.Split(host, ":")[0]) {
-			log.Info("Found saml sp for host ", host, " with acs url ", samlSP.ServiceProvider.AcsURL)
 			return samlSP
 		}
 	}


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

#932 didn't work quite as expected because the /shib endpoint rejects requests for the wrong domains when using a default sp to parse it.

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->

This PR adds a list of service providers from which the right one is selected for each request depending on the request host. 

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Code review.