### PR TITLE
Improve semester selection in home sidebar

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -150,7 +150,7 @@
                 <i class="fa-solid fa-calendar"></i>
                 Semesters
             </header>
-            <span class="tum-live-side-navigation-group-item mb-1 border-l-4 bg-blue-100/50 border-blue-500/50 dark:bg-indigo-500/25 dark:border-indigo-600/50"
+            <span class="tum-live-side-navigation-group-item mb-4 border-l-4 bg-blue-100/50 border-blue-500/50 dark:bg-indigo-500/25 dark:border-indigo-600/50"
                   x-text="semesters[selectedSemesterIndex]?.FriendlyString()"></span>
             <template x-if="navigation.getChild('allSemesters').value">
                 <template x-for="s in semesters">

--- a/web/ts/api/semesters.ts
+++ b/web/ts/api/semesters.ts
@@ -15,7 +15,7 @@ export class Semester {
     }
 
     public FriendlyString(): string {
-        if (this.TeachingTerm === "W") return `Winter ${this.Year}/${this.Year + 1}`;
+        if (this.TeachingTerm === "W") return `Winter ${this.Year}/` + `${this.Year + 1}`.slice(-2);
         else return `Summer ${this.Year}`;
     }
 }

--- a/web/ts/api/semesters.ts
+++ b/web/ts/api/semesters.ts
@@ -15,7 +15,8 @@ export class Semester {
     }
 
     public FriendlyString(): string {
-        return `${this.TeachingTerm === "W" ? "Winter" : "Summer"} ${this.Year}`;
+        if (this.TeachingTerm === "W") return `Winter ${this.Year}/${this.Year + 1}`;
+        else return `Summer ${this.Year}`;
     }
 }
 


### PR DESCRIPTION
### Motivation and Context
Resolves #1138.

### Description
Adds `/20xx` to all winter semesters in the semester selection sidebar.
Also increases bottom margin on the currently selected semester.

### Steps for Testing
1. Go to home view
2. Notice the changes on the sidebar
3. Click on "show all"
4. Notice the changes here as well.

### Screenshots
![grafik](https://github.com/joschahenningsen/TUM-Live/assets/82521952/0dadb503-4ec6-450b-9eb2-82a731f88682)
---
![grafik](https://github.com/joschahenningsen/TUM-Live/assets/82521952/d37f1d98-eeb2-47e5-b6f6-8b3ff94cfe1e)
