### PR TITLE
Fix skip silence button fadeout 

### DIFF
--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -509,7 +509,7 @@ a.fc-event, a.fc-event:hover {
 }
 
 .vjs-has-started.vjs-user-inactive.vjs-playing .vjs-skip-silence-control {
-    visibility: visible;
+    visibility: hidden;
     opacity: 0;
     pointer-events: none;
     transition: visibility 1s,opacity 1s;


### PR DESCRIPTION
### Motivation and Context
Resolves #938 

### Description
Update CSS.

### Steps for Testing
- 1 Livestream

1. Navigate to a Livestream
2. Fade out the control bar (move your mouse somewhere else than the player)
3. The skip silence button shouldn't pop up and fade out immediately
4. Check if the skip silence button at the beginning of the VoD still works
