### PR TITLE
display lecture time in vod title, if stream name not present

### DIFF
--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -5,7 +5,8 @@
     <meta charset="UTF-8">
     {{$stream := .IndexData.TUMLiveContext.Stream}}
     {{$course := .IndexData.TUMLiveContext.Course}}
-    <title>{{.IndexData.Branding.Title}} | {{$course.Name}}: {{$stream.Name}}</title>
+    {{$displayName := or $stream.Name (printf "Lecture: %s %02d. %d" $stream.Start.Month $stream.Start.Day $stream.Start.Year)}}
+    <title>{{.IndexData.Branding.Title}} | {{$course.Name}}: {{$displayName}}</title>
     <link rel="canonical" href="{{.IndexData.CanonicalURL.Stream $course.Slug $stream.ID .Version}}" />
     {{template "headImports" .IndexData.VersionTag}}
     <script>window.HELP_IMPROVE_VIDEOJS = false;</script>
@@ -426,11 +427,7 @@
                 <div class="pb-3 border-b dark:border-gray-600 grid shrink mb-auto lg:pb-0 lg:border-0">
                     <h1 class="font-bold text-4 text-lg grow lg:text-2xl"
                         @titleupdate.window="$el.innerText=$event.detail.title">
-                        {{if $stream.Name}}
-                            {{$stream.Name}}
-                        {{else}}
-                            Lecture: {{$stream.Start.Month}} {{printf "%02d." $stream.Start.Day}} {{$stream.Start.Year}}
-                        {{end}}
+                        {{$displayName}}
                     </h1>
                     <div class="flex justify-between flex-col sm:flex-row text-sm lg:text-base">
                         <div class="flex my-auto">


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
blank title with `:` looks bad

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
I put `Lecture: D M, Y` there

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- Web Browser

1. Navigate to a VOD without name
2. notice the title is different

### Screenshots
![屏幕截图 2023-07-26 211027](https://github.com/joschahenningsen/TUM-Live/assets/12656264/e26c9eb2-33a3-474f-817e-e0e4814847ce)

