### PR TITLE
Ensure that the mouse pointing time is displayed above the playback progress

### DIFF
--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -185,6 +185,11 @@ label:has(~ .tl-input), label:has(~.tl-textarea) {
     background-color: #3070b3 !important;
 }
 
+/* Ensure that the mouse pointing time is displayed above the playback progress */
+.video-js .vjs-mouse-display {
+    z-index: 2 !important;
+}
+
 .video-js .vjs-big-play-button {
     @apply absolute top-0 left-0 bottom-0 right-0 m-auto;
 }


### PR DESCRIPTION
closes #1256

### Screenshots

Before: 

<img width="71" alt="image" src="https://github.com/TUM-Dev/gocast/assets/78721605/10436f9d-9375-40d8-b20f-a48b62732742">
<img width="179" alt="image" src="https://github.com/TUM-Dev/gocast/assets/78721605/6c93af06-0820-4300-8cce-9b0a8cd6e577">

After:

<img width="71" alt="image" src="https://github.com/TUM-Dev/gocast/assets/78721605/0fbe0013-542f-476a-b7ee-402f36c3532a">
<img width="179" alt="image" src="https://github.com/TUM-Dev/gocast/assets/78721605/1362f740-c457-4911-8485-9ac82e84a4ee">
