### PR TITLE
Fix Firefox file drop

### DIFF
--- a/web/template/partial/course/manage/lecture-management-card.gohtml
+++ b/web/template/partial/course/manage/lecture-management-card.gohtml
@@ -81,14 +81,14 @@
                             <button @click="await admin.requestSubtitles(lecture.lectureId, 'de')"
                                     class="flex items-center justify-start
                                     py-1 px-2 text-3 w-full hover:bg-gray-200 hover:dark:bg-gray-600">
-                                <i class = "text-lg w-8">🇩🇪</i>
-                                <span class = "font-light text-sm ">German</span>
+                                <i class="text-lg w-8">🇩🇪</i>
+                                <span class="font-light text-sm ">German</span>
                             </button>
                             <button @click="await admin.requestSubtitles(lecture.lectureId, 'en')"
                                     class="flex items-center justify-start
                                     py-1 px-2 text-3 w-full hover:bg-gray-200 hover:dark:bg-gray-600">
-                                <i class = "text-lg w-8">🇬🇧</i>
-                                <span class = "font-light text-sm ">English</span>
+                                <i class="text-lg w-8">🇬🇧</i>
+                                <span class="font-light text-sm ">English</span>
                             </button>
                         </div>
                     </div>
@@ -230,15 +230,13 @@
                            class="w-auto mr-2" type="checkbox"/>
                     <span>Enable Live Chat</span>
                 </div>
-                <div x-data="{ id: $id('text-input'), fileDropHover: false }"
+                <div x-data="{ id: $id('text-input') }"
+                     @drop.prevent="(e) => lecture.onFileDrop(e)"
+                     @dragover.prevent=""
                      class="w-full flex flex-row">
                     <label :for="id" class="hidden">Lecture description</label>
                     <textarea :id="id"
-                              @drop="(e) => lecture.onFileDrop(e); fileDropHover = false"
-                              @dragover="fileDropHover = true"
-                              @dragleave="fileDropHover = false"
-                              class="tl-textarea grow"
-                              :class="fileDropHover ? 'shadow-sm border-blue-500/50' : 'border-transparent'"
+                              class="tl-textarea grow border-transparent"
                               placeholder="Add a nice description, links, and more. You can use Markdown. Drop files here."
                               autocomplete="off"
                               x-model="lecture.newDescription"

--- a/web/ts/edit-course.ts
+++ b/web/ts/edit-course.ts
@@ -352,7 +352,6 @@ export class Lecture {
     }
 
     onFileDrop(e) {
-        e.preventDefault();
         if (e.dataTransfer.items) {
             const kind = e.dataTransfer.items[0].kind;
             switch (kind) {


### PR DESCRIPTION
### Motivation and Context
Resolves #997 

### Description
Move `@drop` to `div` instead of `textarea`. Add empty `@dragover.prevent` to prevent Firefox' default behavior. Thus making dropping files possible.

### Steps for Testing
- 1 Admin of Course
- 1 Course

1. Log in
2. Navigate to a course management
3. Edit Lecture
4. Drop file in Firefox
5. Done ⚡️
