### PR TITLE
Canonical URLS

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -101,3 +101,4 @@ meili:
   host: http://localhost:7700
   apiKey: MASTER_KEY
 vodURLTemplate: https://stream.lrz.de/vod/_definst_/mp4:tum/RBG/%s.mp4/playlist.m3u8
+canonicalURL: https://tum.live

--- a/tools/canonical.go
+++ b/tools/canonical.go
@@ -24,3 +24,11 @@ func (c CanonicalURL) Course(year int, term string, slug string) string {
 func (c CanonicalURL) Stream(slug string, id uint, version string) string {
 	return path.Join(c.url, "w", slug, strconv.Itoa(int(id)), version)
 }
+
+func (c CanonicalURL) Login() string {
+	return path.Join(c.url, "login")
+}
+
+func (c CanonicalURL) Info(version string) string {
+	return path.Join(c.url, version)
+}

--- a/tools/canonical.go
+++ b/tools/canonical.go
@@ -1,0 +1,26 @@
+package tools
+
+import (
+	"path"
+	"strconv"
+)
+
+type CanonicalURL struct {
+	url string
+}
+
+func NewCanonicalURL(url string) CanonicalURL {
+	return CanonicalURL{url: url}
+}
+
+func (c CanonicalURL) Root() string {
+	return c.url
+}
+
+func (c CanonicalURL) Course(year int, term string, slug string) string {
+	return path.Join(c.url, "course", strconv.Itoa(year), term, slug)
+}
+
+func (c CanonicalURL) Stream(slug string, id uint) string {
+	return path.Join(c.url, "w", slug, strconv.Itoa(int(id)))
+}

--- a/tools/canonical.go
+++ b/tools/canonical.go
@@ -21,6 +21,6 @@ func (c CanonicalURL) Course(year int, term string, slug string) string {
 	return path.Join(c.url, "course", strconv.Itoa(year), term, slug)
 }
 
-func (c CanonicalURL) Stream(slug string, id uint) string {
-	return path.Join(c.url, "w", slug, strconv.Itoa(int(id)))
+func (c CanonicalURL) Stream(slug string, id uint, version string) string {
+	return path.Join(c.url, "w", slug, strconv.Itoa(int(id)), version)
 }

--- a/tools/config.go
+++ b/tools/config.go
@@ -172,6 +172,7 @@ type Config struct {
 		ApiKey string `yaml:"apiKey"`
 	} `yaml:"meili"`
 	VodURLTemplate string `yaml:"vodURLTemplate"`
+	CanonicalURL   string `yaml:"canonicalURL"`
 }
 
 func (Config) GetJWTKey() *rsa.PrivateKey {

--- a/web/index.go
+++ b/web/index.go
@@ -49,7 +49,7 @@ func (r mainRoutes) MainPage(c *gin.Context) {
 	}
 }
 
-func (r mainRoutes) InfoPage(id uint) gin.HandlerFunc {
+func (r mainRoutes) InfoPage(id uint, name string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var indexData IndexData
 		var tumLiveContext tools.TUMLiveContext
@@ -73,7 +73,8 @@ func (r mainRoutes) InfoPage(id uint) gin.HandlerFunc {
 		_ = templateExecutor.ExecuteTemplate(c.Writer, "info-page.gohtml", struct {
 			IndexData
 			Text template.HTML
-		}{indexData, text.Render()})
+			Name string
+		}{indexData, text.Render(), name})
 	}
 }
 

--- a/web/index.go
+++ b/web/index.go
@@ -92,13 +92,15 @@ type IndexData struct {
 	CurrentTerm         string
 	UserName            string
 	ServerNotifications []model.ServerNotification
+	CanonicalURL        tools.CanonicalURL
 	Branding            tools.Branding
 }
 
 func NewIndexData() IndexData {
 	return IndexData{
-		VersionTag: VersionTag,
-		Branding:   tools.BrandingCfg,
+		VersionTag:   VersionTag,
+		CanonicalURL: tools.NewCanonicalURL(tools.Cfg.CanonicalURL),
+		Branding:     tools.BrandingCfg,
 	}
 }
 

