### PR TITLE
Page structure updates for Course Management

### DIFF
--- a/web/template/admin/admin_tabs/edit-course.gohtml
+++ b/web/template/admin/admin_tabs/edit-course.gohtml
@@ -40,20 +40,20 @@
                     <li class="mr-2">
                         <button
                             @click="selectedTab = $el.dataset.tab"
-                            data-tab="external-participants"
-                            :class="selectedTab == $el.dataset.tab ?
-                            'inline-block p-4 border-b-2 rounded-t-lg'
-                            : 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300'"
-                        >External Participants</button>
-                    </li>
-                    <li class="mr-2">
-                        <button
-                            @click="selectedTab = $el.dataset.tab"
                             data-tab="settings"
                             :class="selectedTab == $el.dataset.tab ?
                             'inline-block p-4 border-b-2 rounded-t-lg'
                             : 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300'"
                         >Settings</button>
+                    </li>
+                    <li class="mr-2">
+                        <button
+                                @click="selectedTab = $el.dataset.tab"
+                                data-tab="external-participants"
+                                :class="selectedTab == $el.dataset.tab ?
+                            'inline-block p-4 border-b-2 rounded-t-lg'
+                            : 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300'"
+                        >External Participants</button>
                     </li>
                 </ul>
             </div>
@@ -67,13 +67,6 @@
                     <div class="form-container">
                         <h2 class="form-container-title">Lectures</h2>
                         {{template "course-lecture-management" .}}
-                    </div>
-                </div>
-
-                <div data-tab="external-participants" x-show="selectedTab === $el.dataset.tab">
-                    <div class="form-container">
-                        <h2 class="form-container-title">External Participants</h2>
-                        {{template "externalParticipants" $course}}
                     </div>
                 </div>
 
@@ -95,6 +88,13 @@
                     <div class="form-container">
                         <h2 class="form-container-title">Actions</h2>
                         {{template "dangerzone" $course}}
+                    </div>
+                </div>
+
+                <div data-tab="external-participants" x-show="selectedTab === $el.dataset.tab">
+                    <div class="form-container">
+                        <h2 class="form-container-title">External Participants</h2>
+                        {{template "externalParticipants" $course}}
                     </div>
                 </div>
             </div>

--- a/web/template/admin/admin_tabs/edit-course.gohtml
+++ b/web/template/admin/admin_tabs/edit-course.gohtml
@@ -24,39 +24,80 @@
 
         <label class="hidden" for="courseID">CourseID<input id="courseID" type="text" class="hidden"
                 value="{{$course.Model.ID}}"></label>
-        <div class="form-container">
-            <h2 class="form-container-title">Settings</h2>
-            {{template "course_settings" $course}}
-        </div>
 
-        <div class="form-container">
-            <h2 class="form-container-title">Course Admins</h2>
-            {{template "course-admin-management" $course}}
-        </div>
+        <div x-data="{ selectedTab: 'lectures' }">
+            <div class="mb-4 border-b border-gray-200 dark:border-gray-700">
+                <ul class="flex flex-wrap -mb-px text-sm font-medium text-center">
+                    <li class="mr-2">
+                        <button
+                            @click="selectedTab = $el.dataset.tab"
+                            data-tab="lectures"
+                            :class="selectedTab == $el.dataset.tab ?
+                            'inline-block p-4 border-b-2 rounded-t-lg'
+                            : 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300'"
+                        >Lectures</button>
+                    </li>
+                    <li class="mr-2">
+                        <button
+                            @click="selectedTab = $el.dataset.tab"
+                            data-tab="external-participants"
+                            :class="selectedTab == $el.dataset.tab ?
+                            'inline-block p-4 border-b-2 rounded-t-lg'
+                            : 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300'"
+                        >External Participants</button>
+                    </li>
+                    <li class="mr-2">
+                        <button
+                            @click="selectedTab = $el.dataset.tab"
+                            data-tab="settings"
+                            :class="selectedTab == $el.dataset.tab ?
+                            'inline-block p-4 border-b-2 rounded-t-lg'
+                            : 'inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300'"
+                        >Settings</button>
+                    </li>
+                </ul>
+            </div>
+            <div>
+                <div data-tab="lectures" x-show="selectedTab === $el.dataset.tab">
+                    <div class="form-container">
+                        <h2 class="form-container-title">New Lecture</h2>
+                        {{template "create-lecture-form" .}}
+                    </div>
 
-        <div class="form-container">
-            <h2 class="form-container-title">Lecture Hall Settings</h2>
-            {{template "source-settings"}}
-        </div>
+                    <div class="form-container">
+                        <h2 class="form-container-title">Lectures</h2>
+                        {{template "course-lecture-management" .}}
+                    </div>
+                </div>
 
-        <div class="form-container">
-            <h2 class="form-container-title">New Lecture</h2>
-            {{template "create-lecture-form" .}}
-        </div>
+                <div data-tab="external-participants" x-show="selectedTab === $el.dataset.tab">
+                    <div class="form-container">
+                        <h2 class="form-container-title">External Participants</h2>
+                        {{template "externalParticipants" $course}}
+                    </div>
+                </div>
 
