### PR TITLE
Show watch progress in playlist view

### DIFF
--- a/api/stream.go
+++ b/api/stream.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/TUM-Dev/gocast/tools/pathprovider"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -357,26 +358,44 @@ func (r streamRoutes) getStream(c *gin.Context) {
 
 func (r streamRoutes) getStreamPlaylist(c *gin.Context) {
 	type StreamPlaylistEntry struct {
-		StreamID   uint      `json:"streamId"`
-		CourseSlug string    `json:"courseSlug"`
-		StreamName string    `json:"streamName"`
-		LiveNow    bool      `json:"liveNow"`
-		Watched    bool      `json:"watched"`
-		Start      time.Time `json:"start"`
-		CreatedAt  time.Time `json:"createdAt"`
+		StreamID       uint                 `json:"streamId"`
+		CourseSlug     string               `json:"courseSlug"`
+		StreamName     string               `json:"streamName"`
+		LiveNow        bool                 `json:"liveNow"`
+		Watched        bool                 `json:"watched"`
+		Start          time.Time            `json:"start"`
+		StreamProgress model.StreamProgress `json:"streamProgress"`
+		CreatedAt      time.Time            `json:"createdAt"`
 	}
 
 	tumLiveContext := c.MustGet("TUMLiveContext").(tools.TUMLiveContext)
+
+	// Create mapping of stream id to progress for all progresses of user
+	var streamIDs []uint
+	for _, stream := range tumLiveContext.Course.Streams {
+		streamIDs = append(streamIDs, stream.ID)
+	}
+	streamProgresses := make(map[uint]model.StreamProgress)
+	res, err := r.LoadProgress(tumLiveContext.User.ID, streamIDs)
+	if err != nil {
+		log.WithError(err).Error("Couldn't load progresses")
+	} else {
+		for _, progress := range res {
+			streamProgresses[progress.StreamID] = progress
+		}
+	}
+
 	var result []StreamPlaylistEntry
 	for _, stream := range tumLiveContext.Course.Streams {
 		result = append(result, StreamPlaylistEntry{
-			StreamID:   stream.ID,
-			CourseSlug: tumLiveContext.Course.Slug,
-			StreamName: stream.GetName(),
-			LiveNow:    stream.LiveNow,
-			Watched:    stream.Watched,
-			Start:      stream.Start,
-			CreatedAt:  stream.CreatedAt,
+			StreamID:       stream.ID,
+			CourseSlug:     tumLiveContext.Course.Slug,
+			StreamName:     stream.GetName(),
+			LiveNow:        stream.LiveNow,
+			Watched:        stream.Watched,
+			Start:          stream.Start,
+			StreamProgress: streamProgresses[stream.ID],
+			CreatedAt:      stream.CreatedAt,
 		})
 	}
 

--- a/web/assets/css/watch.css
+++ b/web/assets/css/watch.css
@@ -1,5 +1,5 @@
 .playlist-thumbnail {
-    @apply bg-gray-100 dark:bg-gray-800 rounded-lg mr-4 bg-cover transition-all duration-500 hover:shadow-xl dark:shadow-gray-900/75;
+    @apply relative bg-gray-100 dark:bg-gray-800 rounded-lg mr-4 bg-cover transition-all duration-500 hover:shadow-xl dark:shadow-gray-900/75;
 }
 
 /* Rendered, but not visible on the screen. Enables layout calculations. */

--- a/web/template/partial/stream/playlist.gohtml
+++ b/web/template/partial/stream/playlist.gohtml
@@ -32,6 +32,15 @@
                             <div
                                 :style="`background-image:url('/api/stream/${elem.streamId}/thumbs/vod')`"
                                  class="h-14 w-24 shrink-0 playlist-thumbnail">
+                                <div :id="`vod-progress-${elem.streamId}`"
+                                     class="tum-live-thumbnail-progress">
+                                    <div>
+                                        <template x-if="elem.progress !== undefined">
+                                            <span :style="`width: ${elem.progress.Percentage()}%`"
+                                                  :class="{'rounded-br-lg': elem.progress.HasProgressOne()}"></span>
+                                        </template>
+                                    </div>
+                                </div>
                             </div>
                             <i x-show="selected" class="fa-solid fa-play text-2 mr-2"></i>
                             <h2 x-text="elem.streamName" class="text-sm dark:text-white"></h2>

--- a/web/ts/data-store/stream-playlist.ts
+++ b/web/ts/data-store/stream-playlist.ts
@@ -1,21 +1,23 @@
 import { Delete, getData, postData, putData, Time } from "../global";
 import { StreamableMapProvider } from "./provider";
-import {Progress} from "../api/progress";
+import { Progress } from "../api/progress";
 
 export class StreamPlaylistProvider extends StreamableMapProvider<number, StreamPlaylistEntry[]> {
     protected async fetcher(streamId: number): Promise<StreamPlaylistEntry[]> {
         const result = await StreamPlaylist.get(streamId);
-        return result
-            .map((e) => {
-                e.startDate = new Date(e.start);
-                return e;
-            })
-            // Convert stream progress to Typescript object
-            .map((e) => {
-                e.progress = new Progress(JSON.parse(JSON.stringify(e.streamProgress)));
-                return e;
-            })
-            .sort((a, b) => (a.startDate < b.startDate ? -1 : 1));
+        return (
+            result
+                .map((e) => {
+                    e.startDate = new Date(e.start);
+                    return e;
+                })
+                // Convert stream progress to Typescript object
+                .map((e) => {
+                    e.progress = new Progress(JSON.parse(JSON.stringify(e.streamProgress)));
+                    return e;
+                })
+                .sort((a, b) => (a.startDate < b.startDate ? -1 : 1))
+        );
     }
 }
 

--- a/web/ts/data-store/stream-playlist.ts
+++ b/web/ts/data-store/stream-playlist.ts
@@ -1,5 +1,6 @@
 import { Delete, getData, postData, putData, Time } from "../global";
 import { StreamableMapProvider } from "./provider";
+import {Progress} from "../api/progress";
 
 export class StreamPlaylistProvider extends StreamableMapProvider<number, StreamPlaylistEntry[]> {
     protected async fetcher(streamId: number): Promise<StreamPlaylistEntry[]> {
@@ -7,6 +8,11 @@ export class StreamPlaylistProvider extends StreamableMapProvider<number, Stream
         return result
             .map((e) => {
                 e.startDate = new Date(e.start);
+                return e;
+            })
+            // Convert stream progress to Typescript object
+            .map((e) => {
+                e.progress = new Progress(JSON.parse(JSON.stringify(e.streamProgress)));
                 return e;
             })
             .sort((a, b) => (a.startDate < b.startDate ? -1 : 1));
@@ -20,10 +26,12 @@ export type StreamPlaylistEntry = {
     liveNow: boolean;
     watched: boolean;
     start: string;
+    streamProgress: string;
     createdAt: string;
 
-    // Client Generated
+    // Client generated to package data with Typescript constructors
     startDate: Date;
+    progress: Progress;
 };
 
 const StreamPlaylist = {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #1248 
Much how the watch progress of a recording is displayed on the thumbnail of a stream on the course page, the watch progress of a recording is displayed in the playlist view.

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
The stream API now also passes the stream progress in the returned StreamPlaylistEntry object. This data is passed to the Typescript Progress class constructor allowing the html to call functions on the progress so that it can be rendered in the same manner as on the course page.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
1. Log in
2. Navigate to a recording
3. Blend in the playlist
4. Notice the the thumbnails show a progress bar

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
![Screenshot 2024-01-11 at 17-38-19 TUM-Live Einführung Brauereiwesen VL 2 Wie mache ich Bier](https://github.com/TUM-Dev/gocast/assets/61728152/55037e10-5f3d-4d95-a6dd-5777051f6882)


