### PR TITLE
fix course mgmt overlay bug

### DIFF
--- a/web/template/partial/course/manage/lecture-management-card.gohtml
+++ b/web/template/partial/course/manage/lecture-management-card.gohtml
@@ -182,7 +182,7 @@
                             x-on:click.outside="closeMoreDropdown($refs.button)"
                             :id="$id('more-dropdown-button')"
                             style="display: none;"
-                            class="absolute left-0 mt-2 w-36 bg-white dark:bg-gray-800 border border-black rounded shadow-md overflow-hidden"
+                            class="absolute left-0 mt-2 w-36 bg-white dark:bg-gray-800 border border-black rounded shadow-md overflow-hidden z-10"
                     >
                         <div>
                             <button @click="startSingleEdit(); closeMoreDropdown();"


### PR DESCRIPTION
### Motivation and Context
If lectures are sorted ASC, the option menu is below the next lecture section.
![Bildschirmfoto 2023-09-21 um 11 53 22](https://github.com/TUM-Dev/gocast/assets/17506411/79756878-2182-48d4-ba87-6b92ed4b1ce5)

### Description
Setting `z-index` to `10`.

### Steps for Testing
1. Log in
2. Navigate to a Course management page
3. Set sort to `asc`
4. Check if the menu is overlaying the next lecture row

### Screenshots
![Bildschirmfoto 2023-09-21 um 11 53 11](https://github.com/TUM-Dev/gocast/assets/17506411/a9267ff9-9648-4a89-ab2a-e94332929de7)
