### PR TITLE
Add `live_rate` parameter and add dynamic rate adjusting

### DIFF
--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -122,7 +122,7 @@ class PlayerSettings {
     }
 
     storeRate() {
-        PlayerSettings.setInStorage(this.isLive ? "live_rate" : "rate", String(this.player.playbackRate()););
+        PlayerSettings.setInStorage(this.isLive ? "live_rate" : "rate", String(this.player.playbackRate()));
     }
 
     static setInStorage(key: string, value: string) {


### PR DESCRIPTION
### Motivation and Context
- Resolves #1031 and #1030 by adding the key `live_rate` to the LocalStorage.
- Resolves #544 by adding query parameter `?rate={float >= 0}`. This way anyone can adjust the playback-speed to his/her desired value 😬
- Add `PlayerSettings` object to tidy up player settings setting and storing.

### Steps for Testing
- 1 Lecturer
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Add `?rate=2.3` to query (Playback speed should now be 2.3)
4. Add `?t=1337` to query (Video should jump forwards)
5. Mute, Set Volume, Set Playback speed manually via the video menu. Reload. (Settings should now be the same as before)
6. Any combination of 3, 4, & 5
7. 🌟

You can also check the browser console for those values since I've added some useful logging messages.
