### PR TITLE
Added close button to settings - working with browser history

### DIFF
--- a/web/template/partial/close-btn.gohtml
+++ b/web/template/partial/close-btn.gohtml
@@ -1,0 +1,10 @@
+{{define "close-button"}}
+    <div class="h-fit w-fit">
+        <button type="button" class="transition-colors duration-200 hover:text-gray-600
+            dark:hover:text-white text-gray-400 text-xl w-4" tabindex="0" @click="history.back()">
+            <div class="flex items-center">
+                <i class="icon-cancel"></i>
+            </div>
+        </button>
+    </div>
+{{end}}

--- a/web/template/user-settings.gohtml
+++ b/web/template/user-settings.gohtml
@@ -17,6 +17,8 @@
     <script src="static/assets/init.js"></script>
     <script src="/static/assets/ts-dist/global.bundle.js?v={{if .VersionTag}}{{.VersionTag}}{{else}}development{{end}}"></script>
 
+    <link href="/static/assets/css/icons.css?v={{if .VersionTag}}{{.VersionTag}}{{else}}development{{end}}"
+          rel="stylesheet">
     <link href="/static/assets/css-dist/home.css?v={{if .VersionTag}}{{.VersionTag}}{{else}}development{{end}}"
           rel="stylesheet">
     <style>[x-cloak] {
@@ -35,7 +37,12 @@
 <main id="content" class="flex justify-center grow h-full overflow-y-scroll">
     <article class="tum-live-settings-grid" x-data=" { err: '' } ">
         <header>
-            <h1 class="font-bold text-3">Settings</h1>
+            <div class="flex flex-row justify-between">
+                <h1 class="font-bold text-3">Settings</h1>
+                <div class="h-fit w-fit">
+                    {{template "close-button"}}
+                </div>
+            </div>
         </header>
         <div x-cloak x-show="err!==''" class="bg-danger/25 text-sm rounded-lg px-2 py-1 space-x-3 py-2">
             <i class="fa-solid fa-triangle-exclamation"></i>


### PR DESCRIPTION
### Motivation and Context
Fixes #1181 

### Description
Added a Button to exit the settings page. Currently uses browser history but can be extended to use custom history.

### Steps for Testing
- Log into any account
- Open settings page of account
- Press the small "x" at the top right of the page


Prerequisites:
- 1 Account


### Screenshots
![exit_button_settings](https://github.com/TUM-Dev/gocast/assets/67778694/9e17b34f-e82a-473a-ae2f-cb0003be3263)


