### PR TITLE
Preload next `N` thumbnails on new start page

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -655,7 +655,8 @@
                                                 <template x-if="course.NextLecture.IsComingUp">
                                                     <span>
                                                         <span>Next lecture starts in </span><!--
-                                                        --><span x-text="course.NextLecture.MinutesLeftToStart()"></span><!--
+                                                        --><span
+                                                                x-text="course.NextLecture.MinutesLeftToStart()"></span><!--
                                                         --><span> Minutes.</span>
                                                         <a :href="course.WatchURL(course.NextLecture.ID)"
                                                            title="Join waiting room">

--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -604,7 +604,7 @@
                                         </div>
                                         <div class="px-2">
                                             <a class="course text-sm"
-                                               :href="course.URL()"
+                                               :href="livestream.Course.URL()"
                                                @click.prevent="showCourse(livestream.Course.Slug)"
                                                x-text="livestream.Course.Name">
                                             </a>

--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -441,7 +441,7 @@
                                                         <i class="fa-solid fa-ellipsis-vertical"></i>
                                                     </button>
                                                     <template x-if="vod.Dropdown.value">
-                                                        <div class="absolute tum-live-menu py-2 absolute top-full right-0 h-fit overflow-hidden z-50 w-56">
+                                                        <div class="absolute tum-live-menu py-2 absolute bottom-full right-0 h-fit overflow-hidden z-50 w-56">
                                                             {{if $user}}
                                                                 <button type="button"
                                                                         @click="vod.Progress.ToggleWatched()"

--- a/web/ts/api/courses.ts
+++ b/web/ts/api/courses.ts
@@ -22,6 +22,7 @@ export class Stream {
     Progress?: Progress;
 
     Dropdown = new ToggleableElement([["downloads", new ToggleableElement()]]);
+    Thumbnail?: HTMLImageElement;
 
     public HasName(): boolean {
         return this.Name !== "";
@@ -73,6 +74,11 @@ export class Stream {
         return 0;
     }
 
+    public FetchThumbnail() {
+        this.Thumbnail = new Image();
+        this.Thumbnail.src = `/api/stream/${this.ID}/thumbs/vod`;
+    }
+
     private static TimeOf(d: string): string {
         return new Date(d).toLocaleTimeString("default", { hour: "2-digit", minute: "2-digit" });
     }
@@ -106,11 +112,6 @@ export class Course {
         c.Recordings = c.Streams.filter((s) => s.IsRecording);
         c.Planned = c.Streams.filter((s) => s.IsPlanned);
         return c;
-    }
-
-    static LoadThumbnail(course: Course) {
-        const i = new Image();
-        i.src = `/api/stream/${course.ID}/thumbs/vod`;
     }
 
     public URL(): string {

--- a/web/ts/api/courses.ts
+++ b/web/ts/api/courses.ts
@@ -108,6 +108,11 @@ export class Course {
         return c;
     }
 
+    static LoadThumbnail(course: Course) {
+        const i = new Image();
+        i.src = `/api/stream/${course.ID}/thumbs/vod`;
+    }
+
     public URL(): string {
         return `?year=${this.Year}&term=${this.TeachingTerm}&slug=${this.Slug}&view=3`;
     }

--- a/web/ts/components/course.ts
+++ b/web/ts/components/course.ts
@@ -25,7 +25,7 @@ export function courseContext(slug: string, year: number, term: string): AlpineC
 
         course: new Course() as Course,
 
-        courseStreams: new Paginator<Stream>([], 8),
+        courseStreams: new Paginator<Stream>([], 8, (s: Stream) => s.FetchThumbnail()),
 
         plannedStreams: new Paginator<Stream>([], 3),
 
@@ -57,7 +57,8 @@ export function courseContext(slug: string, year: number, term: string): AlpineC
                         this.courseStreams
                             .set(this.course.Recordings)
                             .forEach((s: Stream, i) => (s.Progress = progresses[i]))
-                            .reset();
+                            .reset()
+                            .preload();
                     });
                     console.log("🌑 init course", this.course);
                 });

--- a/web/ts/components/course.ts
+++ b/web/ts/components/course.ts
@@ -59,7 +59,7 @@ export function courseContext(slug: string, year: number, term: string): AlpineC
                             .set(this.course.Recordings)
                             .forEach((s: Stream, i) => (s.Progress = progresses[i]))
                             .reset()
-                            .preload();
+                            .preload(this.sortFn(this.streamSortMode));
                     });
                     console.log("🌑 init course", this.course);
                 });

