### PR TITLE
Revise golangci-lint configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,3 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+# For a description for each linter, see https://golangci-lint.run/usage/linters/.
 linters:
   enable:
     - gosimple
@@ -14,7 +15,6 @@ linters:
     - ineffassign
     - gofumpt
     - revive
-    - depguard
     - nakedret
     - unconvert
     - wastedassign
@@ -73,7 +73,8 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
   new: true
-  new-from-rev: HEAD
+  new-from-rev: bd63a53f
+  fix: false 
   exclude-rules:
     # Exclude some linters from running on tests files.
     - path: _test\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,7 +73,7 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
   new: true
-  new-from-rev: bd63a53f
+  new-from-rev: dev
   fix: false 
   exclude-rules:
     # Exclude some linters from running on tests files.

--- a/api/lecture_halls.go
+++ b/api/lecture_halls.go
@@ -43,6 +43,9 @@ func configGinLectureHallApiRouter(router *gin.Engine, daoWrapper dao.DaoWrapper
 type lectureHallRoutes struct {
 	dao.DaoWrapper
 	presetUtility tools.PresetUtility
+
+
+
 }
 
 type updateLectureHallReq struct {

--- a/api/lecture_halls.go
+++ b/api/lecture_halls.go
@@ -43,9 +43,6 @@ func configGinLectureHallApiRouter(router *gin.Engine, daoWrapper dao.DaoWrapper
 type lectureHallRoutes struct {
 	dao.DaoWrapper
 	presetUtility tools.PresetUtility
-
-
-
 }
 
 type updateLectureHallReq struct {

--- a/api/maintenance.go
+++ b/api/maintenance.go
@@ -2,12 +2,13 @@ package api
 
 import (
 	"fmt"
+	"net/http"
+	"strconv"
+
 	"github.com/TUM-Dev/gocast/dao"
 	"github.com/TUM-Dev/gocast/model"
 	"github.com/TUM-Dev/gocast/tools"
 	"github.com/gin-gonic/gin"
-	"net/http"
-	"strconv"
 )
 
 func configMaintenanceRouter(router *gin.Engine, daoWrapper dao.DaoWrapper) {

--- a/api/server-notifications.go
+++ b/api/server-notifications.go
@@ -2,12 +2,13 @@ package api
 
 import (
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/TUM-Dev/gocast/dao"
 	"github.com/TUM-Dev/gocast/model"
 	"github.com/TUM-Dev/gocast/tools"
 	"github.com/gin-gonic/gin"
-	"net/http"
-	"time"
 )
 
 func configServerNotificationsRoutes(engine *gin.Engine, daoWrapper dao.DaoWrapper) {

--- a/api/users.go
+++ b/api/users.go
@@ -652,7 +652,6 @@ func (r usersRoutes) updateCustomSpeeds(c *gin.Context) {
 		})
 		return
 	}
-
 }
 
 func (r usersRoutes) updatePlaybackSpeeds(c *gin.Context) {

--- a/cmd/tumlive/tumlive.go
+++ b/cmd/tumlive/tumlive.go
@@ -2,6 +2,14 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
 	"github.com/TUM-Dev/gocast/api"
 	"github.com/TUM-Dev/gocast/dao"
 	"github.com/TUM-Dev/gocast/model"
@@ -17,13 +25,6 @@ import (
 	"github.com/pkg/profile"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
-	"log/slog"
-	"net/http"
-	_ "net/http/pprof"
-	"os"
-	"os/signal"
-	"syscall"
-	"time"
 )
 
 var VersionTag = "development"
@@ -101,7 +102,7 @@ func main() {
 	}()
 
 	// log with time, fmt "23.09.2021 10:00:00"
-	//log.SetFormatter(&log.TextFormatter{TimestampFormat: "02.01.2006 15:04:05", FullTimestamp: true})
+	// log.SetFormatter(&log.TextFormatter{TimestampFormat: "02.01.2006 15:04:05", FullTimestamp: true})
 
 	web.VersionTag = VersionTag
 	osSignal = make(chan os.Signal, 1)

--- a/model/user.go
+++ b/model/user.go
@@ -98,12 +98,9 @@ func (u *User) GetEnabledPlaybackSpeeds() (res []float32) {
 	if u == nil {
 		return []float32{1}
 	}
-	for _, setting := range u.GetPlaybackSpeeds().GetEnabled() {
-		res = append(res, setting)
-	}
-	for _, setting := range u.GetCustomSpeeds() {
-		res = append(res, setting)
-	}
+	// Possibly, this could be collapsed into a single line, but readibility suffers.
+	res = append(res, u.GetPlaybackSpeeds().GetEnabled()...)
+	res = append(res, u.GetCustomSpeeds()...)
 	sort.SliceStable(res, func(i, j int) bool {
 		return res[i] < res[j]
 	})


### PR DESCRIPTION
### Motivation and Context
Previously, the linter started linting starting from the moving branch `HEAD`.
Of course, this is always the latest commit, rendering the linter ineffective.

### Description
Update the golangci configuration to mitigate this problem. Besides, I remove `depguard` as it seems a bit over the top.
We now actually only highlight new issues now, i.e., issues that will come on top of `dev`.
Feel free to run it locally on older changes to find meaningful issues.

### Steps for Testing
None. A passing CI should be enough.
