### PR TITLE
load stream progresses in one query

### DIFF
--- a/api/progress_test.go
+++ b/api/progress_test.go
@@ -157,7 +157,7 @@ func TestUserProgress(t *testing.T) {
 							progressMock.
 								EXPECT().
 								LoadProgress(testutils.TUMLiveContextStudent.User.ID, gomock.Any()).
-								Return(model.StreamProgress{}, errors.New(""))
+								Return([]model.StreamProgress{}, errors.New(""))
 							return progressMock
 						}(),
 					}
@@ -175,7 +175,7 @@ func TestUserProgress(t *testing.T) {
 							progressMock.
 								EXPECT().
 								LoadProgress(testutils.TUMLiveContextStudent.User.ID, gomock.Any()).
-								Return(model.StreamProgress{}, gorm.ErrRecordNotFound)
+								Return([]model.StreamProgress{}, gorm.ErrRecordNotFound)
 							return progressMock
 						}(),
 					}
@@ -194,7 +194,7 @@ func TestUserProgress(t *testing.T) {
 							progressMock.
 								EXPECT().
 								LoadProgress(testutils.TUMLiveContextStudent.User.ID, gomock.Any()).
-								Return(model.StreamProgress{StreamID: 16, Watched: true, Progress: 0.5}, nil).
+								Return([]model.StreamProgress{{StreamID: 16, Watched: true, Progress: 0.5}}, nil).
 								AnyTimes()
 							return progressMock
 						}(),
@@ -214,7 +214,7 @@ func TestUserProgress(t *testing.T) {
 							progressMock.
 								EXPECT().
 								LoadProgress(testutils.TUMLiveContextStudent.User.ID, gomock.Any()).
-								Return(model.StreamProgress{StreamID: 16, Watched: true, Progress: 0.5}, nil)
+								Return([]model.StreamProgress{{StreamID: 16, Watched: true, Progress: 0.5}}, nil)
 							return progressMock
 						}(),
 					}

--- a/dao/progress.go
+++ b/dao/progress.go
@@ -13,7 +13,7 @@ var Progress = NewProgressDao()
 type ProgressDao interface {
 	SaveProgresses(progresses []model.StreamProgress) error
 	GetProgressesForUser(userID uint) ([]model.StreamProgress, error)
-	LoadProgress(userID uint, streamID uint) (streamProgress model.StreamProgress, err error)
+	LoadProgress(userID uint, streamIDs []uint) (streamProgress []model.StreamProgress, err error)
 	SaveWatchedState(progress *model.StreamProgress) error
 }
 
@@ -47,7 +47,7 @@ func (d progressDao) SaveWatchedState(progress *model.StreamProgress) error {
 }
 
 // LoadProgress retrieves the current StreamProgress from the database for a given user and stream.
-func (d progressDao) LoadProgress(userID uint, streamID uint) (streamProgress model.StreamProgress, err error) {
-	err = DB.First(&streamProgress, "user_id = ? AND stream_id = ?", userID, streamID).Error
+func (d progressDao) LoadProgress(userID uint, streamIDs []uint) (streamProgress []model.StreamProgress, err error) {
+	err = DB.Find(&streamProgress, "user_id = ? AND stream_id IN ?", userID, streamIDs).Error
 	return streamProgress, err
 }

--- a/mock_dao/progress.go
+++ b/mock_dao/progress.go
@@ -50,18 +50,18 @@ func (mr *MockProgressDaoMockRecorder) GetProgressesForUser(userID interface{}) 
 }
 
 // LoadProgress mocks base method.
-func (m *MockProgressDao) LoadProgress(userID, streamID uint) (model.StreamProgress, error) {
+func (m *MockProgressDao) LoadProgress(userID uint, streamIDs []uint) ([]model.StreamProgress, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadProgress", userID, streamID)
-	ret0, _ := ret[0].(model.StreamProgress)
+	ret := m.ctrl.Call(m, "LoadProgress", userID, streamIDs)
+	ret0, _ := ret[0].([]model.StreamProgress)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadProgress indicates an expected call of LoadProgress.
-func (mr *MockProgressDaoMockRecorder) LoadProgress(userID, streamID interface{}) *gomock.Call {
+func (mr *MockProgressDaoMockRecorder) LoadProgress(userID, streamIDs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadProgress", reflect.TypeOf((*MockProgressDao)(nil).LoadProgress), userID, streamID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadProgress", reflect.TypeOf((*MockProgressDao)(nil).LoadProgress), userID, streamIDs)
 }
 
 // SaveProgresses mocks base method.

--- a/web/watch.go
+++ b/web/watch.go
@@ -84,14 +84,14 @@ func (r mainRoutes) WatchPage(c *gin.Context) {
 	// Check for fetching progress
 	if tumLiveContext.User != nil && tumLiveContext.Stream.Recording {
 
-		progress, err := dao.Progress.LoadProgress(tumLiveContext.User.ID, tumLiveContext.Stream.ID)
+		progress, err := dao.Progress.LoadProgress(tumLiveContext.User.ID, []uint{tumLiveContext.Stream.ID})
 		if err != nil {
 			data.Progress = model.StreamProgress{Progress: 0}
 			if !errors.Is(err, gorm.ErrRecordNotFound) {
 				log.WithError(err).Warn("Couldn't fetch progress from the database.")
 			}
-		} else {
-			data.Progress = progress
+		} else if len(progress) > 0 {
+			data.Progress = progress[0]
 		}
 	}
 	if c.Query("restart") == "1" {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Currently, we load stream progresses in multiple queries for each request. Especially for admins visiting the start page, this is very inefficient. 

### Description
Unify the db query to accept multiple ids and return all progresses. I simulated a slow database connection by connecting to a remote database via vpn and observed the timings of the endpoint `/api/progress/streams`:
- before: 1959.984845 ms 
- after: 48.86526 ms

