### PR TITLE
popupContext ws subscription is added.

### DIFF
--- a/web/ts/components/popup.ts
+++ b/web/ts/components/popup.ts
@@ -5,7 +5,11 @@ import { SocketConnections } from "../api/chat-ws";
 export function popupContext(streamId: number): AlpineComponent {
     return {
         init() {
+            // subscription?
             SocketConnections.ws = new RealtimeFacade("chat/" + streamId);
+            // ws needs to subscribe, so that pop-out chat can work
+            const handler = (data) => {};
+            SocketConnections.ws.subscribe(handler);
         },
     } as AlpineComponent;
 }


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes the issue Popup chat does not update  #1199 

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
When pop-up chat is opened, a new web socket(ws) is created so that the new chat can work properly. When examined, the only difference between normal-chat(chat near video) and popup chat is that, normal chat subscribes a void handler when created, but popup chat does not do that. As a solution, a void handler is created on popup.ts and the web socket subscribed via this handler and popup chat started working.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Lecturer

1. Log in
2. Create a course and enable chat
3. Create a lecture and open the chats lecture
4. Open the popup chat and test sendin messages in both chats and check whether both checks are updated accordingly.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
