### PR TITLE
Fixed bug with long course titles

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -476,11 +476,14 @@
                                                                 </div>
                                                             </a>
                                                             <div class="relative flex justify-between px-1 min-h-[32px]">
-                                                                <div>
+                                                                <div class="w-full">
                                                                     <template x-if="vod.HasName()">
-                                                                        <a class="title"
+                                                                        <a class="title overflow-hidden"
                                                                            :href="course.WatchURL(vod.ID)"
-                                                                           x-text="vod.Name"></a>
+                                                                           :title="vod.Name"
+                                                                           x-text="vod.Name">
+
+                                                                        </a>
                                                                     </template>
                                                                     <span class="date text-sm"
                                                                           x-text="vod.FriendlyDateStart()"></span>


### PR DESCRIPTION
### Motivation and Context
Fixes UI bugs with long titles.

### Description
Text will now be cut off if it's too long and only be shown on mouse hover.

### Screenshots
![image](https://github.com/TUM-Dev/gocast/assets/67778694/2604ea52-8043-43df-876e-8b0491bd9fe3)
![image](https://github.com/TUM-Dev/gocast/assets/67778694/4712ce92-eecf-4913-b640-13a3e59404b7)
