### PR TITLE
Subscribe to WS in video-information

### DIFF
--- a/web/ts/components/video-information.ts
+++ b/web/ts/components/video-information.ts
@@ -32,7 +32,7 @@ export function videoInformationContext(streamId: number): AlpineComponent {
                     this.handleDescriptionUpdate(data);
                 }
             };
-            SocketConnections.ws.addHandler(handler);
+            SocketConnections.ws.subscribe(handler);
         },
 
         handleViewersUpdate(upd: { viewers: number }) {

--- a/web/ts/components/video-interaction.ts
+++ b/web/ts/components/video-interaction.ts
@@ -1,7 +1,6 @@
 import { AlpineComponent } from "./alpine-component";
 import { User } from "../api/users";
 import { SocketConnections } from "../api/chat-ws";
-import { RealtimeFacade } from "../utilities/ws";
 
 enum InteractionType {
     Chat,
@@ -13,9 +12,8 @@ export function videoInteractionContext(user: User) {
         type: InteractionType.Chat,
         user: user as User,
 
-        init() {
-            SocketConnections.ws.subscribe();
-        },
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        init() {},
 
         showChat() {
             this.type = InteractionType.Chat;


### PR DESCRIPTION
### Motivation and Context
Currently the `viewers` counter and dynamic description update doesn't work since the websocket is not initialized properly. 

### Description
Move `.subscribe` to parent context `videoInformationContext`.

### Steps for Testing
- 1 Account
- 2 Livestream (1 `+Chat` and 1 `-Chat`)

1. Log in
2. Navigate to a livestream  (`+Chat`)
3. Send messages. Should work. 
4. Navigation to another livestream (`-Chat`)
5. Viewers count should increase without reload if you open the livestream in multiple browser windows.
6. 🕺
