### PR TITLE
Update workflow go version to go1.20

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.19.x ]
+        go-version: [ 1.20.x ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
### Motivation and Context
Currently, we test TUM-Live with `go1.19` and deploy the app with `go1.20`. This PR addresses the issue in the workflow.

### Description
Update workflow.

### Steps for Testing
The `go test / test` workflow doesn't throw an error.
