### PR TITLE
update if skip silence button is shown on seek

### DIFF
--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -275,6 +275,12 @@ export const skipSilence = function (options) {
                 }, intervalMillis);
             });
 
+            // Triggered when user seeks
+            players[j].on("seeked", () => {
+                toggleSkipSilence();
+            });
+
+            // Updates if skip silence button be shown
             const toggleSkipSilence = () => {
                 const ctime = players[j].currentTime();
                 let shouldShow = false;


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #1223.
When jumping backward or forwards in the video player the "Skip pause" button is not updated, meaning that pressing it after jumping forwards could take you back again. Or when jumping into a silent segment it is not possible to immediately jump to the end of it without first unpausing.

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
The function that checks whether this button should be displayed is called whenever the user seeks (jumps backwards or forwards)

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Stream

1. Log in
2. Navigate to a Stream with silences
3. Pause the Stream in a silent segment
4. Jump past it, notice the "Skip pause" button vanishes
5. Jump back into a silent segment, notice the button reappears

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
https://github.com/TUM-Dev/gocast/assets/61728152/9f4b5c14-fbf2-448f-b3c9-234f7bb0f966

