### PR TITLE
"Remember me" feature

### DIFF
--- a/api/users.go
+++ b/api/users.go
@@ -87,7 +87,7 @@ func (r usersRoutes) impersonateUser(c *gin.Context) {
 		})
 		return
 	}
-	tools.StartSession(c, &tools.SessionData{Userid: u.ID})
+	tools.StartSession(c, &tools.SessionData{Userid: u.ID}, false)
 }
 
 func (r usersRoutes) updateUser(c *gin.Context) {

--- a/tools/middlewares.go
+++ b/tools/middlewares.go
@@ -74,7 +74,7 @@ func InitContext(daoWrapper dao.DaoWrapper) gin.HandlerFunc {
 
 		// in case when the user has selected "remember me" when logging in, prolong the validity of the token
 		// but only when the token has not been updated during the last 1 hour
-		if claims.RememberMe && time.Now().Sub(claims.UpdatedAt.Time).Hours() > MinUpdateIntervalInHours {
+		if claims.RememberMe && time.Since(claims.UpdatedAt.Time).Hours() > MinUpdateIntervalInHours {
 			// remove jwt cookie older than MaxTokenAgeWithRefreshInDays
 			expiresAt := &jwt.NumericDate{time.Now().Add(time.Hour * 24 * MaxTokenAgeInDays)}
 			if expiresAt.Sub(claims.IssuedAt.Time).Hours() > MaxTokenLifetimeWithRememberMeInDays*24 {

--- a/tools/middlewares.go
+++ b/tools/middlewares.go
@@ -27,6 +27,7 @@ type JWTClaims struct {
 	*jwt.RegisteredClaims
 	UserID        uint
 	SamlSubjectID *string // identifier of the SAML session (if any)
+	RememberMe    bool
 }
 
 func InitContext(daoWrapper dao.DaoWrapper) gin.HandlerFunc {

--- a/tools/middlewares.go
+++ b/tools/middlewares.go
@@ -76,13 +76,13 @@ func InitContext(daoWrapper dao.DaoWrapper) gin.HandlerFunc {
 		// but only when the token has not been updated during the last 1 hour
 		if claims.RememberMe && time.Since(claims.UpdatedAt.Time).Hours() > MinUpdateIntervalInHours {
 			// remove jwt cookie older than MaxTokenAgeWithRefreshInDays
-			expiresAt := &jwt.NumericDate{time.Now().Add(time.Hour * 24 * MaxTokenAgeInDays)}
+			expiresAt := &jwt.NumericDate{Time: time.Now().Add(time.Hour * 24 * MaxTokenAgeInDays)}
 			if expiresAt.Sub(claims.IssuedAt.Time).Hours() > MaxTokenLifetimeWithRememberMeInDays*24 {
 				c.SetCookie("jwt", "", -1, "/", "", false, true)
 				return
 			}
 			claims.ExpiresAt = expiresAt
-			claims.UpdatedAt = &jwt.NumericDate{time.Now()}
+			claims.UpdatedAt = &jwt.NumericDate{Time: time.Now()}
 
 			token = jwt.NewWithClaims(token.Method, claims)
 			signedToken, err := token.SignedString(Cfg.GetJWTKey())

--- a/tools/session.go
+++ b/tools/session.go
@@ -30,8 +30,10 @@ func createToken(user uint, samlSubjectID *string, rememberMe bool) (string, err
 
 	t.Claims = &JWTClaims{
 		RegisteredClaims: &jwt.RegisteredClaims{
+			IssuedAt:  &jwt.NumericDate{Time: time.Now()},
 			ExpiresAt: &jwt.NumericDate{Time: time.Now().Add(time.Hour * 24 * MaxTokenAgeInDays)}, // Token expires in one week
 		},
+		UpdatedAt:     &jwt.NumericDate{Time: time.Now()},
 		UserID:        user,
 		SamlSubjectID: samlSubjectID,
 		RememberMe:    rememberMe,

--- a/tools/session.go
+++ b/tools/session.go
@@ -7,29 +7,34 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
+const (
+	MaxTokenAgeInDays = 7
+)
+
 type SessionData struct {
 	Userid        uint
 	SamlSubjectID *string
 }
 
-func StartSession(c *gin.Context, data *SessionData) {
-	token, err := createToken(data.Userid, data.SamlSubjectID)
+func StartSession(c *gin.Context, data *SessionData, rememberMe bool) {
+	token, err := createToken(data.Userid, data.SamlSubjectID, rememberMe)
 	if err != nil {
 		logger.Error("Could not create token", "err", err)
 		return
 	}
-	c.SetCookie("jwt", token, 60*60*24*7, "/", "", CookieSecure, true)
+	c.SetCookie("jwt", token, 60*60*24*MaxTokenAgeInDays, "/", "", CookieSecure, true)
 }
 
-func createToken(user uint, samlSubjectID *string) (string, error) {
+func createToken(user uint, samlSubjectID *string, rememberMe bool) (string, error) {
 	t := jwt.New(jwt.GetSigningMethod("RS256"))
 
 	t.Claims = &JWTClaims{
 		RegisteredClaims: &jwt.RegisteredClaims{
-			ExpiresAt: &jwt.NumericDate{Time: time.Now().Add(time.Hour * 24 * 7)}, // Token expires in one week
+			ExpiresAt: &jwt.NumericDate{Time: time.Now().Add(time.Hour * 24 * MaxTokenAgeInDays)}, // Token expires in one week
 		},
 		UserID:        user,
 		SamlSubjectID: samlSubjectID,
+		RememberMe:    rememberMe,
 	}
 	return t.SignedString(Cfg.GetJWTKey())
 }

--- a/web/template/login.gohtml
+++ b/web/template/login.gohtml
@@ -24,6 +24,13 @@
     <style>[x-cloak] {
             display: none !important;
         }</style>
+
+    <script>
+        window.onload = function() {
+            document.cookie = 'rememberMe=; path=/; max-age=-1';
+        };
+    </script>
+
 </head>
 <body class="h-screen flex flex-col items-stretch tum-live-bg">
 <header class="text-3 flex z-50 w-full items-center px-3 py-2 h-16 justify-between shrink-0 grow-0">
@@ -39,6 +46,19 @@
         <header>
             <h1 class="font-bold text-3">Login</h1>
         </header>
+
+        <div x-show="!resetPassword" class="flex">
+            <input type="checkbox" name="rememberMe" id="rememberMe">
+            <label for="rememberMe" class="text-5 text-sm px-2">Remember me for 6 months</label>
+            <script>
+                document.getElementById('rememberMe').addEventListener('change', function() {
+                    document.cookie = "rememberMe=" + this.checked + "; path=/; max-age=600";
+                    // The status whether "remember me" is checked is saved in a cookie, valid for 10 minutes
+                    // This cookie will be deleted once logged in
+                });
+            </script>
+        </div>
+
         {{if .UseSAML}}
             <article class="text-center w-full">
                 <a href="/saml/out"

--- a/web/user.go
+++ b/web/user.go
@@ -58,7 +58,15 @@ func (r mainRoutes) LoginHandler(c *gin.Context) {
 
 // HandleValidLogin starts a session and redirects the user to the page they were trying to access.
 func HandleValidLogin(c *gin.Context, data *tools.SessionData) {
-	tools.StartSession(c, data)
+	rememberMeCookie, err := c.Request.Cookie("rememberMe")
+	rememberMe := false
+	if err == nil && rememberMeCookie.Value == "true" {
+		rememberMe = true
+	}
+	// Delete cookie that was used for saving the status of "remember me"
+	c.SetCookie("rememberMe", "", -1, "/", "", tools.CookieSecure, true)
+
+	tools.StartSession(c, data, rememberMe)
 	redirURL, err := c.Cookie(redirCookieName)
 	if err != nil {
 		redirURL = "/" // Fallback in case no cookie is present: Redirect to index page


### PR DESCRIPTION
### Motivation and Context
Related issue: #1302 

### Description
1. Added a checkbox on the login page that allows users to select "Remember Me" before logging in
2. The state whether or not "Remember Me" is checked, is saved in a temporary cookie during the login process, and stored as a jwt claim after successfully logged in
3. In the middleware, check whether the jwt should be refreshed after validation, if so, extend the validity period in both jwt and the cookie's age
4. A `MaxTokenLifetimeWithRememberMeInDays` is set, to prevent the token from being valid forever
5. A `MinUpdateIntervalInHours` is set, so that (if "Remember Me" checked upon logging in) the token won't get refreshed too frequently

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
1. To be able to see the effect quickly, first change `MinUpdateIntervalInHours` in "\tools\middlewares.go" to a smaller value, e.g. 0.01, which corresponds to 36 seconds
2. Log in with "Remember Me" selected
3. Refresh the website within the period of `MinUpdateIntervalInHours`, see the cookie remain unchanged
4. Refresh the website after `MinUpdateIntervalInHours`, see both the value and the Max-Age of the cookie "jwt" is changed, and in the payload of jwt, the value of "exp" corresponds to the Max-Age of the cookie

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
Change of UI:
<img width=40% src="https://github.com/TUM-Dev/gocast/assets/78721605/4adf29e2-03a9-4e5a-96b4-25ac67a6c5e2">
<img width=40% src="https://github.com/TUM-Dev/gocast/assets/78721605/b7f91e8b-f545-4750-a0ba-15f799fedc02">

