### PR TITLE
Fix false order of videos on course-page

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -431,7 +431,7 @@
                             </header>
                             <section>
                                 <template x-if="courseStreams.hasElements()">
-                                    <article class="flex flex-col" :class="{'flex-col-reverse' : isOldestFirst() }">
+                                    <article class="flex flex-col" :class="{'flex-col-reverse' : !isOldestFirst() }">
                                         <template
                                                 x-for="[m, streams] of Object.entries(courseStreams.get(sortFn(streamSortMode), filterPred(streamFilterMode)))">
                                             <article class="mb-8">


### PR DESCRIPTION
### Motivation and Context
Resolves #1143 

### Description
Negates predicate which determines order of groups, i.e. months.

### Steps for Testing
- 1 Course

1. Log in
2. Navigate to a Course
3. Re-order Elements
    1. `Oldest first`: Oldest month first; Oldest stream first; 
    2. `Newest first`: Newest month first; Newest stream first; 
4. 🌟
