### PR TITLE
Improve styling of user notifications

### DIFF
--- a/web/template/admin/admin_tabs/notifications.gohtml
+++ b/web/template/admin/admin_tabs/notifications.gohtml
@@ -4,14 +4,16 @@
     {{ range . }}
         {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.Notification*/ -}}
         <section x-data class="form-container">
-            <h2 class="form-container-title">
-                <span class="mr-4">{{.Model.CreatedAt.Format "02.01.2006 15:04"}}</span>
-                {{if .Title}}{{.Title}}{{else}}<i>No title</i>{{end}}
-                <button class="btn primary align-right" type="button"
-                        @click="admin.deleteNotification({{.Model.ID}})">Delete
-                </button>
+            <h2 class="form-container-title flex justify-between">
+                <span>
+                    <span class="mr-4">{{.Model.CreatedAt.Format "02.01.2006 15:04"}}</span>
+                    {{if .Title}}{{.Title}}{{else}}<i>No title</i>{{end}}
+                </span>
+                <div class="justify-self-end ml-2">
+                    <i @click="admin.deleteNotification({{.Model.ID}})" class="fas fa-trash btn primary"></i>
+                </div>
             </h2>
-            <div class="form-container-body">
+            <div class="form-container-body text-3">
                 <div>{{.GetBodyForGoTemplate}}</div>
             </div>
         </section>

--- a/web/template/admin/admin_tabs/notifications.gohtml
+++ b/web/template/admin/admin_tabs/notifications.gohtml
@@ -5,9 +5,9 @@
         {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.Notification*/ -}}
         <section x-data class="form-container">
             <h2 class="form-container-title flex justify-between items-center">
-                <div class="justify-self-center">
+                <div>
                     <div class="mr-4 text-sm">{{.Model.CreatedAt.Format "02.01.2006 15:04"}}</div>
-                    {{if .Title}}{{.Title}}{{else}}<i>No title</i>{{end}}
+                    <i>{{if .Title}}{{.Title}}{{else}}No title{{end}}</i>
                 </div>
                 <div>
                     <i @click="admin.deleteNotification({{.Model.ID}})" class="fas fa-trash btn primary"></i>

--- a/web/template/admin/admin_tabs/notifications.gohtml
+++ b/web/template/admin/admin_tabs/notifications.gohtml
@@ -4,12 +4,12 @@
     {{ range . }}
         {{- /*gotype: github.com/joschahenningsen/TUM-Live/model.Notification*/ -}}
         <section x-data class="form-container">
-            <h2 class="form-container-title flex justify-between">
-                <span>
-                    <span class="mr-4">{{.Model.CreatedAt.Format "02.01.2006 15:04"}}</span>
+            <h2 class="form-container-title flex justify-between items-center">
+                <div class="justify-self-center">
+                    <div class="mr-4 text-sm">{{.Model.CreatedAt.Format "02.01.2006 15:04"}}</div>
                     {{if .Title}}{{.Title}}{{else}}<i>No title</i>{{end}}
-                </span>
-                <div class="justify-self-end ml-2">
+                </div>
+                <div>
                     <i @click="admin.deleteNotification({{.Model.ID}})" class="fas fa-trash btn primary"></i>
                 </div>
             </h2>


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Font styling broken in dark / light mode
- Alignments could be improved

### Description
Simple restyling of the user notifications.

### Steps for Testing

Create a user notification via the admin UI and use dark and light mode.

### Screenshots
<img width="778" alt="Screenshot 2023-04-27 at 21 46 27" src="https://user-images.githubusercontent.com/30267166/234975111-767c8dc1-065a-486e-ac86-6d9036cb80e1.png">
<img width="794" alt="Screenshot 2023-04-27 at 21 46 14" src="https://user-images.githubusercontent.com/30267166/234975123-d612da05-b2f3-41ec-a7f9-c7c62ac61b03.png">

