### PR TITLE
Fixed and optimized several issues in the front end of the course settings page

### DIFF
--- a/web/template/admin/admin_tabs/create-course.gohtml
+++ b/web/template/admin/admin_tabs/create-course.gohtml
@@ -3,7 +3,7 @@
 {{define "create-course"}}
     <div class="text-1 container mx-auto"
          x-data="{ tumonlineid: '', slug: '', title: '', year: '', yearW: '', semester: 'Wintersemester', numberAttendees: null, searchQuery: '', searchResults: [] , isSearchResultVisible: false}"
-        x-init="$watch('year',(value)=>{if(value<2000)return; yearW = (value%1000) + 1})">
+        x-init="$watch('year',(value)=>{ yearW = (value<2000) ? '' : (value%1000) + 1 })">
         <div class="min-w-screen flex items-center justify-center">
             <div class="w-full lg:w-5/6 p-3 bg-gray-100 dark:bg-secondary rounded dark:border dark:border-gray-500 shadow">
                 <h2 class="mb-0">Find your course from TUMOnline</h2>

--- a/web/template/admin/admin_tabs/create-course.gohtml
+++ b/web/template/admin/admin_tabs/create-course.gohtml
@@ -35,14 +35,14 @@
                     <h2>Manually enter Infos:</h2>
                     <div class="flex space-x-1">
                         <label for="name" class="hidden">Course Title</label>
-                        <input class="w-4/5 tl-input !ml-0" id="name" name="name" type="text"
+                        <input class="w-4/5 tl-input border !ml-0" id="name" name="name" type="text"
                                autocomplete="off"
                                placeholder="Einführung in die Informatik (IN0001)"
                                x-model="title"
                                required
                                :class="title === '' ? 'border-red-500 focus:border-red-500' : ''"/>
                         <label for="slug" class="hidden">Slug</label>
-                        <input class="w-1/5 tl-input" id="slug" name="slug" type="text" x-ref="slug"
+                        <input class="w-1/5 tl-input border" id="slug" name="slug" type="text" x-ref="slug"
                                autocomplete="off"
                                x-model="slug"
                                required

--- a/web/template/admin/admin_tabs/create-course.gohtml
+++ b/web/template/admin/admin_tabs/create-course.gohtml
@@ -2,7 +2,7 @@
 {{template "header" .IndexData.TUMLiveContext}}
 {{define "create-course"}}
     <div class="text-1 container mx-auto"
-         x-data="{ tumonlineid: '', slug: '', title: '', year: '', yearW: '', semester: 'Wintersemester', numberAttendees: null, searchQuery: '', searchResults: [] }"
+         x-data="{ tumonlineid: '', slug: '', title: '', year: '', yearW: '', semester: 'Wintersemester', numberAttendees: null, searchQuery: '', searchResults: [] , isSearchResultVisible: false}"
         x-init="$watch('year',(value)=>{if(value<2000)return; yearW = (value%1000) + 1})">
         <div class="min-w-screen flex items-center justify-center">
             <div class="w-full lg:w-5/6 p-3 bg-gray-100 dark:bg-secondary rounded dark:border dark:border-gray-500 shadow">
@@ -12,9 +12,11 @@
                         <input class="w-full box-border rounded px-4 py-3 mt-3 focus:outline-none border-0 bg-gray-50 w-full dark:bg-gray-600 dark:text-white"
                                type="search" autocomplete="off" placeholder="Search" x-model="searchQuery"
                                @change="fetch('/api/searchCourse?q='+searchQuery).then(r=>r.json()).then(r => searchResults=r)"
-                               @keyup="fetch('/api/searchCourse?q='+searchQuery).then(r=>r.json()).then(r => searchResults=r)"/>
+                               @keyup="fetch('/api/searchCourse?q='+searchQuery).then(r=>r.json()).then(r => searchResults=r)"
+                               @focus="isSearchResultVisible = true"
+                               @blur="setTimeout(() => isSearchResultVisible = false, 100)"/>
                     </div>
-                    <div class="px-2" x-show="searchResults.length!==0">
+                    <div class="px-2" x-show="isSearchResultVisible && searchQuery !== '' && searchResults.length!==0">
                         <ul role="listbox">
                             <template x-for="searchResult in searchResults">
                                 <li role="option" aria-selected="false"

