### PR TITLE
Firefox Subtitles

### DIFF
--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -88,9 +88,8 @@ export const initPlayer = function (
             player.playbackRate(1);
         }
     });
-
-    loadAndSetTrackbars(player, streamID);
     player.ready(function () {
+        loadAndSetTrackbars(player, streamID);
         player.airPlay({
             addButtonToControlBar: true,
             buttonPositionIndex: -2,


### PR DESCRIPTION
### Motivation and Context
Resolve #936 

### Description
As it seems Firefox handles things differently. Therefore the player state must be ready in order to add subtitles.
One potential explanation is that Firefox handles the video source differently.

Documentation of `player.addRemoteTrack()`:
```
Create a remote TextTrack and an HTMLTrackElement. 
It will automatically removed from the video element whenever the source changes, 
unless manualCleanup is set to false.
```
### Steps for Testing
- 1 Livestream
- Firefox Browser

1. Navigate to a livestream without subtitles
    * No subtitle button
2. Add subtitles to database and head back to livestream
    * Subtitle Button should be visible
