### PR TITLE
1032 option to make beta default mode

### DIFF
--- a/api/users.go
+++ b/api/users.go
@@ -726,7 +726,15 @@ func (r usersRoutes) updateSeekingTime(c *gin.Context) {
 }
 
 func (r usersRoutes) updateAutoSkip(c *gin.Context) {
-	u := getUserFromContext(c)
+	u := c.MustGet("TUMLiveContext").(tools.TUMLiveContext).User
+	if u == nil {
+		_ = c.Error(tools.RequestError{
+			Status:        http.StatusUnauthorized,
+			CustomMessage: "login required for updating user settings",
+		})
+		return
+	}
+
 	var req struct{ Value model.AutoSkipSetting }
 	if err := c.BindJSON(&req); err != nil {
 		_ = c.Error(tools.RequestError{

--- a/api/users.go
+++ b/api/users.go
@@ -726,14 +726,7 @@ func (r usersRoutes) updateSeekingTime(c *gin.Context) {
 }
 
 func (r usersRoutes) updateAutoSkip(c *gin.Context) {
-	u := c.MustGet("TUMLiveContext").(tools.TUMLiveContext).User
-	if u == nil {
-		_ = c.Error(tools.RequestError{
-			Status:        http.StatusUnauthorized,
-			CustomMessage: "login required",
-		})
-		return
-	}
+	u := getUserFromContext(c)
 	var req struct{ Value model.AutoSkipSetting }
 	if err := c.BindJSON(&req); err != nil {
 		_ = c.Error(tools.RequestError{
@@ -758,15 +751,7 @@ func (r usersRoutes) updateAutoSkip(c *gin.Context) {
 
 // updateDefaultMode updates whether the default stream mode for a user should be "beta"
 func (r usersRoutes) updateDefaultMode(c *gin.Context) {
-	u := c.MustGet("TUMLiveContext").(tools.TUMLiveContext).User
-	if u == nil {
-		_ = c.Error(tools.RequestError{
-			Status:        http.StatusUnauthorized,
-			CustomMessage: "login required",
-		})
-		return
-	}
-
+	u := getUserFromContext(c)
 	var req struct{ Value model.DefaultModeSetting }
 	if err := c.BindJSON(&req); err != nil {
 		_ = c.Error(tools.RequestError{

--- a/model/user.go
+++ b/model/user.go
@@ -59,6 +59,7 @@ const (
 	SeekingTime
 	UserDefinedSpeeds
 	AutoSkip
+	DefaultMode
 )
 
 type UserSetting struct {
@@ -216,6 +217,25 @@ func (u User) GetAutoSkipEnabled() (AutoSkipSetting, error) {
 		}
 	}
 	return AutoSkipSetting{Enabled: false}, nil
+}
+
+// DefaultModeSetting wraps whether the default stream mode for the user is beta
+type DefaultModeSetting struct {
+	Beta bool `json:"beta"`
+}
+
+func (u User) GetDefaultMode() (DefaultModeSetting, error) {
+	for _, setting := range u.Settings {
+		if setting.Type == DefaultMode {
+			var m DefaultModeSetting
+			err := json.Unmarshal([]byte(setting.Value), &m)
+			if err != nil {
+				return DefaultModeSetting{Beta: false}, err
+			}
+			return m, nil
+		}
+	}
+	return DefaultModeSetting{Beta: false}, nil
 }
 
 type argonParams struct {

--- a/web/template/user-settings.gohtml
+++ b/web/template/user-settings.gohtml
@@ -150,7 +150,20 @@
                         peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px]
                         after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5
                         after:transition-all dark:border-gray-600 peer-checked:bg-blue-600 dark:peer-checked:bg-indigo-600"></div>
-                    <span class="ml-3 text-sm font-medium text-3">Skip</span>
+                </label>
+            </span>
+        </section>
+        <section x-data="{ defaultMode: {{toJson .TUMLiveContext.User.GetDefaultMode}} }">
+            <h2>Always use beta stream when available</h2>
+            <span class="mr-2">
+                <label class="relative inline-flex items-center cursor-pointer">
+                    <input :checked="defaultMode.beta" type="checkbox" x-model="defaultMode.beta" class="sr-only peer"
+                           @change="global.updatePreference(global.UserSetting.DefaultMode, defaultMode)"/>
+                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-600
+                        dark:peer-focus:ring-indigo-600 rounded-full peer dark:bg-gray-600 peer-checked:after:translate-x-full
+                        peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px]
+                        after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5
+                        after:transition-all dark:border-gray-600 peer-checked:bg-blue-600 dark:peer-checked:bg-indigo-600"></div>
                 </label>
             </span>
         </section>

--- a/web/template/user-settings.gohtml
+++ b/web/template/user-settings.gohtml
@@ -154,7 +154,7 @@
             </span>
         </section>
         <section x-data="{ defaultMode: {{toJson .TUMLiveContext.User.GetDefaultMode}} }">
-            <h2>Always use beta stream when available</h2>
+            <h2>Always use beta Stream when Available</h2>
             <span class="mr-2">
                 <label class="relative inline-flex items-center cursor-pointer">
                     <input :checked="defaultMode.beta" type="checkbox" x-model="defaultMode.beta" class="sr-only peer"

--- a/web/ts/user-settings.ts
+++ b/web/ts/user-settings.ts
@@ -10,6 +10,7 @@ export enum UserSetting {
     SeekingTime = "seekingTime",
     CustomSpeeds = "customSpeeds",
     AutoSkip = "autoSkip",
+    DefaultMode = "defaultMode",
 }
 
 export function updatePreference(t: UserSetting, value: string | boolean | number[]): Promise<string> {

--- a/web/watch.go
+++ b/web/watch.go
@@ -110,11 +110,18 @@ func (r mainRoutes) WatchPage(c *gin.Context) {
 		c.Redirect(http.StatusFound, strings.Split(c.Request.RequestURI, "?")[0])
 		return
 	}
-	if _, dvr := c.GetQuery("dvr"); dvr {
+	// Check if user wants to use beta stream mode
+	mode, err := tumLiveContext.User.GetDefaultMode()
+	if err != nil {
+		logger.Error("Couldn't decode user setting", "err", err)
+	}
+
+	if _, dvr := c.GetQuery("dvr"); dvr || mode.Beta {
 		data.DVR = "?dvr"
 	} else {
 		data.DVR = ""
 	}
+
 	data.CutOffLength = api.CutOffLength
 	if strings.HasPrefix(data.Version, "unit-") {
 		data.Description = data.Unit.GetDescriptionHTML()


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #1032.
Many users prefer the beta stream mode, so it makes sense for there to be a user option that makes this the default.

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
Toggling the "Always use beta Stream when Available" option in the user settings will change the json value in the db for that user setting.
When the WatchPageData is being prepared this user setting is checked and if the default stream mode is set to beta, then the dvr value is set (in the same way it is if the URL contains the dvr query)

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Student

1. Log in
2. Navigate to Settings
3. Enable the "Always use beta Stream when Available" option, notice the value in the db has updated
4. Disable the option and the db will also have been updated

As for testing whether beta stream mode is actually used: that is something I cannot do locally.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
![image](https://github.com/TUM-Dev/gocast/assets/61728152/4b300a34-c9fb-4ae3-b39c-0a5d8cabd767)