--- a/web/template/admin/admin_tabs/create-course.gohtml
+++ b/web/template/admin/admin_tabs/create-course.gohtml
@@ -9,8 +9,9 @@
                 <h2 class="mb-0">Find your course from TUMOnline</h2>
                 <form id="createCourseForm" aria-haspopup="listbox" class="grid gap-3 mt-3">
                     <div class="flex space-x-1">
-                        <input class="w-full box-border rounded px-4 py-3 mt-3 focus:outline-none border-0 bg-gray-50 w-full dark:bg-gray-600 dark:text-white"
-                               type="search" autocomplete="off" placeholder="Search" x-model="searchQuery"
+                        <label for="search-course" class="hidden">Search Course</label>
+                        <input class="w-full box-border rounded px-4 py-3 mt-3 focus:outline-none border-0 bg-gray-50 dark:bg-gray-600 dark:text-white"
+                               id="search-course" type="search" autocomplete="off" placeholder="Search" x-model="searchQuery"
                                @change="fetch('/api/searchCourse?q='+searchQuery).then(r=>r.json()).then(r => searchResults=r)"
                                @keyup="fetch('/api/searchCourse?q='+searchQuery).then(r=>r.json()).then(r => searchResults=r)"
                                @focus="isSearchResultVisible = true"
@@ -47,7 +48,8 @@
                                x-model="slug"
                                required
                                placeholder="eidi"
-                               :class="slug === '' ? 'border-red-500 focus:border-red-500' : ''"/>
+                               :class="slug === '' ? 'border-red-500 focus:border-red-500' : ''"
+                               @input="slug = slug.replace(/[^A-Za-z0-9\-_.+()~]/g, '')"/>
                     </div>
                     {{template "semester-selection"}}
                 </form>

--- a/web/template/admin/admin_tabs/edit-course.gohtml
+++ b/web/template/admin/admin_tabs/edit-course.gohtml
@@ -13,7 +13,7 @@
             <div x-cloak x-show="(new URL(document.location)).searchParams.get('copied')!==null"
                 class="p-4 text-sm text-green-700 bg-green-100 rounded-lg dark:bg-green-200 dark:text-green-800"
                 role="alert">
-                Course was copied successfully.
+                Course was copied successfully. Welcome to the settings page of your newly copied course.
             </div>
             <div x-cloak x-show="(new URL(document.location)).searchParams.get('created')!==null"
                 class="p-4 text-sm text-green-700 bg-green-100 rounded-lg dark:bg-green-200 dark:text-green-800"

--- a/web/template/partial/course/manage/course_actions.gohtml
+++ b/web/template/partial/course/manage/course_actions.gohtml
@@ -1,7 +1,17 @@
 {{define "dangerzone"}}
     {{- /*gotype: github.com/TUM-Dev/gocast/model.Course*/ -}}
     <div class="form-container-body grid gap-3"
-         x-data="{ copying: false , year: '', yearW: '', semester: 'Wintersemester' }">
+         x-data="{ copying: false , year: '', yearW: '', semester: 'Wintersemester',
+         init() {
+              this.$watch('year', (newYear) => {
+                  if (newYear.length === 4) {
+                      const nextYear = parseInt(newYear) + 1;
+                      this.yearW = ('' + nextYear).slice(-2);
+                  } else {
+                      this.yearW = '';
+                  }
+              });
+         }}">
         <div x-show="copying" class="grid gap-3">
             {{template "semester-selection"}}
             <button :disabled="year==''" class="btn" @click="admin.copyCourse('{{.Model.ID}}',year,yearW,semester)">

--- a/web/template/partial/course/manage/create-lecture-form-slides/lecture-type-slide.gohtml
+++ b/web/template/partial/course/manage/create-lecture-form-slides/lecture-type-slide.gohtml
@@ -4,8 +4,8 @@
             <button
                     x-data="{ itemCreateType: admin.LectureCreateType.livestream }"
                     @click.prevent="() => updateCreateType(itemCreateType)"