--- a/web/ts/components/main.ts
+++ b/web/ts/components/main.ts
@@ -10,7 +10,7 @@ export function mainContext(year: number, term: string) {
 
         userCourses: [] as Course[],
         liveToday: [] as Course[],
-        recently: new Paginator<Course>([], 10, Course.LoadThumbnail),
+        recently: new Paginator<Course>([], 10, (c: Course) => c.LastRecording.FetchThumbnail()),
 
         /**
          * AlpineJS init function which is called automatically in addition to 'x-init'
@@ -30,7 +30,7 @@ export function mainContext(year: number, term: string) {
                     console.error(err);
                 })
                 .then(() => {
-                    this.recently.set(this.getRecently()).reset();
+                    this.recently.set(this.getRecently()).reset().preload();
                     this.liveToday = this.getLiveToday();
                     this.loadProgresses(this.userCourses.map((c) => c.LastRecording.ID));
                     console.log("🌑 init recently", this.recently);

--- a/web/ts/components/main.ts
+++ b/web/ts/components/main.ts
@@ -10,7 +10,7 @@ export function mainContext(year: number, term: string) {
 
         userCourses: [] as Course[],
         liveToday: [] as Course[],
-        recently: new Paginator<Course>([], 10),
+        recently: new Paginator<Course>([], 10, Course.LoadThumbnail),
 
         /**
          * AlpineJS init function which is called automatically in addition to 'x-init'

--- a/web/ts/utilities/paginator.ts
+++ b/web/ts/utilities/paginator.ts
@@ -27,7 +27,7 @@ export class Paginator<T> {
 
     next(all = false) {
         this.index = all ? this.list.length / this.split_number : this.index + 1;
-        this.preload();
+        this.__preload();
     }
 
     hasNext() {
@@ -48,10 +48,15 @@ export class Paginator<T> {
         return this;
     }
 
-    private preload() {
+    preload(): Paginator<T> {
+        this.__preload();
+        return this;
+    }
+
+    private __preload() {
         if (this.hasNext() && this.preloader) {
             this.list
-                .slice((this.index - 1) * this.split_number, this.index * this.split_number)
+                .slice(this.index * this.split_number, (this.index + 1) * this.split_number)
                 .forEach((el: T) => this.preloader(el));
         }
     }

--- a/web/ts/utilities/paginator.ts
+++ b/web/ts/utilities/paginator.ts
@@ -13,7 +13,7 @@ export class Paginator<T> {
         this.preloader = preloader;
     }
 
-    get(sortFn?: (a: T, b: T) => number, filterPred?: (o: T) => boolean): T[] {
+    get(sortFn?: CompareFunction<T>, filterPred?: FilterPredicate<T>): T[] {
         const copy = filterPred ? [...this.list].filter(filterPred) : [...this.list];
         return sortFn
             ? copy.sort(sortFn).slice(0, this.index * this.split_number)
@@ -27,7 +27,7 @@ export class Paginator<T> {
 
     next(all = false) {
         this.index = all ? this.list.length / this.split_number : this.index + 1;
-        this.__preload();
+        this.preload();
     }
 
     hasNext() {
@@ -48,18 +48,17 @@ export class Paginator<T> {
         return this;
     }
 
-    preload(): Paginator<T> {
-        this.__preload();
-        return this;
-    }
-
-    private __preload() {
+    preload(sortFn?: CompareFunction<T>): Paginator<T> {
         if (this.hasNext() && this.preloader) {
-            this.list
+            [...this.list]
+                .sort(sortFn)
                 .slice(this.index * this.split_number, (this.index + 1) * this.split_number)
                 .forEach((el: T) => this.preloader(el));
         }
+        return this;
     }
 }
 
 type Preload<T> = (o: T) => void;
+type CompareFunction<T> = (a: T, b: T) => number;
+type FilterPredicate<T> = (o: T) => boolean;

--- a/web/ts/utilities/paginator.ts
+++ b/web/ts/utilities/paginator.ts
@@ -49,8 +49,9 @@ export class Paginator<T> {
     }
 
     preload(sortFn?: CompareFunction<T>): Paginator<T> {
+        const copy = [...this.list];
         if (this.hasNext() && this.preloader) {
-            [...this.list]
+            (sortFn ? copy.sort(sortFn) : copy)
                 .sort(sortFn)
                 .slice(this.index * this.split_number, (this.index + 1) * this.split_number)
                 .forEach((el: T) => this.preloader(el));
@@ -60,5 +61,6 @@ export class Paginator<T> {
 }
 
 type Preload<T> = (o: T) => void;
+
 type CompareFunction<T> = (a: T, b: T) => number;
 type FilterPredicate<T> = (o: T) => boolean;

--- a/web/ts/utilities/paginator.ts
+++ b/web/ts/utilities/paginator.ts
@@ -4,10 +4,13 @@ export class Paginator<T> {
 
     private index: number;
 
-    constructor(list: T[], split_number: number) {
+    private readonly preloader: Preload<T>;
+
+    constructor(list: T[], split_number: number, preloader?: Preload<T>) {
         this.list = list;
         this.split_number = split_number;
         this.index = 1;
+        this.preloader = preloader;
     }
 
     get(sortFn?: (a: T, b: T) => number, filterPred?: (o: T) => boolean): T[] {
@@ -17,20 +20,21 @@ export class Paginator<T> {
             : copy.slice(0, this.index * this.split_number);
     }
 
-    set(list: T[]): Paginator<any> {
+    set(list: T[]): Paginator<T> {
         this.list = list;
         return this;
     }
 
     next(all = false) {
         this.index = all ? this.list.length / this.split_number : this.index + 1;
+        this.preload();
     }
 
     hasNext() {
         return Math.ceil(this.list.length / this.split_number) >= this.index + 1;
     }
 
-    forEach(callback: (obj: T, i: number) => void): Paginator<any> {
+    forEach(callback: (obj: T, i: number) => void): Paginator<T> {
         this.list.forEach(callback);
         return this;
     }
@@ -39,8 +43,18 @@ export class Paginator<T> {
         return this.list.length > 0;
     }
 
-    reset(): Paginator<any> {
+    reset(): Paginator<T> {
         this.index = 1;
         return this;
     }
+
+    private preload() {
+        if (this.hasNext() && this.preloader) {
+            this.list
+                .slice((this.index - 1) * this.split_number, this.index * this.split_number)
+                .forEach((el: T) => this.preloader(el));
+        }
+    }
 }
+
+type Preload<T> = (o: T) => void;


### PR DESCRIPTION
### Motivation and Context
Currently we load images, i.e. thumbnails, simply with `img(...)` via CSS. Since we also paginate most content (to avoid floods of image loading) most thumbnails "pop up" after loading (grey default thumbnail → image thumbnail). This can be circumvented by prefetching the next `N` images via javascript.


### Description
Add a `preloader` callback function to the `Paginator` class and call the callback on `.next()`.

### Steps for Testing
- 1 Lecturer
- 2 Students
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. ...
