### PR TITLE
Show public, own and pinned courses without selecting semester

### DIFF
--- a/web/ts/views/home.ts
+++ b/web/ts/views/home.ts
@@ -170,7 +170,10 @@ class PageState {
     constructor(url: URL) {
         this.url = url;
         this.term = url.searchParams.get("term") ?? undefined;
-        this.year = +url.searchParams.get("year");
+        this.year = +url.searchParams.get("year") ?? undefined;
+        if(this.year === 0) {
+            this.year = undefined;
+        }
         this.slug = url.searchParams.get("slug") ?? undefined;
         this.view = url.searchParams.get("view") ?? View.Main;
     }

--- a/web/ts/views/home.ts
+++ b/web/ts/views/home.ts
@@ -171,7 +171,7 @@ class PageState {
         this.url = url;
         this.term = url.searchParams.get("term") ?? undefined;
         this.year = +url.searchParams.get("year") ?? undefined;
-        if(this.year === 0) {
+        if (this.year === 0) {
             this.year = undefined;
         }
         this.slug = url.searchParams.get("slug") ?? undefined;


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This resolves an issue where the start page does not show the courses on the left when visiting it without specifying the year and term.

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->

This issue occurs because the expression to set the current year resolves like this:
`this.year = +url.searchParams.get("year") ?? undefined;`
-> `this.year = +null ?? undefined;`
-> `this.year = 0 ?? undefined;`
-> `this.year = 0;`


### Steps for testing


I created a public course on the testserver. It should be visible without selecting a teaching term first.