-                    class="inline-flex items-center justify-between w-full p-5 text-gray-500 bg-white border border-gray-200 rounded-lg cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-600 dark:hover:bg-gray-500"
-                    :class="createType === itemCreateType ? 'dark:text-white dark:border-white border-blue-600 text-blue-600' : ''"
+                    class="inline-flex items-center justify-between w-full p-5 bg-white border rounded-lg cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-600 dark:hover:bg-gray-500"
+                    :class="createType === itemCreateType ? 'dark:text-white dark:border-white border-blue-600 text-blue-600' : 'text-gray-500 border-gray-200'"
             >
                 <div class="block text-left">
                     <div class="w-full text-lg font-semibold">Livestream</div>
@@ -17,8 +17,8 @@
             <button
                     x-data="{ itemCreateType: admin.LectureCreateType.vodRecord }"
                     @click.prevent="() => updateCreateType(itemCreateType)"
-                    class="inline-flex items-center justify-between w-full p-5 text-gray-500 bg-white border border-gray-200 rounded-lg cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-600 dark:hover:bg-gray-500"
-                    :class="createType === itemCreateType ? 'dark:text-white dark:border-white border-blue-600 text-blue-600' : ''"
+                    class="inline-flex items-center justify-between w-full p-5 bg-white border rounded-lg cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-600 dark:hover:bg-gray-500"
+                    :class="createType === itemCreateType ? 'dark:text-white dark:border-white border-blue-600 text-blue-600' : 'text-gray-500 border-gray-200'"
             >
                 <div class="block text-left">
                     <div class="w-full text-lg font-semibold">Record Lecture</div>
@@ -30,8 +30,8 @@
             <button
                     x-data="{ itemCreateType: admin.LectureCreateType.vodUpload }"
                     @click.prevent="() => updateCreateType(itemCreateType)"
-                    class="inline-flex items-center justify-between w-full p-5 text-gray-500 bg-white border border-gray-200 rounded-lg cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-600 dark:hover:bg-gray-500"
-                    :class="createType === itemCreateType ? 'dark:text-white dark:border-white border-blue-600 text-blue-600' : ''"
+                    class="inline-flex items-center justify-between w-full p-5 bg-white border rounded-lg cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-600 dark:hover:bg-gray-500"
+                    :class="createType === itemCreateType ? 'dark:text-white dark:border-white border-blue-600 text-blue-600' : 'text-gray-500 border-gray-200'"
             >
                 <div class="block text-left">
                     <div class="w-full text-lg font-semibold">Video Upload</div>

--- a/web/template/partial/course/manage/create-lecture-form.gohtml
+++ b/web/template/partial/course/manage/create-lecture-form.gohtml
@@ -68,11 +68,15 @@
             <span class="text-white rounded bg-danger px-4 py-2" >Something went wrong.</span>
         </div>
 
+        <div x-show="!canContinue" class="flex justify-end px-6">
+            <span class="text-gray-500" style="white-space: pre-wrap; text-align: right;" x-text="cannotContinueReason"></span>
+        </div>
+
         <div class="flex justify-end py-2 px-4">
             <button x-show="!loading" :disabled="!canGoBack" class="mx-2 disabled:text-gray-300 dark:disabled:text-gray-500" @click.prevent="() => prev()">
                 Back
             </button>
-            <button :disabled="loading || !canContinue" class="btn mx-2" @click.prevent="() => next()">
+            <button :disabled="loading || !canContinue" class="btn mx-2 disabled:text-gray-300 dark:disabled:text-gray-500" @click.prevent="() => next()">
                 <span x-show="!loading && !onLastSlide">Continue</span>
                 <span x-show="!loading && onLastSlide" x-text="formData.recurring && formData.recurringDates.filter(({enabled}) => enabled).length > 0
                                                             ? `Create ${(formData.recurringDates.filter(({enabled}) => enabled).length + 1).toString()} Lectures`

--- a/web/template/partial/course/manage/semester-selection.gohtml
+++ b/web/template/partial/course/manage/semester-selection.gohtml
@@ -7,15 +7,21 @@
         <option value="Sommersemester">Sommersemester</option>
     </select>
     <label for="year" class="hidden">teachingTermYear</label>
+
     <div class="flex">
