### PR TITLE
fix duration on video thumbnails

### DIFF
--- a/api/worker_grpc.go
+++ b/api/worker_grpc.go
@@ -3,6 +3,7 @@ package api
 // worker_grpc.go handles communication with workers via grpc
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -387,7 +388,7 @@ func (s server) NotifyTranscodingFinished(ctx context.Context, request *pb.Trans
 	}
 
 	if request.Duration != 0 {
-		stream.Duration = request.Duration
+		stream.Duration = sql.NullInt32{Int32: int32(request.Duration)}
 	}
 	err = s.DaoWrapper.StreamsDao.SaveStream(&stream)
 	if err != nil {

--- a/dao/video-seek.go
+++ b/dao/video-seek.go
@@ -31,12 +31,12 @@ func (d videoSeekDao) Add(streamID string, pos float64) error {
 		return err
 	}
 
-	if (pos / float64(stream.Duration)) > 1 {
+	if (pos / float64(stream.Duration.Int32)) > 1 {
 		log.Error("position is bigger than stream duration")
 		return errors.New("position is bigger than stream duration")
 	}
 
-	chunkTimeRange := float64(stream.Duration) / maxChunksPerVideo
+	chunkTimeRange := float64(stream.Duration.Int32) / maxChunksPerVideo
 	chunk := uint(pos / chunkTimeRange)
 
 	return DB.Clauses(clause.OnConflict{

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,6 +1,4 @@
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
-github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
-github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
@@ -11,9 +9,6 @@ golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
-golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
+google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5 h1:L6iMMGrtzgHsWofoFcihmDEMYeDR9KN/ThbPWGrh++g=
 gorm.io/gorm v1.25.1 h1:nsSALe5Pr+cM3V1qwwQ7rOkw+6UeLrX5O4v3llhHa64=
-gorm.io/gorm v1.25.1/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
-mvdan.cc/xurls/v2 v2.5.0 h1:lyBNOm8Wo71UknhUs4QTFUNNMyxy2JEIaKKo0RWOh+8=
-mvdan.cc/xurls/v2 v2.5.0/go.mod h1:yQgaGQ1rFtJUzkmKiHYSSfuQxqfYmd//X6PxvholpeE=

--- a/model/stream.go
+++ b/model/stream.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"github.com/gin-gonic/gin"
@@ -47,7 +48,7 @@ type Stream struct {
 	Files                 []File `gorm:"foreignKey:StreamID"`
 	ThumbInterval         uint32 `gorm:"default:null"`
 	StreamName            string
-	Duration              uint32           `gorm:"default:null"`
+	Duration              sql.NullInt32    `gorm:"default:null"`
 	StreamWorkers         []Worker         `gorm:"many2many:stream_workers;"`
 	StreamProgresses      []StreamProgress `gorm:"foreignKey:StreamID"`
 	VideoSections         []VideoSection
@@ -369,12 +370,17 @@ type StreamDTO struct {
 	Downloads   []DownloadableVod
 	Start       time.Time
 	End         time.Time
+	Duration    int32
 }
 
 func (s Stream) ToDTO() StreamDTO {
 	downloads := []DownloadableVod{}
 	if s.IsDownloadable() {
 		downloads = s.GetVodFiles()
+	}
+	duration := int32(s.End.Sub(s.Start).Seconds())
+	if s.Duration.Valid {
+		duration = s.Duration.Int32
 	}
 	return StreamDTO{
 		ID:          s.ID,
@@ -387,5 +393,6 @@ func (s Stream) ToDTO() StreamDTO {
 		HLSUrl:      s.HLSUrl(),
 		Start:       s.Start,
 		End:         s.End,
+		Duration:    duration,
 	}
 }

--- a/web/ts/api/courses.ts
+++ b/web/ts/api/courses.ts
@@ -20,6 +20,7 @@ export class Stream implements Identifiable {
     readonly End: string;
     readonly Start: string;
     readonly Downloads: DownloadableVOD[];
+    readonly Duration: number;
 
     Progress?: Progress;
 
@@ -70,12 +71,7 @@ export class Stream implements Identifiable {
     }
 
     public DurationString() {
-        const diff = new Date(this.End).getTime() - new Date(this.Start).getTime();
-        return new Date(diff).toLocaleTimeString("default", {
-            hour: "2-digit",
-            minute: "2-digit",
-            second: "2-digit",
-        });
+        return new Date(this.Duration * 1000).toISOString().slice(11, 19);
     }
 
     public UntilString(): string {

--- a/web/ts/components/course.ts
+++ b/web/ts/components/course.ts
@@ -8,6 +8,7 @@ import { Tunnel } from "../utilities/tunnels";
 import { ToggleableElement } from "../utilities/ToggleableElement";
 import { getFromStorage, setInStorage } from "../utilities/storage";
 import { GroupedSmartArray, SmartArray } from "../utilities/smartarray";
+import { retinaScale } from "chart.js/helpers";
 
 export enum StreamSortMode {
     NewestFirst,

--- a/web/ts/components/course.ts
+++ b/web/ts/components/course.ts
@@ -8,7 +8,6 @@ import { Tunnel } from "../utilities/tunnels";
 import { ToggleableElement } from "../utilities/ToggleableElement";
 import { getFromStorage, setInStorage } from "../utilities/storage";
 import { GroupedSmartArray, SmartArray } from "../utilities/smartarray";
-import { retinaScale } from "chart.js/helpers";
 
 export enum StreamSortMode {
     NewestFirst,


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The current duration in only approximated based on the planned times of the lectures. Instead, we should use the duration stored in the database to accurately display the video duration.
Additionally, the current frontend renders the time based on the locale of the browser, which leads to weird behavior like `03:00:00 AM`  (see screenshot)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
#### Before 
![image](https://github.com/joschahenningsen/TUM-Live/assets/44805696/ac7df3cd-139c-469d-9879-6f9d2509179b)

#### After 
 ![image](https://github.com/joschahenningsen/TUM-Live/assets/44805696/637116dd-a130-43ae-9e36-3d7190b10c85)