### PR TITLE
Fix order of playlist entries

### DIFF
--- a/web/ts/data-store/stream-playlist.ts
+++ b/web/ts/data-store/stream-playlist.ts
@@ -6,10 +6,10 @@ export class StreamPlaylistProvider extends StreamableMapProvider<number, Stream
         const result = await StreamPlaylist.get(streamId);
         return result
             .map((e) => {
-                e.createdAtDate = new Date(e.createdAt);
+                e.startDate = new Date(e.start);
                 return e;
             })
-            .sort((a, b) => a.createdAtDate.getTime() - b.createdAtDate.getTime());
+            .sort((a, b) => (a.startDate < b.startDate ? -1 : 1));
     }
 }
 
@@ -23,7 +23,7 @@ export type StreamPlaylistEntry = {
     createdAt: string;
 
     // Client Generated
-    createdAtDate: Date;
+    startDate: Date;
 };
 
 const StreamPlaylist = {


### PR DESCRIPTION
### Motivation and Context
- Resolves #1140 

### Description
The weird ordering occurred because we used `createdAt` for sorting. To fix this issue, use the `start` attribute.

### Steps for Testing
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Check playlist. Should be sorted starting from the first video in the current semester.