-        <input id="year" x-model="year" name="year" class="w-32 tl-input"
-            :class="year === '' ? 'border-red-500 focus:border-red-500' : ''" placeholder="2022" type="number">
+        <input id="year" x-model="year" x-data="{initialYear: 2022}" name="year" class="w-32 tl-input border"
+               :class="year === '' ? 'border-red-500 focus:border-red-500' : ''"
+               :placeholder="year === '' ? initialYear : ''"
+               type="number"
+               @focus="if (year === '') year = initialYear">
         <template x-if="semester === 'Wintersemester'">
             <div class="flex">
                 <span class="mx-2 my-auto text-3">/</span>
                 <label for="yearW" class="hidden">teachingTermYearW</label>
                 <input id="yearW" x-model="yearW" name="yearW" class="w-16 tl-input"
-                    :class="yearW === '' ? 'border-red-500 focus:border-red-500' : ''" placeholder="23" type="text" readonly disabled>
+                       :class="yearW === '' ? 'border-red-500 focus:border-red-500' : ''"
+                       :placeholder="year === '' ? '23' : ''"
+                       type="text" readonly disabled>
             </div>
         </template>
     </div>

--- a/web/template/partial/course/manage/semester-selection.gohtml
+++ b/web/template/partial/course/manage/semester-selection.gohtml
@@ -9,7 +9,7 @@
     <label for="year" class="hidden">teachingTermYear</label>
 
     <div class="flex">
-        <input id="year" x-model="year" x-data="{initialYear: 2022}" name="year" class="w-32 tl-input border"
+        <input id="year" x-model="year" x-data="{initialYear: 2024}" name="year" class="w-32 tl-input border"
                :class="year === '' ? 'border-red-500 focus:border-red-500' : ''"
                :placeholder="year === '' ? initialYear : ''"
                type="number"
@@ -20,7 +20,7 @@
                 <label for="yearW" class="hidden">teachingTermYearW</label>
                 <input id="yearW" x-model="yearW" name="yearW" class="w-16 tl-input"
                        :class="yearW === '' ? 'border-red-500 focus:border-red-500' : ''"
-                       :placeholder="year === '' ? '23' : ''"
+                       :placeholder="year === '' ? '25' : ''"
                        type="text" readonly disabled>
             </div>
         </template>

--- a/web/template/partial/course/manage/semester-selection.gohtml
+++ b/web/template/partial/course/manage/semester-selection.gohtml
@@ -15,7 +15,7 @@
                 <span class="mx-2 my-auto text-3">/</span>
                 <label for="yearW" class="hidden">teachingTermYearW</label>
                 <input id="yearW" x-model="yearW" name="yearW" class="w-16 tl-input"
-                    :class="yearW === '' ? 'border-red-500 focus:border-red-500' : ''" type="text" readonly disabled>
+                    :class="yearW === '' ? 'border-red-500 focus:border-red-500' : ''" placeholder="23" type="text" readonly disabled>
             </div>
         </template>
     </div>

