### PR TITLE
Prolong maximum chat message length to 1000 characters

### DIFF
--- a/model/chat.go
+++ b/model/chat.go
@@ -3,14 +3,15 @@ package model
 import (
 	"database/sql"
 	"errors"
-	"github.com/microcosm-cc/bluemonday"
-	"github.com/russross/blackfriday/v2"
-	"gorm.io/gorm"
 	"html"
-	"mvdan.cc/xurls/v2"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/microcosm-cc/bluemonday"
+	"github.com/russross/blackfriday/v2"
+	"gorm.io/gorm"
+	"mvdan.cc/xurls/v2"
 )
 
 var (
@@ -36,7 +37,7 @@ var (
 )
 
 const (
-	maxMessageLength = 250
+	maxMessageLength = 1000
 	coolDown         = time.Minute * 2
 	coolDownMessages = 5 // 5 messages -> 5 messages per 2 minutes max
 )

--- a/web/template/components/chat.gohtml
+++ b/web/template/components/chat.gohtml
@@ -288,11 +288,11 @@
                             </button>
                         </template>
                     </section>
-                    <article class="flex flex-col space-y-2 px-5 border-t dark:border-gray-800 py-2 font-light">
+                    <article class="flex flex-col space-y-2 px-3 border-t dark:border-gray-800 py-2 font-light">
                         <label class="grow">
-                            <input id="chat-input" type="text" spellcheck="true" maxlength="200"
+                            <textarea id="chat-input" type="text" spellcheck="true" maxlength="1000"
                                    @keyup="keyup()"
-                                   @keyup.enter="send()"
+                                   @keyup.enter="send(event)"
                                    @keyup.esc="cancelReply()"
                                    :disabled="!isLoggedIn()"
                                    x-model="message"

--- a/web/ts/components/chat-prompt.ts
+++ b/web/ts/components/chat-prompt.ts
@@ -21,7 +21,7 @@ export function chatPromptContext(streamId: number): AlpineComponent {
 
         ws: new ChatWebsocketConnection(SocketConnections.ws),
 
-        inputEl: document.getElementById("chat-input") as HTMLInputElement,
+        inputEl: document.getElementById("chat-input") as HTMLTextAreaElement,
         usersEl: document.getElementById("chat-user-list") as HTMLInputElement,
         emojiEl: document.getElementById("chat-emoji-list") as HTMLInputElement,
 
@@ -41,7 +41,10 @@ export function chatPromptContext(streamId: number): AlpineComponent {
             this.users.reset();
         },
 
-        send() {
+        send(event: KeyboardEvent) {
+            if (event.shiftKey) {
+                return;
+            }
             console.log("🌑 send message '", this.message, "'");
             this.ws.sendMessage({
                 msg: this.message,
@@ -84,6 +87,10 @@ export function chatPromptContext(streamId: number): AlpineComponent {
             } else if (this.emojis.hasSuggestions()) {
                 this.emojiEl.focus();
             }
+
+            // https://stackoverflow.com/a/21079335
+            this.inputEl.style.height = "0px";
+            this.inputEl.style.height = (this.inputEl.scrollHeight) + "px";
         },
 
         keypressAlphanumeric(e) {

--- a/web/ts/components/chat-prompt.ts
+++ b/web/ts/components/chat-prompt.ts
@@ -90,7 +90,7 @@ export function chatPromptContext(streamId: number): AlpineComponent {
 
             // https://stackoverflow.com/a/21079335
             this.inputEl.style.height = "0px";
-            this.inputEl.style.height = (this.inputEl.scrollHeight) + "px";
+            this.inputEl.style.height = this.inputEl.scrollHeight + "px";
         },
 
         keypressAlphanumeric(e) {


### PR DESCRIPTION
### Motivation and Context
We want longer chat messages! I can't answer to the questions of our students if I'm not able to write a long prose with at least 800 characters! :-P
Resolves #778.

### Description
I replaced the chat input box with a multiline text area and extended the maximum message length from 200 to 1000 characters.

### Steps for Testing
1. Log in
2. Find a stream or VOD you can comment on
3. Write a long text message with more then 200 characters. May include multiple lines with Shift+Enter.
