### PR TITLE
Fix VOD not working if path != /vod/

### DIFF
--- a/worker/edge/edge.go
+++ b/worker/edge/edge.go
@@ -183,7 +183,7 @@ func validateToken(w http.ResponseWriter, r *http.Request, download bool) (claim
 	}
 
 	urlParts := strings.Split(allowedPlaylist.Path, "/")
-	allowedPath := vodPath + "/" + strings.Join(urlParts[2:len(urlParts)-1], "/")
+	allowedPath := "/vod/" + strings.Join(urlParts[2:len(urlParts)-1], "/")
 	if !strings.HasPrefix(r.URL.Path, allowedPath+"/") {
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = w.Write([]byte("Forbidden. URL doesn't match claim in jwt. " + allowedPath + " vs " + r.URL.Path))

--- a/worker/edge/edge.go
+++ b/worker/edge/edge.go
@@ -225,7 +225,7 @@ func vodHandler(w http.ResponseWriter, r *http.Request) {
 				upath = "/" + upath
 				r.URL.Path = upath
 			}
-			r.URL.Path = strings.TrimPrefix(r.URL.Path, vodPath)
+			r.URL.Path = strings.TrimPrefix(r.URL.Path, "/vod")
 			f, err := os.Open(path.Join(vodPath, path.Clean(r.URL.Path)))
 
 			if err != nil {


### PR DESCRIPTION
### Motivation and Context
Previously, the VOD (Video on Demand) feature was only accessible through the specific VOD-Path `/vod`. If any other path was used, the content delivery edge would respond with a 404 error. This limitation prevented users from customizing their VOD paths according to their preferences. The motivation behind the recent changes was to resolve this issue and allow developers to specify custom VOD paths.

### Description
- Previously, if a path other than `/vod` was used, the system responded with a 404 error. This has been fixed, and the system will now recognize and handle custom VOD paths appropriately.
- JWT Check was only working if the path was `/vod`. Now it's working for custom paths as well.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Lecturer
- 1 Course

1. Log in
2. Navigate to a course management page
3. Create a new Video-on-Demand
4. Check if the Video-on-Demand is accessible
5. **Change the VoD-Path on your local environment** ()
6. Create a new Video-on-Demand
7. Check if the Video-on-Demand is accessible

### Screenshots
