### PR TITLE
Hide current semester if show all is pressed and highlight current se…

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -155,7 +155,7 @@
             <template x-if="navigation.getChild('allSemesters').value">
                 <template x-for="(s, i) in semesters">
                     <button type="button" @click="switchSemester(s.Year, s.TeachingTerm)"
-                            :class="{'border-l-4 bg-blue-100/50 border-blue-500/50 dark:bg-indigo-500/25 dark:border-indigo-600/50': i == selectedSemesterIndex, }"
+                            :class="{'border-l-4 bg-blue-100/50 border-blue-500/50 dark:bg-indigo-500/25 dark:border-indigo-600/50': i == selectedSemesterIndex }"
                             class="tum-live-side-navigation-group-item hover"
                             x-text="s.FriendlyString()"></button>
                 </template>

--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -151,10 +151,11 @@
                 Semesters
             </header>
             <span class="tum-live-side-navigation-group-item mb-4 border-l-4 bg-blue-100/50 border-blue-500/50 dark:bg-indigo-500/25 dark:border-indigo-600/50"
-                  x-text="semesters[selectedSemesterIndex]?.FriendlyString()"></span>
+                  x-text="semesters[selectedSemesterIndex]?.FriendlyString()" x-show="!navigation.getChild('allSemesters').value"></span>
             <template x-if="navigation.getChild('allSemesters').value">
-                <template x-for="s in semesters">
+                <template x-for="(s, i) in semesters">
                     <button type="button" @click="switchSemester(s.Year, s.TeachingTerm)"
+                            :class="{'border-l-4 bg-blue-100/50 border-blue-500/50 dark:bg-indigo-500/25 dark:border-indigo-600/50': i == selectedSemesterIndex, }"
                             class="tum-live-side-navigation-group-item hover"
                             x-text="s.FriendlyString()"></button>
                 </template>

--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -151,7 +151,8 @@
                 Semesters
             </header>
             <span class="tum-live-side-navigation-group-item mb-4 border-l-4 bg-blue-100/50 border-blue-500/50 dark:bg-indigo-500/25 dark:border-indigo-600/50"
-                  x-text="semesters[selectedSemesterIndex]?.FriendlyString()" x-show="!navigation.getChild('allSemesters').value"></span>
+                  x-text="semesters[selectedSemesterIndex]?.FriendlyString()"
+                  x-show="!navigation.getChild('allSemesters').value"></span>
             <template x-if="navigation.getChild('allSemesters').value">
                 <template x-for="(s, i) in semesters">
                     <button type="button" @click="switchSemester(s.Year, s.TeachingTerm)"


### PR DESCRIPTION
### Motivation and Context
Fixes #1184 

### Description
Currently selected semester will be highlighted in semester list but won't be shown twice at the top

### Steps for Testing
On the main page just click show all on the semesters list

### Screenshots
![semester_selection_0](https://github.com/TUM-Dev/gocast/assets/67778694/0b51aa51-a2c8-4161-a36c-ef0d41579a49)
![semester_selection_1](https://github.com/TUM-Dev/gocast/assets/67778694/e33e9c52-644c-4ef3-8c32-ed21659e8850)

