### PR TITLE
`bug` Don't transmit chat replies twice

### DIFF
--- a/dao/chat.go
+++ b/dao/chat.go
@@ -88,8 +88,12 @@ func (d chatDao) GetReactions(chatID uint) ([]model.ChatReaction, error) {
 // or sent by user with id 'userID'
 func (d chatDao) GetVisibleChats(userID uint, streamID uint) ([]model.Chat, error) {
 	var chats []model.Chat
-	query := DB.Preload("Replies").Preload("Reactions").Preload("AddressedToUsers")
-	query.Where("(visible = 1) OR (user_id = ?)", userID).Find(&chats, "stream_id = ?", streamID)
+	query := DB.
+		Preload("Replies").
+		Preload("Reactions").
+		Preload("AddressedToUsers").
+		Where("(visible = 1) OR (user_id = ?)", userID).
+		Find(&chats, "stream_id = ? AND reply_to is null", streamID)
 	err := query.Error
 	if err != nil {
 		return nil, err
@@ -104,7 +108,11 @@ func (d chatDao) GetVisibleChats(userID uint, streamID uint) ([]model.Chat, erro
 // Number of likes are inserted and the user's like status is determined
 func (d chatDao) GetAllChats(userID uint, streamID uint) ([]model.Chat, error) {
 	var chats []model.Chat
-	query := DB.Preload("Replies").Preload("Reactions").Preload("AddressedToUsers").Find(&chats, "stream_id = ?", streamID)
+	query := DB.
+		Preload("Replies").
+		Preload("Reactions").
+		Preload("AddressedToUsers").
+		Find(&chats, "stream_id = ? AND reply_to is null", streamID)
 	err := query.Error
 	if err != nil {
 		return nil, err

--- a/web/template/partial/stream/chat/chat_message.gohtml
+++ b/web/template/partial/stream/chat/chat_message.gohtml
@@ -4,7 +4,7 @@
     <template x-for="(m, index) in c.messages" :key="m.ID + 'v' + m.renderVersion">
         <div x-ref="message" class="grid gap-y-1 text-4 text-sm $m.ID message"
              x-data="{ showReplies: false, emojiPicker: c.initEmojiPicker(m.ID) }"
-             x-show="!m.deleted && m.replyTo && !m.replyTo.Valid"
+             x-show="!m.deleted"
              :class="{'opacity-60' : m.isGrayedOut}"
              x-init="$watch('c.focusedMessageId', () => {if (c.isMessageToBeFocused(index)){watch.scrollToElement($refs.message)}});">
             <!-- name and message -->


### PR DESCRIPTION
### Motivation and Context
At the moment we send chat replies twice: Once as normal message and once as element of the attribute `replies` of the base message (using gorm's `preload`). We then hide replies with a `x-show` in Alpine. This is unnecessary.

For example:
```python
# Chat:
> hello 
      > good morning 
> nice weather today, huh?

# Transmitted:
[{m:'hello', replies: 'good morning'}, {m:'good morning', isReply: true}, {m:'nice weather today, huh?'}]
```


### Description
Add SQL check `reply_to is null` and update `x-show`.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 2 Accounts
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Chat and reply and see if everything still works fine.
4. 🌟
