### PR TITLE
Change startMinutes to startHours

### DIFF
--- a/web/ts/video-sections.ts
+++ b/web/ts/video-sections.ts
@@ -81,7 +81,7 @@ export class VideoSectionsAdminController {
         return (
             this.current.description !== "" &&
             this.current.startHours !== null &&
-            this.current.startMinutes < 32 &&
+            this.current.startHours < 32 &&
             this.current.startMinutes !== null &&
             this.current.startMinutes < 60 &&
             this.current.startSeconds !== null &&


### PR DESCRIPTION
### Motivation and Context
Introduced in #1125. 

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Admin
- 1 Course

1. Log in
2. Navigate to a Admin Course Page
3. Try to insert invalid start hours, minutes, and seconds. (e.g. startMinutes=107)
4. The "Add" button should be disabled. 