### PR TITLE
Added id to sort_order_button

### DIFF
--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -89,7 +89,7 @@
                     <span class="dark:bg-green-500 bg-green-400 rounded-full text-lg font-bold text-white px-5 my-auto">VoDs</span>
                     <div class="my-auto">
                         {{if .Course.HasRecordings}}
-                            <button class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded px-2"
+                            <button id="sort_order_button" class="hover:bg-gray-200 dark:hover:bg-gray-600 rounded px-2"
                                     x-init="if (asc) mirror();"
                                     @click="asc = !asc; mirror();">
                             <span class="text-sm font-semibold uppercase dark:text-white"


### PR DESCRIPTION
### Motivation and Context
Enables automated tools to determine sort order of the page.
### Description
All this should do is add a unique id to the button, as finding it by XPATH is apparently not reliable.

### Screenshots
[Button is displaying the text "DESC" here]:

![image](https://user-images.githubusercontent.com/31850924/221392606-ed0a484b-6ba4-4290-bbb0-7f690472987f.png)
