### PR TITLE
Add 'overflow-wrap-anywhere' to reply messages and reply prompt message

### DIFF
--- a/web/template/components/chat.gohtml
+++ b/web/template/components/chat.gohtml
@@ -202,7 +202,7 @@
                                             </div>
                                             <div class="group p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700">
                                                 <div class="flex justify-between">
-                                                    <span class="w-5/6 my-auto" x-html="reply.message"></span>
+                                                    <span class="w-5/6 overflow-wrap-anywhere my-auto" x-html="reply.message"></span>
                                                     <span class="hidden group-hover:inline text-xs text-5 font-light mt-auto"
                                                           x-text="reply.friendlyCreatedAt()"></span>
                                                 </div>
@@ -255,7 +255,7 @@
                                       class="h-fit fa-video text-xs text-white bg-red-400 p-1 rounded fas mr-1"></span>
                                 <span class="text-2 font-semibold mr-2" x-text="`${reply.message.name}:`"
                                       :style="'color:'+reply.message.color"></span>
-                                <span class="" x-html="reply.message.message"
+                                <span class="w-5/6 overflow-wrap-anywhere" x-html="reply.message.message"
                                       x-init="$nextTick(() => renderMathInElement($el, global.getKatexOptions()))"></span>
                             </div>
                         </article>


### PR DESCRIPTION
### Motivation and Context
- Resolve #1133 

### Description
Add `overflow-wrap-anywhere` class to reply messages and reply prompt message.

### Steps for Testing
Prerequisites:
- 1 Account
- 1 Livestream (`+Chat`)

1. Go to any VoD with a chat
2. Write `asdasdadadadadadasdasdadadadadadadaasdasdadadadadadasdasdadadadadadada` to the chat
3. Reply to your own message
4. No layout break.

