### PR TITLE
Exclude course admins from chat rate limit

### DIFF
--- a/model/chat.go
+++ b/model/chat.go
@@ -3,14 +3,15 @@ package model
 import (
 	"database/sql"
 	"errors"
-	"github.com/microcosm-cc/bluemonday"
-	"github.com/russross/blackfriday/v2"
-	"gorm.io/gorm"
 	"html"
-	"mvdan.cc/xurls/v2"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/microcosm-cc/bluemonday"
+	"github.com/russross/blackfriday/v2"
+	"gorm.io/gorm"
+	"mvdan.cc/xurls/v2"
 )
 
 var (
@@ -88,15 +89,17 @@ func (c *Chat) BeforeCreate(tx *gorm.DB) (err error) {
 	if len(c.Message) == 0 {
 		return ErrMessageNoText
 	}
-	var recentMessages int64
-	err = tx.Model(&Chat{}).
-		Where("created_at > ? AND user_id = ?", time.Now().Add(-coolDown), c.UserID).
-		Count(&recentMessages).Error
-	if err != nil {
-		return err
-	}
-	if recentMessages >= coolDownMessages {
-		return ErrCooledDown
+	if !c.Admin {
+		var recentMessages int64
+		err = tx.Model(&Chat{}).
+			Where("created_at > ? AND user_id = ?", time.Now().Add(-coolDown), c.UserID).
+			Count(&recentMessages).Error
+		if err != nil {
+			return err
+		}
+		if recentMessages >= coolDownMessages {
+			return ErrCooledDown
+		}
 	}
 
 	// set chat color:


### PR DESCRIPTION
### Motivation and Context
Course administrators should not be rate limited. See #778.

### Description
Ratelimit removed for moderators.

### Steps for Testing
1. Log in as course admins on active stream or VOD
2. Send maaaany messages
3. See no ratelimit.
