### PR TITLE
Date is now clickable, if lecture doesn't have a name

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -491,8 +491,18 @@
 
                                                                         </a>
                                                                     </template>
+                                                                    <template x-if="vod.HasName()">
+
                                                                     <span class="date text-sm"
                                                                           x-text="vod.FriendlyDateStart()"></span>
+                                                                    </template>
+
+                                                                    <template x-if="!vod.HasName()">
+                                                                        <a :href="course.WatchURL(vod.ID)">
+                                                                        <span class="date text-sm"
+                                                                              x-text="vod.FriendlyDateStart()"></span>
+                                                                        </a>
+                                                                    </template>
                                                                 </div>
                                                                 <button type="button" @click="vod.Dropdown.toggle()"
                                                                         class="md:group-hover:opacity-100 md:opacity-0 px-2">

--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -492,14 +492,13 @@
                                                                         </a>
                                                                     </template>
                                                                     <template x-if="vod.HasName()">
-
                                                                     <span class="date text-sm"
                                                                           x-text="vod.FriendlyDateStart()"></span>
                                                                     </template>
 
                                                                     <template x-if="!vod.HasName()">
-                                                                        <a :href="course.WatchURL(vod.ID)">
-                                                                        <span class="date text-sm"
+                                                                        <a :class="isListView() ? 'title overflow-hidden' : ''" :href="course.WatchURL(vod.ID)">
+                                                                        <span class="date" :class="isListView() ? '' : 'text-sm'"   
                                                                               x-text="vod.FriendlyDateStart()"></span>
                                                                         </a>
                                                                     </template>


### PR DESCRIPTION
### Motivation and Context
Fixes #1314

### Description
If a lecture doesn't have a name, the date is now clickable so you can select them in list view as well.