### PR TITLE
`Bug` Today's lecture list

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -278,7 +278,7 @@
             </article>
         </template>
         <template x-if="view === home.Views.Main">
-            <article id="main-view" class="relative min-h-full">
+            <article id="main-view" class="relative min-h-full pb-8">
                 {{if $user}}
                     {{if $user.Name}}
                         <h1 id="greeting" class="md:text-2xl text-xl font-bold mb-4 px-3">

--- a/web/ts/views/home.ts
+++ b/web/ts/views/home.ts
@@ -163,7 +163,7 @@ export function context() {
         getLiveToday() {
             const today = new Date();
             const eq = (a: Date, b: Date) =>
-                a.getDay() === b.getDay() && a.getMonth() == b.getMonth() && a.getFullYear() === b.getFullYear();
+                a.getDate() === b.getDate() && a.getMonth() == b.getMonth() && a.getFullYear() === b.getFullYear();
             return this.userCourses
                 .filter((c) => c.NextLecture.ID !== 0)
                 .filter((c) => eq(today, new Date(c.NextLecture.Start)));


### PR DESCRIPTION
### Motivation and Context
Because of a wrong Javascript method, the "today list" depicts lectures that go live on the same day in a week instead of the same day in a month. 

### Description
- Use correct javascript method.
- Add some padding-bottom to make the next button more visible on mobile browsers.
### Steps for Testing
- Account

1. Log in
2. `/new`
3. Check if the today's lecture list still works

