### PR TITLE
Added dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/"
     schedule:
       intervale: "weekly"
+      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/web/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      intervale: "weekly"


### PR DESCRIPTION
### Motivation and Context
Dependabot is an automated dependency update service of github. It will check the versions of the npm packages and go modules and create automatic pull requests to update them. 

I think that it still needs to be enabled by the maintainers under Settings->Security->Code security and analysis:
![Bildschirmfoto vom 2023-05-24 21-54-31](https://github.com/joschahenningsen/TUM-Live/assets/37212628/8efc4292-0ec9-4e2b-b84b-dbb073eaab8c)


For more information, checkout this page: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

### Description
Enables the dependabot to check the npm packages and go modules for newer versions on a weekly basis. 

