### PR TITLE
Fix chat

### DIFF
--- a/web/template/components/chat.gohtml
+++ b/web/template/components/chat.gohtml
@@ -298,7 +298,7 @@
                                    x-model="message"
                                    :placeholder="!isConnected() ? 'Reconnecting to chat...' : isLoggedIn() ? 'Send a message' : 'Log in to chat'"
                                    class="tum-live-border border-b bg-transparent text-sm font-normal placeholder:text-sm focus:outline-none py-1 w-full"
-                                   autocomplete="off">
+                                      autocomplete="off"></textarea>
                         </label>
                         <section class="flex justify-between">
                             <div class="relative">

--- a/web/ts/components/chat-prompt.ts
+++ b/web/ts/components/chat-prompt.ts
@@ -41,8 +41,8 @@ export function chatPromptContext(streamId: number): AlpineComponent {
             this.users.reset();
         },
 
-        send(event: KeyboardEvent) {
-            if (event.shiftKey) {
+        send(event?: KeyboardEvent) {
+            if (event !== undefined && event.shiftKey) {
                 return;
             }
             console.log("🌑 send message '", this.message, "'");


### PR DESCRIPTION
### Motivation and Context
In #1135 the `textarea` tag hasn't been closed. As a result the chat UI doesn't work properly. Furthermore, it broke the polls. 
(For examples, see testserver of #1145)

### Description
Close tag. 

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Account
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Chat `send` button should say `send` and not `New Poll`. 
4. Polls work. 
5. 🤠
