### PR TITLE
Fix chat replay message scrolling

### DIFF
--- a/web/template/partial/stream/chat/chat.gohtml
+++ b/web/template/partial/stream/chat/chat.gohtml
@@ -90,9 +90,9 @@
                     </button>
                 </template>
             </div>
-            <div class="my-auto space-x-2 ml-auto">
-                <button class="text-5 text-xs rounded-full font-semibold px-2 py-1 my-auto uppercase"
-                        :class="c.chatReplayActive ? 'bg-gray-300 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600' : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-700'"
+            <div class="flex items-center my-auto space-x-2 ml-auto">
+                <button class="flex border-0 h-8 w-8 rounded-full"
+                        :class="c.chatReplayActive ? 'bg-gray-100 dark:bg-gray-600 hover:bg-transparent' : 'bg-transparent hover:dark:bg-gray-600 hover:bg-gray-100'"
                         x-show="{{not (or $isComingUp $liveNow .IsPopUp)}}"
                         title="(De-)Activate Chat Replay"
                         @click="c.chatReplayActive = !c.chatReplayActive;"
@@ -100,7 +100,7 @@
                             $watch('c.chatReplayActive', (value) => {
                                 value ? c.activateChatReplay() : c.deactivateChatReplay();
                             })">
-                    <i class="fa-solid fa-clock-rotate-left"></i>
+                    <i class="fa-solid fa-clock-rotate-left m-auto text-sm"></i>
                 </button>
 
                 <!-- Toggle Chat and Polls -->

--- a/web/ts/chat.ts
+++ b/web/ts/chat.ts
@@ -29,8 +29,7 @@ export function scrollToTop() {
 }
 
 export function scrollToElement(element: HTMLElement) {
-    const chatBox = document.getElementById("chatBox");
-    chatBox.scrollTop = element.offsetTop;
+    element.scrollIntoView({ behavior: "smooth", block: "end", inline: "nearest" });
 }
 
 let orderByLikes = false; // sorting by likes or by time


### PR DESCRIPTION
### Motivation and Context
- Resolves #739 
- Update chat-replay button CSS

### Description
Use modern JS function.

### Steps for Testing
Prerequisites:
- 1 Account
- 1 Livestream with chat messages

1. Log in
2. Navigate to a Livestream
3. Activate chat replay
4. Should immediately jump to current chat message (smoothly!)
5. Check if the offset is still correct for messages sent later
6. 🚀

