### PR TITLE
1266 private vods are still publicly listed

### DIFF
--- a/api/courses.go
+++ b/api/courses.go
@@ -153,8 +153,12 @@ func (r coursesRoutes) getLive(c *gin.Context) {
 				continue
 			}
 		}
-		// Only show hidden streams to admins
-		if courseForLiveStream.Visibility == "hidden" && (tumLiveContext.User == nil || tumLiveContext.User.Role != model.AdminType) {
+		// Only show hidden streams to course admins
+		if courseForLiveStream.Visibility == "hidden" && (tumLiveContext.User == nil || !tumLiveContext.User.IsAdminOfCourse(courseForLiveStream)) {
+			continue
+		}
+		// Only show private streams to course admins
+		if stream.Private && (tumLiveContext.User == nil || !tumLiveContext.User.IsAdminOfCourse(courseForLiveStream)) {
 			continue
 		}
 		var lectureHall *model.LectureHall

--- a/api/courses.go
+++ b/api/courses.go
@@ -359,7 +359,14 @@ func (r coursesRoutes) getCourseBySlug(c *gin.Context) {
 		c.AbortWithStatus(http.StatusUnauthorized)
 	}
 
-	streams := course.Streams
+	user := tumLiveContext.User
+	var streams []model.Stream
+	for _, stream := range course.Streams {
+		if !stream.Private || (user != nil && user.IsAdminOfCourse(course)) {
+			streams = append(streams, stream)
+		}
+	}
+
 	streamsDTO := make([]model.StreamDTO, len(streams))
 	for i, s := range streams {
 		err := tools.SetSignedPlaylists(&s, &model.User{

--- a/api/courses.go
+++ b/api/courses.go
@@ -140,6 +140,7 @@ func (r coursesRoutes) getLive(c *gin.Context) {
 
 	livestreams := make([]CourseStream, 0)
 
+	user := tumLiveContext.User
 	for _, stream := range streams {
 		courseForLiveStream, _ := r.GetCourseById(context.Background(), stream.CourseID)
 
@@ -179,7 +180,7 @@ func (r coursesRoutes) getLive(c *gin.Context) {
 		}
 
 		livestreams = append(livestreams, CourseStream{
-			Course:      courseForLiveStream.ToDTO(),
+			Course:      courseForLiveStream.ToDTO(user),
 			Stream:      stream.ToDTO(),
 			LectureHall: lectureHall.ToDTO(),
 			Viewers:     viewers,
@@ -217,9 +218,10 @@ func (r coursesRoutes) getPublic(c *gin.Context) {
 		courses = commons.Unique(public, func(c model.Course) uint { return c.ID })
 	}
 
+	user := tumLiveContext.User
 	resp := make([]model.CourseDTO, len(courses))
 	for i, course := range courses {
-		resp[i] = course.ToDTO()
+		resp[i] = course.ToDTO(user)
 	}
 
 	c.JSON(http.StatusOK, resp)
@@ -258,10 +260,12 @@ func (r coursesRoutes) getUsers(c *gin.Context) {
 
 	sortCourses(courses)
 	courses = commons.Unique(courses, func(c model.Course) uint { return c.ID })
+
+	user := tumLiveContext.User
 	resp := make([]model.CourseDTO, 0, len(courses))
 	for _, course := range courses {
 		if !course.IsHidden() {
-			resp = append(resp, course.ToDTO())
+			resp = append(resp, course.ToDTO(user))
 		}
 	}
 
@@ -279,10 +283,11 @@ func (r coursesRoutes) getPinned(c *gin.Context) {
 	}
 
 	pinnedCourses = commons.Unique(pinnedCourses, func(c model.Course) uint { return c.ID })
+	user := tumLiveContext.User
 	resp := make([]model.CourseDTO, 0, len(pinnedCourses))
 	for _, course := range pinnedCourses {
 		if !course.IsHidden() {
-			resp = append(resp, course.ToDTO())
+			resp = append(resp, course.ToDTO(user))
 		}
 	}
 
@@ -391,7 +396,7 @@ func (r coursesRoutes) getCourseBySlug(c *gin.Context) {
 		}
 	}
 
-	courseDTO := course.ToDTO()
+	courseDTO := course.ToDTO(tumLiveContext.User)
 	courseDTO.Streams = streamsDTO
 	courseDTO.IsAdmin = isAdmin
 

--- a/api/courses_test.go
+++ b/api/courses_test.go
@@ -136,12 +136,12 @@ func TestCoursesCRUD(t *testing.T) {
 				ExpectedCode: http.StatusOK,
 				ExpectedResponse: []CourseStream{
 					{
-						Course:  fpv.ToDTO(),
+						Course:  fpv.ToDTO(testutils.TUMLiveContextAdmin.User),
 						Stream:  testutils.SelfStream.ToDTO(),
 						Viewers: 0,
 					},
 					{
-						Course:      fpv.ToDTO(),
+						Course:      fpv.ToDTO(testutils.TUMLiveContextAdmin.User),
 						Stream:      testutils.StreamFPVLive.ToDTO(),
 						LectureHall: testutils.LectureHall.ToDTO(),
 						Viewers:     0,
@@ -220,8 +220,8 @@ func TestCoursesCRUD(t *testing.T) {
 				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextStudent)),
 				ExpectedCode: http.StatusOK,
 				ExpectedResponse: []model.CourseDTO{
-					testutils.CourseFPV.ToDTO(),
-					testutils.CourseGBS.ToDTO(),
+					testutils.CourseFPV.ToDTO(testutils.TUMLiveContextAdmin.User),
+					testutils.CourseGBS.ToDTO(testutils.TUMLiveContextAdmin.User),
 				},
 			},
 			"success not logged-in": {
@@ -242,8 +242,8 @@ func TestCoursesCRUD(t *testing.T) {
 				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextUserNil)),
 				ExpectedCode: http.StatusOK,
 				ExpectedResponse: []model.CourseDTO{
-					testutils.CourseFPV.ToDTO(),
-					testutils.CourseGBS.ToDTO(),
+					testutils.CourseFPV.ToDTO(testutils.TUMLiveContextAdmin.User),
+					testutils.CourseGBS.ToDTO(testutils.TUMLiveContextAdmin.User),
 				},
 			},
 		}.
@@ -286,7 +286,7 @@ func TestCoursesCRUD(t *testing.T) {
 				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextLecturer)),
 				ExpectedCode: http.StatusOK,
 				ExpectedResponse: []model.CourseDTO{
-					testutils.CourseGBS.ToDTO(),
+					testutils.CourseGBS.ToDTO(testutils.TUMLiveContextAdmin.User),
 				},
 			},
 			"success admin": {
@@ -307,8 +307,8 @@ func TestCoursesCRUD(t *testing.T) {
 				Middlewares:  testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextAdmin)),
 				ExpectedCode: http.StatusOK,
 				ExpectedResponse: []model.CourseDTO{
-					testutils.CourseFPV.ToDTO(),
-					testutils.CourseGBS.ToDTO(),
+					testutils.CourseFPV.ToDTO(testutils.TUMLiveContextAdmin.User),
+					testutils.CourseGBS.ToDTO(testutils.TUMLiveContextAdmin.User),
 				},
 			},
 		}.
@@ -331,7 +331,7 @@ func TestCoursesCRUD(t *testing.T) {
 				Router:           CourseRouterWrapper,
 				Middlewares:      testutils.GetMiddlewares(tools.ErrorHandler, testutils.TUMLiveContext(testutils.TUMLiveContextStudent)),
 				ExpectedCode:     http.StatusOK,
-				ExpectedResponse: []model.CourseDTO{testutils.CourseFPV.ToDTO()},
+				ExpectedResponse: []model.CourseDTO{testutils.CourseFPV.ToDTO(testutils.TUMLiveContextAdmin.User)},
 			},
 		}.
 			Method(http.MethodGet).
@@ -342,7 +342,7 @@ func TestCoursesCRUD(t *testing.T) {
 	t.Run("GET/api/courses/:slug/", func(t *testing.T) {
 		url := fmt.Sprintf("/api/courses/%s/", testutils.CourseTensNet.Slug)
 
-		response := testutils.CourseTensNet.ToDTO()
+		response := testutils.CourseTensNet.ToDTO(testutils.TUMLiveContextAdmin.User)
 		response.Streams = []model.StreamDTO{
 			testutils.StreamTensNetLive.ToDTO(),
 		}

--- a/api/stream.go
+++ b/api/stream.go
@@ -206,8 +206,6 @@ func (r streamRoutes) getSubtitles(c *gin.Context) {
 
 // livestreams returns all streams that are live
 func (r streamRoutes) liveStreams(c *gin.Context) {
-	tumLiveContext := c.MustGet("TUMLiveContext").(tools.TUMLiveContext)
-
 	var res []liveStreamDto
 	streams, err := r.StreamsDao.GetCurrentLive(c)
 	if err != nil {
@@ -219,16 +217,10 @@ func (r streamRoutes) liveStreams(c *gin.Context) {
 		})
 		return
 	}
-
-	user := tumLiveContext.User
 	for _, s := range streams {
 		course, err := r.CoursesDao.GetCourseById(c, s.CourseID)
 		if err != nil {
 			logger.Error("Error fetching course", "err", err)
-		}
-		// Don't include private stream for non course admins
-		if s.Private && (user == nil || !user.IsAdminOfCourse(course)) {
-			continue
 		}
 		lectureHall := "Selfstream"
 		if s.LectureHallID != 0 {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
To prevent streams marked as "private" from being list anywhere (home page, course page and playlist) for a non course admin user. #1266 should be fixed with this.
(Currently they are listed, but unauthorized visiting of the stream is then blocked by a 403 page)

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
Changes are done to backend APIs. Private streams of one course are filtered out in the responses, if the user is not admin of that course.

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
I tested using the example database setup, with:
- Users:
  - Stephanie Studi (role: student, not admin of any course)
  - Anja Admin (role: admin, automatically admin of all courses)
- Course "Einführung Brauereiwesen", visibility public, with the following lectures:
  - VL 1: Was ist Bier? (12:00pm 11.Apr.2022)
  - VL 2: Wie mache ich Bier? (12:00pm 18.Apr.2022)
  - VL 3: Rückblick (Sometime in the future)
(Note that VL 2 is more recent than VL 1)

**Pre-steps:**
1. Log in as Anja Admin
2. Edit course "Einführung Brauereiwesen", mark "VL 2: Wie mache ich Bier?" as private
3. Note that VL 2 is still listed everywhere

**Tests:**
1. Log in as Stephanie Studi (or impersonate them in admin panel)
2. Select the semester of course "Einführung Brauereiwesen" ("Summer 2022" under the example database setup)
3. Check the homepage:
    1. The "most recent lecture" of "Einführung Brauereiwesen", listed under "My Courses", is dated at 11. Apr. 2022 (VL 2 at 18. Apr. 2022 is ignored)
    2. Under "Recent VODs", VL 1 is listed (VL 2 is ignored)
4. Check the page for course "Einführung Brauereiwesen": VL 2 is not listed under "VODs"
5. Watch VL 1, check the playlist: VL 2 is not listed there

**Additional tests:**
Marking a stream without VoD (currently live, or planned in the future) as private is currently not supported, but can be done by direct edition in the database. If one does so, the private live stream / future lecture is as well then *not* listed
1. on the home page in the "live" list
2. on the home page as "next lecture" of the course
3. on the course page under "scheduled"

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
#### 1. Home page
**As admin:**
<img width="500" src="https://github.com/TUM-Dev/gocast/assets/78721605/241ee0f3-ec23-4141-9101-2938cf70684b">
**As student:**
<img width="500" src="https://github.com/TUM-Dev/gocast/assets/78721605/00b1c84b-3b1e-44ef-a3ee-aa474473cc6c">
#### 2. Course page
**As admin:**
<img width="500" src="https://github.com/TUM-Dev/gocast/assets/78721605/d53448f4-9596-4169-a5a9-961f139eb5bc">
**As student:**
<img width="500" src="https://github.com/TUM-Dev/gocast/assets/78721605/cd82ccd0-9cc4-456c-951e-2e49e13e2baa">
#### 3. Playlist
**As admin:**
<img width="500" src="https://github.com/TUM-Dev/gocast/assets/78721605/3fa128cd-5374-4449-9090-f34e60ff4363">
**As student:**
<img width="500" src="https://github.com/TUM-Dev/gocast/assets/78721605/3846bce7-b5b3-435b-bef0-572f4420cbfe">