### PR TITLE
use dedicated array for channels

### DIFF
--- a/web/ts/socket.ts
+++ b/web/ts/socket.ts
@@ -13,6 +13,7 @@ export class Realtime {
     private debugging = false;
     private ws: WebSocket;
     private handler: object = {};
+    private subscribedChannels: string[] = [];
 
     // Singleton
     private static instance;
@@ -43,6 +44,7 @@ export class Realtime {
         await this.send(channel, {
             type: RealtimeMessageTypes.RealtimeMessageTypeSubscribe,
         });
+        this.subscribedChannels.push(channel);
         this.debug("Subscribed", channel);
     }
 
@@ -54,6 +56,7 @@ export class Realtime {
         await this.send(channel, {
             type: RealtimeMessageTypes.RealtimeMessageTypeUnsubscribe,
         });
+        this.subscribedChannels = this.subscribedChannels.filter((c) => c != channel);
         this.debug("Unsubscribed", channel);
     }
 
@@ -97,7 +100,7 @@ export class Realtime {
         this.debug("connected");
 
         // Re-Subscribe to all channels
-        for (const channel of Object.keys(this.handler)) {
+        for (const channel of this.subscribedChannels) {
             await this.send(channel, {
                 type: RealtimeMessageTypes.RealtimeMessageTypeSubscribe,
             });


### PR DESCRIPTION
### Motivation and Context
If handler has been attached before subscribing to a channel, the channel was subscribed twice.
That's because it took a look at the handlers after the connection, assuming that there has been a subscription
for every handler before.

### Description
Changed to use an extra `subscribedChannels` Array to keep track of the subs on client side to resub on reconnect.

### Steps for Testing
Prerequisites:
- 1 Student
- 1 Livestream

1. Log in
2. Navigate to a Livestream with a Chat
3. Use the chat and verify if it works