-        <div class="form-container">
-            <h2 class="form-container-title">Lectures</h2>
-            {{template "course-lecture-management" .}}
-        </div>
+                <div data-tab="settings" x-show="selectedTab === $el.dataset.tab">
+                    <div class="form-container">
+                        <h2 class="form-container-title">Settings</h2>
+                        {{template "course_settings" $course}}
+                    </div>
 
-        <div class="form-container">
-            <h2 class="form-container-title">External Participants</h2>
-            {{template "externalParticipants" $course}}
-        </div>
+                    <div class="form-container">
+                        <h2 class="form-container-title">Course Admins</h2>
+                        {{template "course-admin-management" $course}}
+                    </div>
 
-        <div class="form-container">
-            <h2 class="form-container-title">Actions</h2>
-            {{template "dangerzone" $course}}
+                    <div class="form-container">
+                        <h2 class="form-container-title">Lecture Hall Settings</h2>
+                        {{template "source-settings"}}
+                    </div>
+                    <div class="form-container">
+                        <h2 class="form-container-title">Actions</h2>
+                        {{template "dangerzone" $course}}
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/web/template/partial/course/manage/lecture-management-card.gohtml
+++ b/web/template/partial/course/manage/lecture-management-card.gohtml
@@ -9,8 +9,8 @@
     <li :id="$id('lecture-li')"
         x-show="!filterPast || !lecture.isPast"
         :key="lecture.lectureId"
-        class="w-full mb-4 overflow-hidden relative bg-white dark:bg-gray-800 border dark:border-0 rounded shadow">
-        <div class="border-t-2 flex justify-between mb-2" :class="'border-' + lecture.color">
+        class="w-full mb-4 relative bg-white dark:bg-gray-800 border dark:border-0 rounded shadow">
+        <div class="border-t-2 flex justify-between mb-2 rounded-t" :class="'border-' + lecture.color">
             <div class="pt-2 px-2 w-full">
                 <div class="text-3 font-semibold">
                     <input @change="$event.target.checked ? selectedLectures.push({ id: lecture.lectureId, isPast: lecture.isPast }) : (selectedLectures = selectedLectures.filter(({id}) => id != lecture.lectureId))"
@@ -214,7 +214,7 @@
 
         <button x-show="lecture.uiEditMode == 0"
                 @click="lecture.startSingleEdit(); closeMoreDropdown();"
-                class="bg-gray-100 dark:bg-gray-900 w-full py-2 mt-2">
+                class="bg-gray-100 dark:bg-gray-900 w-full py-2 mt-2 rounded-b">
             <span class="text-gray-700 dark:text-gray-300">Edit Lecture</span>
         </button>
 

--- a/web/template/partial/course/manage/lecture-management-card.gohtml
+++ b/web/template/partial/course/manage/lecture-management-card.gohtml
@@ -9,7 +9,7 @@
     <li :id="$id('lecture-li')"
         x-show="!filterPast || !lecture.isPast"
         :key="lecture.lectureId"
-        class="w-full mb-4 pb-4 relative bg-white dark:bg-gray-800 border dark:border-0 rounded shadow">
+        class="w-full mb-4 overflow-hidden relative bg-white dark:bg-gray-800 border dark:border-0 rounded shadow">
         <div class="border-t-2 flex justify-between mb-2" :class="'border-' + lecture.color">
             <div class="pt-2 px-2 w-full">
                 <div class="text-3 font-semibold">
@@ -211,6 +211,12 @@
                 </div>
             </div>
         </div>
+
+        <button x-show="lecture.uiEditMode == 0"
+                @click="lecture.startSingleEdit(); closeMoreDropdown();"
+                class="bg-gray-100 dark:bg-gray-900 w-full py-2 mt-2">
+            <span class="text-gray-700 dark:text-gray-300">Edit Lecture</span>
+        </button>
 
         <div x-show="lecture.uiEditMode > 0" class="grid gap-y-4 p-4">
             <article class="grid gap-2 w-full">


### PR DESCRIPTION
### Motivation and Context
Lecture Items are not very easy to edit, as the edit functionality is hidden in a small error next to destructive actions.
Course overview page is not very user-friendly as it has much information on one single page.

### Description
Added tabs to the 3 main functionalities of the course management page. Added a more visible button to
the lectures to make them easier to edit.

### Steps for Testing
Prerequisites:
- 1 Lecturer

1. Log in
2. Navigate to a Management Page of a Course
3. Click through tabs and see if the content is displayed accordingly
4. Try to change a Lecture by clicking the new button.

### Screenshots
<img width="481" alt="Bildschirmfoto 2023-04-25 um 13 50 02" src="https://user-images.githubusercontent.com/17506411/234267665-2b18c2e6-f6f3-450b-abd0-0f30d87eb5db.png">

<img width="924" alt="Bildschirmfoto 2023-04-25 um 13 50 31" src="https://user-images.githubusercontent.com/17506411/234267767-7156b8e8-5548-49ab-9a21-4bb208be252c.png">
