### PR TITLE
1185-recent-VODs-section-doesnt-show-pinned-public-courses

### DIFF
--- a/web/ts/components/main.ts
+++ b/web/ts/components/main.ts
@@ -36,8 +36,9 @@ export function mainContext(year: number, term: string) {
                     if (this.userCourses.length > 0) {
                         if (this.pinnedCourses.length > 0) {
                             //
-                            let pinnedOrUserCourses : Course[] = this.userCourses.concat(
-                                this.pinnedCourses.filter((c : Course) => this.userCourses.indexOf(c) < 0));
+                            const pinnedOrUserCourses : Course[] = this.userCourses.concat(
+                                this.pinnedCourses.filter((c : Course) => this.userCourses.indexOf(c) < 0)
+                                );
                             this.recently.set(this.getRecently(pinnedOrUserCourses));
                             this.loadProgresses(pinnedOrUserCourses.map((c) => c.LastRecording.ID));
                         } else {

--- a/web/ts/components/main.ts
+++ b/web/ts/components/main.ts
@@ -36,9 +36,9 @@ export function mainContext(year: number, term: string) {
                     if (this.userCourses.length > 0) {
                         if (this.pinnedCourses.length > 0) {
                             //
-                            const pinnedOrUserCourses : Course[] = this.userCourses.concat(
-                                this.pinnedCourses.filter((c : Course) => this.userCourses.indexOf(c) < 0)
-                                );
+                            const pinnedOrUserCourses: Course[] = this.userCourses.concat(
+                                this.pinnedCourses.filter((c : Course) => this.userCourses.indexOf(c) < 0),
+                            );
                             this.recently.set(this.getRecently(pinnedOrUserCourses));
                             this.loadProgresses(pinnedOrUserCourses.map((c) => c.LastRecording.ID));
                         } else {

--- a/web/ts/components/main.ts
+++ b/web/ts/components/main.ts
@@ -36,7 +36,8 @@ export function mainContext(year: number, term: string) {
                     if (this.userCourses.length > 0) {
                         if (this.pinnedCourses.length > 0) {
                             //
-                            let pinnedOrUserCourses : Course[] = this.userCourses.concat(this.pinnedCourses.filter((c : Course) => this.userCourses.indexOf(c) < 0));
+                            let pinnedOrUserCourses : Course[] = this.userCourses.concat(
+                                this.pinnedCourses.filter((c : Course) => this.userCourses.indexOf(c) < 0));
                             this.recently.set(this.getRecently(pinnedOrUserCourses));
                             this.loadProgresses(pinnedOrUserCourses.map((c) => c.LastRecording.ID));
                         } else {

--- a/web/ts/components/main.ts
+++ b/web/ts/components/main.ts
@@ -37,7 +37,7 @@ export function mainContext(year: number, term: string) {
                         if (this.pinnedCourses.length > 0) {
                             //
                             const pinnedOrUserCourses: Course[] = this.userCourses.concat(
-                                this.pinnedCourses.filter((c : Course) => this.userCourses.indexOf(c) < 0),
+                                this.pinnedCourses.filter((c: Course) => this.userCourses.indexOf(c) < 0),
                             );
                             this.recently.set(this.getRecently(pinnedOrUserCourses));
                             this.loadProgresses(pinnedOrUserCourses.map((c) => c.LastRecording.ID));

--- a/web/ts/components/main.ts
+++ b/web/ts/components/main.ts
@@ -9,6 +9,7 @@ export function mainContext(year: number, term: string) {
         term: term as string,
 
         publicCourses: [] as Course[],
+        pinnedCourses: [] as Course[],
         userCourses: [] as Course[],
         liveToday: [] as Course[],
         recently: new AutoPaginator<Course>([], 10, (c: Course) => c.LastRecording.FetchThumbnail()),
@@ -26,15 +27,23 @@ export function mainContext(year: number, term: string) {
         reload(year: number, term: string) {
             this.year = year;
             this.term = term;
-            Promise.all([this.loadUserCourses(), this.loadPublicCourses()])
+            Promise.all([this.loadUserCourses(), this.loadPublicCourses(), this.loadPinnedCourses()])
                 .catch((err) => {
                     console.error(err);
                 })
                 .then(() => {
                     this.liveToday = this.getLiveToday();
                     if (this.userCourses.length > 0) {
-                        this.recently.set(this.getRecently(this.userCourses));
-                        this.loadProgresses(this.userCourses.map((c) => c.LastRecording.ID));
+                        if (this.pinnedCourses.length > 0) {
+                            //
+                            let pinnedOrUserCourses : Course[] = this.userCourses.concat(this.pinnedCourses.filter((c : Course) => this.userCourses.indexOf(c) < 0));
+                            this.recently.set(this.getRecently(pinnedOrUserCourses));
+                            this.loadProgresses(pinnedOrUserCourses.map((c) => c.LastRecording.ID));
+                        } else {
+                            // If user did not pin any course, just show the userCourses on recently VOD section
+                            this.recently.set(this.getRecently(this.userCourses));
+                            this.loadProgresses(this.userCourses.map((c) => c.LastRecording.ID));
+                        }
                     } else {
                         this.recently.set(this.getRecently(this.publicCourses));
                     }
@@ -69,6 +78,10 @@ export function mainContext(year: number, term: string) {
 
         async loadUserCourses() {
             this.userCourses = await CoursesAPI.getUsers(this.state.year, this.state.term);
+        },
+
+        async loadPinnedCourses() {
+            this.pinnedCourses = await CoursesAPI.getPinned(this.state.year, this.state.term);
         },
 
         async loadProgresses(ids: number[]) {


### PR DESCRIPTION
### Motivation and Context
Issue 1185: Recent VODs section doesnt show pinned (public) courses

### Description
Before the changes, only user courses were listed for the recently VOD section. Now there is a new array for pinned Courses and if it is detected that user has one or more pinned courses, pinned and user courses are merged into a new array (with eliminating duplicates) and this array is used for the recently VOD section. However a user without any course will still be seeing all public courses in recently VOD section whether he/she has pinned any course or not. That can also be changed to see only pinned courses if desired, but since the probability of a user without any course pinning a course is so low, that feature is not implemented. 


### Steps for Testing
1. Log in
2. Pin a public course that is not also listed in my courses. 
3. Navigate to recently VOD section.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
