### PR TITLE
fixed #1214 Playback using link with t=0 does not work

### DIFF
--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -65,7 +65,7 @@ class PlayerSettings {
             let iOSReady;
             const t: number | undefined = +getQueryParam("t");
             this.player.on("loadedmetadata", () => {
-                if (!isNaN(t) && t) {
+                if (!isNaN(t)) {
                     this.player.currentTime(t);
                     console.log(`⚫️ jump to: ${t}`);
                 }
@@ -73,7 +73,7 @@ class PlayerSettings {
             if (videojs.browser.IS_IOS) {
                 this.player.on("canplaythrough", () => {
                     // Can be executed multiple times during playback
-                    if (!iOSReady && t) {
+                    if (!iOSReady) {
                         this.player.currentTime(t);
                         iOSReady = true;
                     }
@@ -323,11 +323,12 @@ export const watchProgress = function (streamID: number, lastProgress: number) {
         let iOSReady = false;
         let intervalMillis = 10000;
         let jumpTo: number;
+        let tParam = +getQueryParam("t");
 
         // Fetch the user's video progress from the database and set the time in the player
         players[j].on("loadedmetadata", () => {
             duration = players[j].duration();
-            jumpTo = +getQueryParam("t") || lastProgress * duration;
+            jumpTo = isNaN(tParam) ? (lastProgress * duration) : tParam;
             players[j].currentTime(jumpTo);
         });
 

--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -323,12 +323,12 @@ export const watchProgress = function (streamID: number, lastProgress: number) {
         let iOSReady = false;
         let intervalMillis = 10000;
         let jumpTo: number;
-        let tParam = +getQueryParam("t");
+        const tParam = +getQueryParam("t");
 
         // Fetch the user's video progress from the database and set the time in the player
         players[j].on("loadedmetadata", () => {
             duration = players[j].duration();
-            jumpTo = isNaN(tParam) ? (lastProgress * duration) : tParam;
+            jumpTo = isNaN(tParam) ? lastProgress * duration : tParam;
             players[j].currentTime(jumpTo);
         });
 


### PR DESCRIPTION
### Motivation and Context
fixed #1214 

### Description
Distinguish the behavior of the watchProgress function when the parameter t is set to 0 and when it is not set, so that it matches the description [in the comment](https://github.com/TUM-Dev/gocast/blob/109be9a6e6dd6c115ae9fffdc37992a7af1f0236/web/ts/TUMLiveVjs.ts#L314):
> If query parameter 't' is specified, the timestamp given by 't' will be used.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->

1. Clear website cache
2. Log in
3. Navigate to a recording video
4. Jump to anywhere in the video other than the start
5. Refresh the page, note that the watch progress has been recorded and can be restored, so that the video resumes at the last progress
6. Add parameter "t=0" to current url and visit it
7. See the video plays from the start