--- a/web/ts/edit-course.ts
+++ b/web/ts/edit-course.ts
@@ -822,6 +822,8 @@ export function createLectureForm(args: { s: [] }) {
 
         // This function sets flags depending on the current tab and current data
         onUpdate() {
+            this.error = false;
+
             if (this.currentTab === 0) {
                 this.canContinue = true;
                 this.canGoBack = false;

--- a/web/ts/edit-course.ts
+++ b/web/ts/edit-course.ts
@@ -424,10 +424,7 @@ export function saveLectureDescription(e: Event, cID: number, lID: number): Prom
     e.preventDefault();
     const input = (document.getElementById("lectureDescriptionInput" + lID) as HTMLInputElement).value;
     return putData("/api/course/" + cID + "/updateDescription/" + lID, { name: input }).then((res) => {
-        if (res.status !== StatusCodes.OK) {
-            return false;
-        }
-        return true;
+        return res.status === StatusCodes.OK;
     });
 }
 
@@ -436,10 +433,7 @@ export function saveLectureName(e: Event, cID: number, lID: number): Promise<boo
     e.preventDefault();
     const input = (document.getElementById("lectureNameInput" + lID) as HTMLInputElement).value;
     return postData("/api/course/" + cID + "/renameLecture/" + lID, { name: input }).then((res) => {
-        if (res.status !== StatusCodes.OK) {
-            return false;
-        }
-        return true;
+        return res.status === StatusCodes.OK;
     });
 }
 
@@ -763,11 +757,7 @@ export function createLectureForm(args: { s: [] }) {
         },
         updateCreateType(newType: LectureCreateType) {
             this.createType = newType;
-            if (newType === LectureCreateType.livestream) {
-                this.formData.vodup = false;
-            } else {
-                this.formData.vodup = true;
-            }
+            this.formData.vodup = newType !== LectureCreateType.livestream;
         },
         updateLiveAdHoc(adHoc: boolean) {
             this.formData.adHoc = adHoc;

--- a/web/ts/edit-course.ts
+++ b/web/ts/edit-course.ts
@@ -737,6 +737,7 @@ export function createLectureForm(args: { s: [] }) {
         error: false,
         courseID: -1,
         invalidReason: "",
+        cannotContinueReason: "",
         init() {
             this.onUpdate();
         },
@@ -816,6 +817,7 @@ export function createLectureForm(args: { s: [] }) {
 
             if (this.currentTab === 0) {
                 this.canContinue = true;
+                this.cannotContinueReason = "";
                 this.canGoBack = false;
                 this.onLastSlide = false;
                 return;
@@ -828,10 +830,21 @@ export function createLectureForm(args: { s: [] }) {
                     // => we are not on the last tab
                     this.canGoBack = true;
                     this.canContinue = this.formData.start.length > 0;
+                    this.cannotContinueReason = "";
+                    if (this.formData.start.length <= 0) {
+                        this.cannotContinueReason += "The start time for the lecture has not been set yet!\n";
+                    }
                 } else {
                     this.onLastSlide = true;
                     this.canGoBack = true;
                     this.canContinue = this.formData.start.length > 0 && this.formData.end.length > 0;
+                    this.cannotContinueReason = "";
+                    if (this.formData.start.length <= 0) {
+                        this.cannotContinueReason += "The start time for the lecture has not been set yet!\n";
+                    }
+                    if (this.formData.end.length <= 0) {
+                        this.cannotContinueReason += "The end time for the lecture has not been set yet!\n";
+                    }
                 }
                 return;
             }
@@ -840,6 +853,14 @@ export function createLectureForm(args: { s: [] }) {
                 this.canContinue =
                     (this.getMediaFiles().length > 0 && this.formData.vodup) ||
                     (this.formData.adHoc && this.formData.end != "");
+                this.cannotContinueReason = "";
+                if (this.formData.vodup && this.getMediaFiles().length <= 0) {
+                    this.cannotContinueReason += "No media files!\n";
+                }
+                if (this.formData.adHoc && this.formData.end == "") {
+                    this.cannotContinueReason += "The end time for the lecture has not been set yet!\n";
+                }
+
                 this.canGoBack = true;
                 this.onLastSlide = true;
                 return;


### PR DESCRIPTION
## 1. Reset error state upon update of the "New Lecture" panel
**Before:** If anything failed when creating a new lecture, the alert banner "Something went wrong." will always be shown in the form, which is ambiguous.

<p align="center">
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/36d90f03-f4b1-4785-bebd-3b44652ca8f1" width="400" alt="A picture showing the wrong behaviour of the alert banner, which doesn't disappear after already left the page where the error has occurred.">
  <br>
  <small>Example: After a user fails to upload a VoD, they are returned to the first step of the settings, but the error message does not disappear, causing confusion.</small>
</p>

**After:** The error banner disappears upon each update.

## 2. Correct the style of the buttons in the create-lecture-form
**Before:** In light mode, the button looks the same whether it is selected or not, making it difficult to notice changes after altering the options for creating a new lecture.

<p align="center">
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/d57a7e00-0381-4910-911d-8fdd2f1a705e" alt="Button \"Livestream\" selected but hard to notice" width="260"/>
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/afdfd8cd-b11c-4e1c-97b9-282c7f8df3f3" alt="Button \"Record Lecture\" selected but hard to notice" width="260"/>
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/0a3da0ef-4912-4bc0-8bec-346cfba9e76d" alt="Button \"Video Upload\" selected but hard to notice" width="260"/>
</p>

**After:** The change of style when selected can be correctly displayed in light mode.

<p align="center">
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/18640327-333d-4ebe-8d2a-5e9003779a29" alt="Button \"Livestream\" selected and highlighted" width="260"/>
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/05a60852-3a38-41e3-b27a-96ca0c53ed71" alt="Button \"Record Lecture\" selected and highlighted" width="260"/>
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/c9ddf370-d334-4955-8546-85d7ecf50ff8" alt="Button \"Video Upload\" selected and highlighted" width="260"/>
</p>

## 3. On the edit-course page:
Change the style of the "continue" button when disabled to make it more obvious that it is disabled; Provide reasons for why the 'continue' button is disabled.

**Before:** Hard to distinct whether the "continue" button is disabled or not, in both light and dark mode.

<p align="center">
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/17b0301a-d15a-40ea-a1e2-471d8485b64b" alt="The continue button is disabled, but not obvious - in light mode" width="400"/>
<br>
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/34209977-1ef8-46a5-9d81-9dd4bff92763" alt="The continue button is disabled, but not obvious - in dark mode" width="400"/>
</p>

**After:** When the button is disabled, it is clearly visible; at the same time, display the reason why the button cannot be clicked above it.

<p align="center">
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/6105f725-a498-44c5-9319-032ff950d218" alt="The continue button is disabled, reasons shown - in light mode, 1/3" width="260"/>
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/e44298e9-11d4-4c61-abbf-0b76ba873cfb" alt="The continue button is disabled, reasons shown - in light mode, 2/3" width="260"/>
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/05592714-f910-40d2-90c5-a6a7eb1a838c" alt="The continue button is disabled, reasons shown - in light mode, 3/3" width="260"/>
</p>

<p align="center">
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/51cd4694-03d0-44dc-bb0f-384ee8fef671" alt="The continue button is disabled, reasons shown - in dark mode, 1/3" width="260"/>
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/eeebb54f-66fe-4c69-b889-b066c73a8191" alt="The continue button is disabled, reasons shown - in dark mode, 2/3" width="260"/>
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/21040a58-af25-4a10-b79e-000ab80ff31a" alt="The continue button is disabled, reasons shown - in dark mode, 3/3" width="260"/>
</p>

## 4. On edit-course page:
When copying a course, ensure the correct display of yearW for winter semesters.

**Before:**

<p align="center">
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/35b490c7-54f9-45fc-baa5-3bbaabc2290e" width="400"/>
</p>

**After:**

<p align="center">
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/1c45a019-aec2-409d-be45-c22c530c161f" width="400"/>
</p>

## 5. After course copy:
Add a tooltip to explain that the current page is the setting page of the newly copied course, not the original one.

**Before:**

<p align="center">
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/b913c081-7167-4a3a-9011-d9174edbdc94" width="600"/>
</p>

**After:**

<p align="center">
  <img src="https://github.com/TUM-Dev/gocast/assets/78721605/eb2e1fd8-7482-4a08-9ca0-54224256134f" width="600"/>
</p>


## 6. Search course on the create-course page:
Hide the search result list if the input box is then emptied, and when the input box loses focus.

## 7. Reset yearW to empty string when year < 2000

**Before:**
The yearW won't be reset until another valid year (>2000) is input. The following picture shows the case when the user first inputs 2077 and then changed the value to 0.
<p align="center">
  <img width="400" src="https://github.com/TUM-Dev/gocast/assets/78721605/9ed556bb-b54a-4638-ab05-397bb1406211"/>
</p>

**After:**
Problem solved. When the year is invalid, yearW will be emptied. Also, the placeholder "25" will only be shown if "year" is displaying the placeholder "2024".

## 8. Placeholder of "year" for a semester-selection:

When the input field "year" gets focused when it's empty, set the placeholder as the input. This also allows the value to change from what the placeholder shows instead of 0, when the value is directly adjusted using the number increase/decrease button in the number-input field.

## 9. On create-course page, mark necessary field with red border if empty

This was not functioning because the line-width of the border had been incorrectly set to 0.

## 10. Ensure the slug of new courses is url-safe

On create-course page, restrict the characters input to the field "slug" to [a-zA-Z0-9\-_.+()~] (Numbers, English characters and 7 special characters). This could prevent the course from having an invalid url.