--- a/web/router.go
+++ b/web/router.go
@@ -86,9 +86,9 @@ func configMainRoute(router *gin.Engine) {
 	atLeastLecturerGroup.GET("/admin/create-course", routes.AdminPage)
 
 	// INFO: Make sure the IDs are correct!
-	router.GET("/privacy", routes.InfoPage(1))
-	router.GET("/imprint", routes.InfoPage(2))
-	router.GET("/about", routes.InfoPage(3))
+	router.GET("/privacy", routes.InfoPage(1, "privacy"))
+	router.GET("/imprint", routes.InfoPage(2, "imprint"))
+	router.GET("/about", routes.InfoPage(3, "about"))
 
 	adminGroup := router.Group("/")
 	adminGroup.GET("/admin/users", routes.AdminPage)

--- a/web/template/course-overview.gohtml
+++ b/web/template/course-overview.gohtml
@@ -1,3 +1,5 @@
+{{- /*gotype: github.com/joschahenningsen/TUM-Live/web.CoursePageData*/ -}}
+{{$course := .IndexData.TUMLiveContext.Course}}
 <!DOCTYPE html>
 <html lang="en" class="dark">
 <head>
@@ -5,12 +7,10 @@
     <title>{{.IndexData.Branding.Title}} | {{.IndexData.TUMLiveContext.Course.Name}}</title>
     <script src="/static/assets/ts-dist/global.bundle.js?v={{.IndexData.VersionTag}}"></script>
     {{template "headImports" .IndexData.VersionTag}}
+    <link rel="canonical" href="{{.IndexData.CanonicalURL.Course $course.Year $course.TeachingTerm $course.Slug }}">
 </head>
 <body class="md:overflow-hidden">
-{{- /*gotype: github.com/joschahenningsen/TUM-Live/web.CoursePageData*/ -}}
-{{$course := .IndexData.TUMLiveContext.Course}}
 {{template "header" .IndexData.TUMLiveContext}}
-
 <div class="m-auto px-1 sm:px-3 lg:px-5 w-full xl:w-2/3"
      style="height: calc(100vh - (6.5rem));" {{/* 6.5 = nav height + padding */}}>
     <div class="flex my-8 pl-2 md:pl-0">

--- a/web/template/index.gohtml
+++ b/web/template/index.gohtml
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>{{.Branding.Title}}</title>
+    <link rel="canonical" href="{{.CanonicalURL.Root}}" />
     {{template "headImports" .VersionTag}}
     <meta name="description" content="{{.Branding.Description}}"/>
 </head>

--- a/web/template/info-page.gohtml
+++ b/web/template/info-page.gohtml
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>{{.Branding.Title}}</title>
+    <link rel="canonical" href="{{.IndexData.CanonicalURL.Info .Name}}" />
     {{template "headImports" .VersionTag}}
 </head>
 <body>

--- a/web/template/login.gohtml
+++ b/web/template/login.gohtml
@@ -2,6 +2,7 @@
 <html lang="en" class="dark">
 <head>
     <title>{{.Branding.Title}} | Login</title>
+    <link rel="canonical" href="{{.CanonicalURL.Login}}" />
     {{template "headImports" .VersionTag}}
 </head>
 <body>

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -6,6 +6,7 @@
     {{$stream := .IndexData.TUMLiveContext.Stream}}
     {{$course := .IndexData.TUMLiveContext.Course}}
     <title>{{.IndexData.Branding.Title}} | {{$course.Name}}: {{$stream.Name}}</title>
+    <link rel="canonical" href="{{.IndexData.CanonicalURL.Stream $course.Slug $stream.ID}}" />
     {{template "headImports" .IndexData.VersionTag}}
     <script>window.HELP_IMPROVE_VIDEOJS = false;</script>
     <script src="/static/assets/ts-dist/watch.bundle.js?v={{.IndexData.VersionTag}}"></script>

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -6,7 +6,7 @@
     {{$stream := .IndexData.TUMLiveContext.Stream}}
     {{$course := .IndexData.TUMLiveContext.Course}}
     <title>{{.IndexData.Branding.Title}} | {{$course.Name}}: {{$stream.Name}}</title>
-    <link rel="canonical" href="{{.IndexData.CanonicalURL.Stream $course.Slug $stream.ID}}" />
+    <link rel="canonical" href="{{.IndexData.CanonicalURL.Stream $course.Slug $stream.ID .Version}}" />
     {{template "headImports" .IndexData.VersionTag}}
     <script>window.HELP_IMPROVE_VIDEOJS = false;</script>
     <script src="/static/assets/ts-dist/watch.bundle.js?v={{.IndexData.VersionTag}}"></script>

--- a/web/user.go
+++ b/web/user.go
@@ -187,9 +187,10 @@ func (r mainRoutes) CreatePasswordPage(c *gin.Context) {
 // NewLoginPageData returns a new struct LoginPageData with the Error value err
 func NewLoginPageData(err bool) LoginPageData {
 	return LoginPageData{
-		VersionTag: VersionTag,
-		Error:      err,
-		Branding:   tools.BrandingCfg,
+		VersionTag:   VersionTag,
+		Error:        err,
+		Branding:     tools.BrandingCfg,
+		CanonicalURL: tools.NewCanonicalURL(tools.Cfg.CanonicalURL),
 	}
 }
 
@@ -202,5 +203,6 @@ type LoginPageData struct {
 	IDPName  string
 	IDPColor string
 
-	Branding tools.Branding
+	Branding     tools.Branding
+	CanonicalURL tools.CanonicalURL
 }


### PR DESCRIPTION
### Motivation and Context
- Addresses #978 

### Description
- Add canonicalURL to `config.yaml`
- Add struct `CanonicalURL` which provides canonical urls for the start, course, and watch page
- Add `<link rel="canonical" href="..">` to start, course, and watch page

### Steps for Testing
1. Navigate to a start, course, and watch page
2. Open web inspector
3. Check if each `<head>` includes `<link rel="canonical" href="..">` and the URL is correct.
4. 🌟
