### PR TITLE
Show user courses for lecturers

### DIFF
--- a/api/courses.go
+++ b/api/courses.go
@@ -220,6 +220,7 @@ func (r coursesRoutes) getUsers(c *gin.Context) {
 		case model.AdminType:
 			courses = routes.GetAllCoursesForSemester(year, term, c)
 		case model.LecturerType:
+			courses = tumLiveContext.User.CoursesForSemester(year, term, context.Background())
 			coursesForLecturer, err := r.GetAdministeredCoursesByUserId(c, tumLiveContext.User.ID, term, year)
 			if err == nil {
 				courses = append(courses, coursesForLecturer...)


### PR DESCRIPTION
### Motivation and Context
Currently, account which are registered as `lecturers` don't see the courses they participate in (i.e. their user courses) on the new start page.

### Description
Add missing function call. 

### Steps for Testing
- 1 Lecturer
- 1 Course that he doesn't administer 

1. Log in
2. Course should be listed under **`user courses`**
3. 🕺
