### PR TITLE
Add "remember me" option for log in

### DIFF
--- a/api/users.go
+++ b/api/users.go
@@ -86,7 +86,7 @@ func (r usersRoutes) impersonateUser(c *gin.Context) {
 		})
 		return
 	}
-	tools.StartSession(c, &tools.SessionData{Userid: u.ID})
+	tools.StartSession(c, &tools.SessionData{Userid: u.ID}, false)
 }
 
 func (r usersRoutes) updateUser(c *gin.Context) {

--- a/tools/session.go
+++ b/tools/session.go
@@ -12,21 +12,26 @@ type SessionData struct {
 	SamlSubjectID *string
 }
 
-func StartSession(c *gin.Context, data *SessionData) {
-	token, err := createToken(data.Userid, data.SamlSubjectID)
+func StartSession(c *gin.Context, data *SessionData, rememberMe bool) {
+	maxAgeInDays := 7 // by default, log-in status expires in one week
+	if rememberMe {
+		maxAgeInDays = 30 * 6 // if user chooses "remember me", let log-in status be valid for 6 months
+	}
+
+	token, err := createToken(data.Userid, data.SamlSubjectID, maxAgeInDays)
 	if err != nil {
 		logger.Error("Could not create token", "err", err)
 		return
 	}
-	c.SetCookie("jwt", token, 60*60*24*7, "/", "", CookieSecure, true)
+	c.SetCookie("jwt", token, 60*60*24*maxAgeInDays, "/", "", CookieSecure, true)
 }
 
-func createToken(user uint, samlSubjectID *string) (string, error) {
+func createToken(user uint, samlSubjectID *string, maxAgeInDays int) (string, error) {
 	t := jwt.New(jwt.GetSigningMethod("RS256"))
 
 	t.Claims = &JWTClaims{
 		RegisteredClaims: &jwt.RegisteredClaims{
-			ExpiresAt: &jwt.NumericDate{Time: time.Now().Add(time.Hour * 24 * 7)}, // Token expires in one week
+			ExpiresAt: &jwt.NumericDate{Time: time.Now().Add(time.Hour * 24 * time.Duration(maxAgeInDays))}, // Token expires in one week
 		},
 		UserID:        user,
 		SamlSubjectID: samlSubjectID,

--- a/web/template/login.gohtml
+++ b/web/template/login.gohtml
@@ -24,6 +24,13 @@
     <style>[x-cloak] {
             display: none !important;
         }</style>
+
+    <script>
+        window.onload = function() {
+            document.cookie = 'rememberMe=; path=/; max-age=-1';
+        };
+    </script>
+
 </head>
 <body class="h-screen flex flex-col items-stretch tum-live-bg">
 <header class="text-3 flex z-50 w-full items-center px-3 py-2 h-16 justify-between shrink-0 grow-0">

--- a/web/template/login.gohtml
+++ b/web/template/login.gohtml
@@ -39,6 +39,20 @@
         <header>
             <h1 class="font-bold text-3">Login</h1>
         </header>
+
+        <div x-show="!resetPassword" class="flex">
+            <input type="checkbox" name="rememberMe" id="rememberMe">
+            <label for="rememberMe" class="text-5 text-sm px-2">Remember me for 6 months</label>
+            <script>
+                document.getElementById('rememberMe').addEventListener('change', function() {
+                    document.cookie = "rememberMe=" + this.checked + "; path=/; max-age=600";
+                    // The status whether "remember me" is checked is saved in a cookie, valid for 10 minutes
+                    // This cookie will be deleted once logged in
+                });
+            </script>
+        </div>
+
+
         {{if .UseSAML}}
             <article class="text-center w-full">
                 <a href="/saml/out"

--- a/web/user.go
+++ b/web/user.go
@@ -58,7 +58,15 @@ func (r mainRoutes) LoginHandler(c *gin.Context) {
 
 // HandleValidLogin starts a session and redirects the user to the page they were trying to access.
 func HandleValidLogin(c *gin.Context, data *tools.SessionData) {
-	tools.StartSession(c, data)
+	rememberMeCookie, err := c.Request.Cookie("rememberMe")
+	rememberMe := false
+	if err == nil && rememberMeCookie.Value == "true" {
+		rememberMe = true
+	}
+	// Delete cookie that was used for saving the status of "remember me"
+	c.SetCookie("rememberMe", "", -1, "/", "", tools.CookieSecure, true)
+
+	tools.StartSession(c, data, rememberMe)
 	redirURL, err := c.Cookie(redirCookieName)
 	if err != nil {
 		redirURL = "/" // Fallback in case no cookie is present: Redirect to index page


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Provide users with the option to make the login status valid for a longer period of time (6 months instead of 1 week).
Related: #1302

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
Passes on whether the user has selected the "remember me" option by setting a cookie, and if so, the jwt cookie set at login is set to be valid for 6 months instead of one week.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
1. Logout if necessary, and access the login page
2. Login via saml or internal login, without selecting the "remember me" option
3. Check the jwt cookie, it expires in 1 week; the decoded payload also shows an expire date in 1 week
4. Logout and login again, with "remember me" option checked
5. Check the jwt cookie, it expires in 6 months; the decoded payload also shows an expire date in 6 months

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
Change of UI on login page:
<img width=40% src="https://github.com/TUM-Dev/gocast/assets/78721605/4adf29e2-03a9-4e5a-96b4-25ac67a6c5e2"><img width=40% src="https://github.com/TUM-Dev/gocast/assets/78721605/b7f91e8b-f545-4750-a0ba-15f799fedc02">
