### PR TITLE
Added skip silence hotkey

### DIFF
--- a/web/ts/hotkeys.ts
+++ b/web/ts/hotkeys.ts
@@ -170,6 +170,10 @@ export const defaultOptions = {
             match: ["End"],
             handle: handleSeekTo(1),
         },
+        skipSilence: {
+            match: ["s", "S"],
+            handle: handleWithClick("SkipSilenceToggle"),
+        },
     } as Hotkeys,
 };
 


### PR DESCRIPTION
### Motivation and Context
Skip Silence should have a hotkey

### Description
Added hotkey "s" and "S" as hotkey for skipping silence

### Steps for Testing

1. Navigate to a Livestream with silence
2.  Press "s" or "S"
