### PR TITLE
fix redirect after login

### DIFF
--- a/web/template/login.gohtml
+++ b/web/template/login.gohtml
@@ -30,8 +30,7 @@
             </div>
         {{end}}
         <template x-if="showInternalLogin">
-            <form x-data="{ref: global.getLoginReferrer()}" id="loginForm" method="post" class="grid gap-3 py-4 px-5">
-                <input x-model="ref" type="hidden" name="ref">
+            <form id="loginForm" method="post" class="grid gap-3 py-4 px-5">
                 <div class="text-sm">
                     <label for="username" class="block text-5">Username</label>
                     <input type="text" name="username" id="username" autocomplete="off"
@@ -51,7 +50,7 @@
                     <span class="text-white uppercase text-sm font-semibold">Login</span>
                 </button>
                 {{if .Error}}
-                    <p class="text-warn text-sm mt-2">Couldn't log in. Please double check your credentials.</p>
+                    <p class="text-warn text-sm mt-2">Couldn't log in. Please double-check your credentials.</p>
                 {{end}}
             </form>
         </template>

--- a/web/ts/global.ts
+++ b/web/ts/global.ts
@@ -241,23 +241,6 @@ export function timer(expiry: string, leadingZero: boolean) {
     };
 }
 
-// getLoginReferrer returns "/" if document.referrer === "http[s]://<hostname>:<port>/login" and document.referrer if not
-export function getLoginReferrer(): string {
-    const lastLocation = document.referrer.split("/"),
-        protocol = lastLocation[0],
-        host = lastLocation[2];
-
-    if (
-        window.location.protocol !== protocol ||
-        window.location.host !== host ||
-        document.referrer === window.location.origin + "/login"
-    ) {
-        return window.location.origin + "/";
-    }
-
-    return document.referrer;
-}
-
 export function getQueryParam(name: string): string {
     return new URL(window.location.href).searchParams.get(name) ?? undefined;
 }

--- a/web/user.go
+++ b/web/user.go
@@ -70,8 +70,7 @@ func HandleValidLogin(c *gin.Context, data *tools.SessionData) {
 }
 
 func getRedirectUrl(c *gin.Context) (*url.URL, error) {
-	ret := c.Request.FormValue("return")
-	ref := c.Request.FormValue("ref")
+	ret := c.Query("return")
 	if ret != "" {
 		red, err := url.QueryUnescape(ret)
 		if err == nil {
@@ -79,11 +78,11 @@ func getRedirectUrl(c *gin.Context) (*url.URL, error) {
 		}
 	}
 
-	if ref == "" {
+	if ret == "" {
 		return url.Parse("/")
 	}
 
-	return url.Parse(ref)
+	return url.Parse(ret)
 }
 
 // loginWithUserCredentials Try to login with non-tum credentials


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The redirect after logins is currently broken. This fixes #1053 

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->

The redirect target cookie is now properly parsed and set when visiting the login page as opposed to when submitting the login form. This fixes issues with saml logins.
