### PR TITLE
popup chat close on esc added.

### DIFF
--- a/web/template/popup-chat.gohtml
+++ b/web/template/popup-chat.gohtml
@@ -17,7 +17,6 @@
     <link href="/static/assets/css-dist/home.css?v={{if .IndexData.VersionTag}}{{.IndexData.VersionTag}}{{else}}development{{end}}"
           rel="stylesheet">
 </head>
-<body class="bg-white dark:bg-secondary h-screen" x-data="interaction.popupContext({{$stream.ID}})">
+<body class="bg-white dark:bg-secondary h-screen" x-data="interaction.popupContext({{$stream.ID}})" x-init="interaction.closeChatOnEscapePressed()">
     {{template "chat-component" .}}
-    <script> interaction.closeChatOnEscapePressed(); </script>
 </body>

--- a/web/template/popup-chat.gohtml
+++ b/web/template/popup-chat.gohtml
@@ -19,4 +19,5 @@
 </head>
 <body class="bg-white dark:bg-secondary h-screen" x-data="interaction.popupContext({{$stream.ID}})">
     {{template "chat-component" .}}
+    <script> interaction.closeChatOnEscapePressed(); </script>
 </body>

--- a/web/ts/components/popup.ts
+++ b/web/ts/components/popup.ts
@@ -13,3 +13,11 @@ export function popupContext(streamId: number): AlpineComponent {
         },
     } as AlpineComponent;
 }
+
+export function closeChatOnEscapePressed() {
+    document.addEventListener("keyup", function (event) {
+        if (event.key === "Escape") {
+            window.close();
+        }
+    });
+}


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
closes #1280

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
add an event listener so that popup chat is closed when esc is clicked

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:

1. Log in
2. Navigate to a lecture recording with chat enabled or create one
3. Open popup chat and click esc and check whether it closes the popup chat browser or not

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
