### PR TITLE
1321 add real last lecture date to courses under my courses and rename last lecture to next lecture

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -268,7 +268,8 @@
                                         : 'No upcoming lecture.'"></span>
                                 <a x-cloak x-show="course.LastRecording.ID !== 0" :href="course.LastRecordingURL()">
                                     <i class="fa-solid fa-square-up-right"></i>
-                                    <span class="hover:underline">Most recent lecture</span>
+                                    <span class="hover:underline">Most recent lecture:</span>
+                                    <span x-text="`${course.LastRecording.FriendlyDateStart()}`"></span>
                                 </a>
                             </div>
                         </section>
@@ -297,12 +298,13 @@
                                x-text="course.Name">
                             </a>
                             <div class="links">
-                                <span x-text="course.LastRecording.ID !== 0
-                                        ? `Next lecture: ${course.LastRecording.FriendlyDateStart()}`
+                                <span x-text="course.NextLecture.ID !== 0
+                                        ? `Next lecture: ${course.NextLecture.FriendlyDateStart()}`
                                         : 'No upcoming lecture.'"></span>
                                 <a x-cloak x-show="course.LastRecording.ID !== 0" :href="course.LastRecordingURL()">
                                     <i class="fa-solid fa-square-up-right"></i>
-                                    <span class="hover:underline">Most recent lecture</span>
+                                    <span class="hover:underline">Most recent lecture:</span>
+                                    <span x-text="`${course.LastRecording.FriendlyDateStart()}`"></span>
                                 </a>
                             </div>
                         </section>
@@ -726,12 +728,13 @@
                                            x-text="course.Name">
                                         </a>
                                         <div class="links">
-                                            <span x-text="course.LastRecording.ID !== 0
-                                                    ? `Next lecture: ${course.LastRecording.FriendlyDateStart()}`
+                                            <span x-text="course.NextLecture.ID !== 0
+                                                    ? `Next lecture: ${course.NextLecture.FriendlyDateStart()}`
                                                     : 'No upcoming lecture.'"></span>
                                             <a x-cloak x-show="course.LastRecording.ID !== 0" :href="course.LastRecordingURL()">
                                                 <i class="fa-solid fa-square-up-right"></i>
-                                                <span class="hover:underline">Most recent lecture</span>
+                                                <span class="hover:underline">Most recent lecture:</span>
+                                                <span x-text="`${course.LastRecording.FriendlyDateStart()}`"></span>
                                             </a>
                                         </div>
                                     </section>

--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -268,8 +268,8 @@
                                         : 'No upcoming lecture.'"></span>
                                 <a x-cloak x-show="course.LastRecording.ID !== 0" :href="course.LastRecordingURL()">
                                     <i class="fa-solid fa-square-up-right"></i>
-                                    <span class="hover:underline">Most recent lecture:</span>
-                                    <span x-text="`${course.LastRecording.FriendlyDateStart()}`"></span>
+                                    <span class="hover:underline"
+                                          x-text="`Most recent lecture: ${course.LastRecording.FriendlyDateStart()}`"></span>
                                 </a>
                             </div>
                         </section>
@@ -303,8 +303,8 @@
                                         : 'No upcoming lecture.'"></span>
                                 <a x-cloak x-show="course.LastRecording.ID !== 0" :href="course.LastRecordingURL()">
                                     <i class="fa-solid fa-square-up-right"></i>
-                                    <span class="hover:underline">Most recent lecture:</span>
-                                    <span x-text="`${course.LastRecording.FriendlyDateStart()}`"></span>
+                                    <span class="hover:underline"
+                                          x-text="`Most recent lecture: ${course.LastRecording.FriendlyDateStart()}`"></span>
                                 </a>
                             </div>
                         </section>
@@ -733,8 +733,8 @@
                                                     : 'No upcoming lecture.'"></span>
                                             <a x-cloak x-show="course.LastRecording.ID !== 0" :href="course.LastRecordingURL()">
                                                 <i class="fa-solid fa-square-up-right"></i>
-                                                <span class="hover:underline">Most recent lecture:</span>
-                                                <span x-text="`${course.LastRecording.FriendlyDateStart()}`"></span>
+                                                <span class="hover:underline"
+                                                      x-text="`Most recent lecture: ${course.LastRecording.FriendlyDateStart()}`"></span>
                                             </a>
                                         </div>
                                     </section>


### PR DESCRIPTION
### Motivation and Context
The dates of "next lecture" of "my courses" displayed on the home page have been incorrectly set to the date of the last recording, as pointed out in #1321.

### Description
Corrected the dates; additionally, add dates of the last lecture, as suggested in #1321.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
**Before:**
![image](https://github.com/TUM-Dev/gocast/assets/78721605/fce64c7a-01f7-4e3e-a378-9f558bcdf70d)

---
**After:**
![image](https://github.com/TUM-Dev/gocast/assets/78721605/4b68365f-ee7d-451d-acf3-801defb2c67e)
