### PR TITLE
allow setting streams and vods private by default

### DIFF
--- a/model/course.go
+++ b/model/course.go
@@ -37,6 +37,9 @@ type Course struct {
 	CameraPresetPreferences string // json encoded. e.g. [{lectureHallID:1, presetID:4}, ...]
 	SourcePreferences       string // json encoded. e.g. [{lectureHallID:1, sourceMode:0}, ...]
 	Pinned                  bool   `gorm:"-"` // Used to determine if the course is pinned when loaded for a specific user.
+
+	LivePrivate bool `gorm:"not null; default:false"` // whether Livestreams are private
+	VodPrivate  bool `gorm:"not null; default:false"` // Whether VODs are made private after livestreams
 }
 
 // GetUrl returns the URL of the course, e.g. /course/2022/S/MyCourse

--- a/web/admin.go
+++ b/web/admin.go
@@ -269,12 +269,16 @@ func (r mainRoutes) UpdateCourse(c *gin.Context) {
 	enChat := c.PostForm("enChat") == "on"
 	enChatAnon := c.PostForm("enChatAnon") == "on"
 	enChatMod := c.PostForm("enChatMod") == "on"
+	livePrivate := c.PostForm("livePrivate") == "on"
+	vodPrivate := c.PostForm("vodPrivate") == "on"
 	tumLiveContext.Course.Visibility = access
 	tumLiveContext.Course.VODEnabled = enVOD
 	tumLiveContext.Course.DownloadsEnabled = enDL
 	tumLiveContext.Course.ChatEnabled = enChat
 	tumLiveContext.Course.AnonymousChatEnabled = enChatAnon
 	tumLiveContext.Course.ModeratedChatEnabled = enChatMod
+	tumLiveContext.Course.LivePrivate = livePrivate
+	tumLiveContext.Course.VodPrivate = vodPrivate
 	r.CoursesDao.UpdateCourseMetadata(context.Background(), *tumLiveContext.Course)
 	c.Redirect(http.StatusFound, fmt.Sprintf("/admin/course/%v", tumLiveContext.Course.ID))
 }

--- a/web/template/partial/course/manage/course_settings.gohtml
+++ b/web/template/partial/course/manage/course_settings.gohtml
@@ -75,6 +75,18 @@
                     </label>
                 </div>
             </div>
+            <h3 class="text-sm text-5">Advanced Visibility</h3>
+            <div>
+                <label class="block">
+                    <input type="checkbox" name="livePrivate"{{if .LivePrivate}} checked{{end}}>
+                    Private livestreams
+                </label>
+
+                <label class="block">
+                    <input type="checkbox" name="vodPrivate"{{if .VodPrivate}} checked{{end}}>
+                    Private recordings after livestream
+                </label>
+            </div>
             <div class="flex flex-col space-y-2 sm:space-y-0 sm:space-x-2 sm:block mt-2">
                 <input name="submit" class="btn" type="submit" value="Save Settings">
                 {{if .TUMOnlineIdentifier}}


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We had a ticket of a prof who wants their streams to be recorded but not accessible until they decide to publish them.

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
This pr adds an option to set streams and vods to be private by default. 

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Lecturer
- 1 Student
- 1 Livestream

1. Set streams and vods private in course settings
2. start stream
3. test that stream is accessible by lecturer but not by student
4. check that vod is accessible by lecturer but not by student
