### PR TITLE
copy admins when copying course

### DIFF
--- a/api/courses.go
+++ b/api/courses.go
@@ -1527,6 +1527,11 @@ func (r coursesRoutes) copyCourse(c *gin.Context) {
 	course := tlctx.Course
 	streams := course.Streams
 
+	admins, err := r.DaoWrapper.CoursesDao.GetCourseAdmins(course.ID)
+	if err != nil {
+		log.WithError(err).Error("Error getting course admins")
+		admins = []model.User{}
+	}
 	course.Model = gorm.Model{}
 	course.Streams = nil
 	yearInt, err := strconv.Atoi(request.Year)
@@ -1558,6 +1563,13 @@ func (r coursesRoutes) copyCourse(c *gin.Context) {
 		err := r.StreamsDao.CreateStream(&stream)
 		if err != nil {
 			log.WithError(err).Error("Can't create stream")
+			numErrors++
+		}
+	}
+	for _, admin := range admins {
+		err := r.CoursesDao.AddAdminToCourse(admin.ID, course.ID)
+		if err != nil {
+			log.WithError(err).Error("Can't add admin to course")
 			numErrors++
 		}
 	}

--- a/api/courses_test.go
+++ b/api/courses_test.go
@@ -791,6 +791,15 @@ func TestCoursesCRUD(t *testing.T) {
 								CreateCourse(gomock.Any(), gomock.Any(), true).
 								Return(errors.New("")).
 								AnyTimes()
+							coursesMock.
+								EXPECT().GetCourseAdmins(testutils.CourseFPV.ID).
+								Return([]model.User{testutils.Admin}, nil).
+								MinTimes(1).MaxTimes(1)
+							coursesMock.
+								EXPECT().
+								AddAdminToCourse(gomock.Any(), gomock.Any()).
+								Return(nil).
+								AnyTimes()
 							return coursesMock
 						}(),
 					}
@@ -803,7 +812,34 @@ func TestCoursesCRUD(t *testing.T) {
 			"success": {
 				Router: func(r *gin.Engine) {
 					wrapper := dao.DaoWrapper{
-						CoursesDao: testutils.GetCoursesMock(t),
+						CoursesDao: func() dao.CoursesDao {
+							coursesMock := mock_dao.NewMockCoursesDao(gomock.NewController(t))
+							coursesMock.
+								EXPECT().
+								GetCourseById(gomock.Any(), testutils.CourseFPV.ID).
+								Return(testutils.CourseFPV, nil).
+								AnyTimes()
+							coursesMock.
+								EXPECT().
+								GetCourseBySlugYearAndTerm(gomock.Any(), testutils.CourseFPV.Slug, testutils.CourseFPV.TeachingTerm, testutils.CourseFPV.Year).
+								Return(testutils.CourseFPV, nil).
+								AnyTimes()
+							coursesMock.
+								EXPECT().
+								CreateCourse(gomock.Any(), gomock.Any(), true).
+								Return(nil).
+								AnyTimes()
+							coursesMock.
+								EXPECT().GetCourseAdmins(testutils.CourseFPV.ID).
+								Return([]model.User{testutils.Admin}, nil).
+								MinTimes(1).MaxTimes(1)
+							coursesMock.
+								EXPECT().
+								AddAdminToCourse(gomock.Any(), gomock.Any()).
+								Return(nil).
+								AnyTimes()
+							return coursesMock
+						}(),
 						StreamsDao: testutils.GetStreamMock(t),
 					}
 					configGinCourseRouter(r, wrapper)


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When copying a course, we want to retain the admins of the course. Likely one of them copied the course in the first place.

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->

When copying a course we iterate over the admins of the previous course and insert them into the database for the new course

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 course
- 1 lectuer

1. Make sure you are logged in as a lecturer and copy a course you are admin of. 
2. Check that you are now admin of the newly created course. 
