### PR TITLE
add 404 metric to edge playlist requests

### DIFF
--- a/worker/edge/edge.go
+++ b/worker/edge/edge.go
@@ -229,6 +229,7 @@ func vodHandler(w http.ResponseWriter, r *http.Request) {
 			f, err := os.Open(path.Join(vodPath, path.Clean(r.URL.Path)))
 
 			if err != nil {
+				err404Playlists.WithLabelValues(claims.StreamID, claims.Playlist).Inc()
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = w.Write([]byte("Not Found"))
 				return

--- a/worker/edge/metrics.go
+++ b/worker/edge/metrics.go
@@ -28,6 +28,11 @@ var (
 		Help: "The number of concurrent users (users active in the last 5 minutes)",
 	})
 
+	err404Playlists = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "edge_404_playlists_total",
+		Help: "The total number of 404 responses per playlist",
+	}, []string{"stream", "playlist"})
+
 	usersMap = NewTTLMap(300)
 )
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This allows creating grafana alerts when unusually many users request playlists that are not available
