### PR TITLE
1177 course import deduplicate emails

### DIFF
--- a/web/template/admin/admin_tabs/course-import.gohtml
+++ b/web/template/admin/admin_tabs/course-import.gohtml
@@ -78,11 +78,11 @@
                             <tbody>
                             <script>
                                 /*
-                                The data coming from TUMonline sometimes duplicates contacts of a course.
-                                The elements of course.contacts has 5 attributes:
-                                first_name, last_name, email, main_contact, and role.
+                                The data coming from TUMonline sometimes duplicates contacts of some courses.
+                                course.contacts has 5 attributes:
+                                first_name, last_name, email, main_contact, role.
                                 All cases considered, the most distinctive among them is e-mail.
-                                and that's why eliminating the duplicates are down accordingly.
+                                and that's why duplicates are eliminated accordingly.
                                 */
                                 function filterUniqueContacts(contacts) {
                                     const uniqueEmails = new Set();

--- a/web/template/admin/admin_tabs/course-import.gohtml
+++ b/web/template/admin/admin_tabs/course-import.gohtml
@@ -76,21 +76,40 @@
                         </label>
                         <table>
                             <tbody>
-                                <template x-for="contact in course.contacts">
-                                    <tr class="pl-3" :class="contact.main_contact?'text-green-400':'text-3'">
-                                        <td class="px-2">
-                                            <label>
-                                                <i class="fa fa-envelope" x-show="contact.main_contact"></i>
-                                                <input class="w-auto" type="checkbox" x-model="contact.main_contact">
-                                            </label>
-                                        </td>
-                                        <td class="px-2" x-text="contact.role + ':'"></td>
-                                        <td x-text="contact.first_name + ' ' + contact.last_name" class="px-2"></td>
-                                        <td class="px-2">
-                                            <a :href="'mailto:'+contact.email" x-text="contact.email"></a>
-                                        </td>
-                                    </tr>
-                                </template>
+                            <script>
+                                /*
+                                The data coming from TUMonline sometimes duplicates contacts of a course.
+                                The elements of course.contacts has 5 attributes:
+                                first_name, last_name, email, main_contact, and role.
+                                All cases considered, the most distinctive among them is e-mail.
+                                and that's why eliminating the duplicates are down accordingly.
+                                */
+                                function filterUniqueContacts(contacts) {
+                                    const uniqueEmails = new Set();
+                                    return contacts.filter(contact => {
+                                        if (!uniqueEmails.has(contact.email)) {
+                                            uniqueEmails.add(contact.email);
+                                            return true;
+                                        }
+                                        return false;
+                                    });
+                                }
+                            </script>
+                            <template x-for="contact in filterUniqueContacts(course.contacts)">
+                                <tr class="pl-3" :class="contact.main_contact ? 'text-green-400' : 'text-3'">
+                                    <td class="px-2">
+                                        <label>
+                                            <i class="fa fa-envelope" x-show="contact.main_contact"></i>
+                                            <input class="w-auto" type="checkbox" x-model="contact.main_contact">
+                                        </label>
+                                    </td>
+                                    <td class="px-2" x-text="contact.role + ':'"></td>
+                                    <td x-text="contact.first_name + ' ' + contact.last_name" class="px-2"></td>
+                                    <td class="px-2">
+                                        <a :href="'mailto:' + contact.email" x-text="contact.email"></a>
+                                    </td>
+                                </tr>
+                            </template>
                             </tbody>
                         </table>
                         <template x-for="event in course.events">

--- a/web/template/admin/admin_tabs/course-import.gohtml
+++ b/web/template/admin/admin_tabs/course-import.gohtml
@@ -76,26 +76,7 @@
                         </label>
                         <table>
                             <tbody>
-                            <script>
-                                /*
-                                The data coming from TUMonline sometimes duplicates contacts of some courses.
-                                course.contacts has 5 attributes:
-                                first_name, last_name, email, main_contact, role.
-                                All cases considered, the most distinctive among them is e-mail.
-                                and that's why duplicates are eliminated accordingly.
-                                */
-                                function filterUniqueContacts(contacts) {
-                                    const uniqueEmails = new Set();
-                                    return contacts.filter(contact => {
-                                        if (!uniqueEmails.has(contact.email)) {
-                                            uniqueEmails.add(contact.email);
-                                            return true;
-                                        }
-                                        return false;
-                                    });
-                                }
-                            </script>
-                            <template x-for="contact in filterUniqueContacts(course.contacts)">
+                            <template x-for="contact in admin.filterUniqueContacts(course.contacts)">
                                 <tr class="pl-3" :class="contact.main_contact ? 'text-green-400' : 'text-3'">
                                     <td class="px-2">
                                         <label>

--- a/web/ts/course-import.ts
+++ b/web/ts/course-import.ts
@@ -44,3 +44,18 @@ export function addNotifyEventListeners() {
         window.location.replace("/");
     });
 }
+
+
+//The data coming from TUMonline sometimes duplicates contacts of some courses. course.contacts has 5 attributes:
+//first_name, last_name, email, main_contact, role.
+//All cases considered, the most distinctive among them is e-mail and duplicates are eliminated accordingly.
+export function filterUniqueContacts(contacts: any[]) {
+    const uniqueEmails = new Set();
+    return contacts.filter(contact => {
+        if (!uniqueEmails.has(contact.email)) {
+            uniqueEmails.add(contact.email);
+            return true;
+        }
+        return false;
+    });
+}

--- a/web/ts/course-import.ts
+++ b/web/ts/course-import.ts
@@ -45,13 +45,12 @@ export function addNotifyEventListeners() {
     });
 }
 
-
 //The data coming from TUMonline sometimes duplicates contacts of some courses. course.contacts has 5 attributes:
 //first_name, last_name, email, main_contact, role.
 //All cases considered, the most distinctive among them is e-mail and duplicates are eliminated accordingly.
-export function filterUniqueContacts(contacts: any[]) {
+export function filterUniqueContacts(contacts) {
     const uniqueEmails = new Set();
-    return contacts.filter(contact => {
+    return contacts.filter((contact) => {
         if (!uniqueEmails.has(contact.email)) {
             uniqueEmails.add(contact.email);
             return true;


### PR DESCRIPTION
### Motivation and Context
Issue 1177: https://github.com/orgs/TUM-Dev/projects/10/views/1?pane=issue&itemId=41336294
The array coming from TUMonline has some duplicates in contacts and these need to be eliminated.

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
The data coming from TUMonline sometimes duplicates contacts of some courses. course.contacts has 5 attributes:
first_name, last_name, email, main_contact, role.
All cases considered, the most distinctive among them is e-mail. So a script is added to modify the array before it is used for course contacts while importing courses.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- Having admin rights


1. Log in
2. Click admin in the menu
3. Click import courses
4. Find a course that used to have duplicate contacts: e.g.  Einführung in die Games Eng(IN0031), IN2064, ...
5. Confirm that there are not duplicate contacts anymore.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
Before there was two Vortragende*r, Leiter*in, but the course has only one actually:
![twoTimesListedGames](https://github.com/TUM-Dev/gocast/assets/70471039/1f3451fe-f15d-49eb-8ca8-7a1348962ed1)
After the changes, the duplicate is eliminated:
![Games_duplicates_eliminated](https://github.com/TUM-Dev/gocast/assets/70471039/cd872cf5-4e0a-49ee-8168-556c6289d37e)
