### PR TITLE
Remove hardcoded stream-id

### DIFF
--- a/web/template/components/chat.gohtml
+++ b/web/template/components/chat.gohtml
@@ -10,7 +10,7 @@
         {{$userId = .IndexData.TUMLiveContext.User.ID}}
     {{end}}
     <article
-            x-data="interaction.videoInteractionContext({{$stream.ID}}, {ID: {{$userId}}, name: '{{$userName}}', isAdmin: {{$isAdmin}}})"
+            x-data="interaction.videoInteractionContext({ID: {{$userId}}, name: '{{$userName}}', isAdmin: {{$isAdmin}}})"
             class="h-full">
         <template x-if="isChat()">
             <article

--- a/web/template/components/chat.gohtml
+++ b/web/template/components/chat.gohtml
@@ -10,7 +10,7 @@
         {{$userId = .IndexData.TUMLiveContext.User.ID}}
     {{end}}
     <article
-            x-data="interaction.videoInteractionContext({ID: {{$userId}}, name: '{{$userName}}', isAdmin: {{$isAdmin}}})"
+            x-data="interaction.videoInteractionContext({{$stream.ID}}, {ID: {{$userId}}, name: '{{$userName}}', isAdmin: {{$isAdmin}}})"
             class="h-full">
         <template x-if="isChat()">
             <article

--- a/web/template/popup-chat.gohtml
+++ b/web/template/popup-chat.gohtml
@@ -17,6 +17,6 @@
     <link href="/static/assets/css-dist/home.css?v={{if .IndexData.VersionTag}}{{.IndexData.VersionTag}}{{else}}development{{end}}"
           rel="stylesheet">
 </head>
-<body class="bg-white dark:bg-secondary h-screen">
+<body class="bg-white dark:bg-secondary h-screen" x-data="interaction.popupContext({{$stream.ID}})">
     {{template "chat-component" .}}
 </body>

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -87,7 +87,7 @@
 <div id="watchPageMainWrapper">
     <input type="hidden" id="description" value="{{.Description}}">
     <input type="hidden" id="streamID" value="{{$stream.Model.ID}}">
-    <div x-data="interaction.videoInformationContext();"
+    <div x-data="interaction.videoInformationContext({{$stream.ID}});"
          class="flex flex-wrap shadow border bg-white dark:bg-secondary dark:shadow-0 dark:border-0">
         <div id="watchWrapper"
              x-data="{ 'chatEnabled': {{and $course.ChatEnabled $stream.ChatEnabled}} }"

--- a/web/ts/api/chat-ws.ts
+++ b/web/ts/api/chat-ws.ts
@@ -11,7 +11,7 @@ enum ChatMessageType {
 }
 
 export abstract class SocketConnections {
-    static ws: RealtimeFacade = new RealtimeFacade("chat/12845");
+    static ws: RealtimeFacade;
 }
 
 export type NewChatMessage = {

--- a/web/ts/components/popup.ts
+++ b/web/ts/components/popup.ts
@@ -1,0 +1,11 @@
+import { AlpineComponent } from "./alpine-component";
+import { RealtimeFacade } from "../utilities/ws";
+import { SocketConnections } from "../api/chat-ws";
+
+export function popupContext(streamId: number): AlpineComponent {
+    return {
+        init() {
+            SocketConnections.ws = new RealtimeFacade("chat/" + streamId);
+        },
+    } as AlpineComponent;
+}

--- a/web/ts/components/video-information.ts
+++ b/web/ts/components/video-information.ts
@@ -1,10 +1,11 @@
 import { AlpineComponent } from "./alpine-component";
 import { SocketConnections } from "../api/chat-ws";
 import { ToggleableElement } from "../utilities/ToggleableElement";
+import { RealtimeFacade } from "../utilities/ws";
 
 const CUTOFFLENGTH = 256;
 
-export function videoInformationContext(): AlpineComponent {
+export function videoInformationContext(streamId: number): AlpineComponent {
     // TODO: REST
     const descriptionEl = document.getElementById("description") as HTMLInputElement;
     return {
@@ -15,6 +16,7 @@ export function videoInformationContext(): AlpineComponent {
         showFullDescription: new ToggleableElement(),
 
         init() {
+            SocketConnections.ws = new RealtimeFacade("chat/" + streamId);
             Promise.all([this.initWebsocket()]);
         },
 

--- a/web/ts/components/video-interaction.ts
+++ b/web/ts/components/video-interaction.ts
@@ -1,18 +1,20 @@
 import { AlpineComponent } from "./alpine-component";
 import { User } from "../api/users";
 import { SocketConnections } from "../api/chat-ws";
+import { RealtimeFacade } from "../utilities/ws";
 
 enum InteractionType {
     Chat,
     Polls,
 }
 
-export function videoInteractionContext(user: User) {
+export function videoInteractionContext(streamId: number, user: User) {
     return {
         type: InteractionType.Chat,
         user: user as User,
 
         init() {
+            SocketConnections.ws = new RealtimeFacade("chat/" + streamId);
             SocketConnections.ws.subscribe();
         },
 

--- a/web/ts/components/video-interaction.ts
+++ b/web/ts/components/video-interaction.ts
@@ -8,13 +8,12 @@ enum InteractionType {
     Polls,
 }
 
-export function videoInteractionContext(streamId: number, user: User) {
+export function videoInteractionContext(user: User) {
     return {
         type: InteractionType.Chat,
         user: user as User,
 
         init() {
-            SocketConnections.ws = new RealtimeFacade("chat/" + streamId);
             SocketConnections.ws.subscribe();
         },
 

--- a/web/ts/entry/interactions.ts
+++ b/web/ts/entry/interactions.ts
@@ -4,3 +4,4 @@ export * from "../components/chat-prompt";
 export * from "../components/poll";
 export * from "../components/emoji-picker";
 export * from "../components/video-information";
+export * from "../components/popup";


### PR DESCRIPTION
### Motivation and Context
The chat currently doesn't work. (Fortunately, not yet deployed though 😅) 
It is however testable for other open PRs: https://1128.test.live.mm.rbg.tum.de/

### Description
Remove hard-coded stream id.

### Steps for Testing
- 1 Account
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Chatting should work. 
