### PR TITLE
1355 add link to wiki on lecture page

### DIFF
--- a/tools/config.go
+++ b/tools/config.go
@@ -88,6 +88,9 @@ func initConfig() {
 		}
 		jwtKey = key
 	}
+	if Cfg.WikiURL == "" {
+		logger.Warn("No Wiki URL found, link cannot be provided on webpage")
+	}
 	// allow overwriting database host with env var, mainly for testing with docker-compose
 	if os.Getenv("DBHOST") != "" {
 		Cfg.Db.Host = os.Getenv("DBHOST")
@@ -170,6 +173,7 @@ type Config struct {
 	} `yaml:"meili"`
 	VodURLTemplate string `yaml:"vodURLTemplate"`
 	CanonicalURL   string `yaml:"canonicalURL"`
+	WikiURL        string `yaml:"wikiURL"`
 }
 
 type MailConfig struct {

--- a/web/index.go
+++ b/web/index.go
@@ -95,6 +95,7 @@ type IndexData struct {
 	ServerNotifications []model.ServerNotification
 	CanonicalURL        tools.CanonicalURL
 	Branding            tools.Branding
+	WikiURL             string
 }
 
 func NewIndexData() IndexData {
@@ -102,6 +103,7 @@ func NewIndexData() IndexData {
 		VersionTag:   VersionTag,
 		CanonicalURL: tools.NewCanonicalURL(tools.Cfg.CanonicalURL),
 		Branding:     tools.BrandingCfg,
+		WikiURL:      tools.Cfg.WikiURL,
 	}
 }
 

--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -237,7 +237,7 @@
                 </button>
             </template>
         </article>
-        {{template "mobile_footer" .VersionTag}}
+        {{template "mobile_footer" .}}
     </section>
 
     <!-- views -->
@@ -809,7 +809,7 @@
         </template>
     </article>
 </main>
-{{template "footer" .VersionTag}}
+{{template "footer" .}}
 </body>
 </html>
 

--- a/web/template/login.gohtml
+++ b/web/template/login.gohtml
@@ -103,7 +103,7 @@
         </template>
     </section>
 </main>
-{{template "footer" .VersionTag}}
-{{template "mobile_footer" .VersionTag}}
+{{template "footer" .}}
+{{template "mobile_footer" .}}
 </body>
 </html>

--- a/web/template/partial/course/manage/create-lecture-form-slides/lecture-details-slide.gohtml
+++ b/web/template/partial/course/manage/create-lecture-form-slides/lecture-details-slide.gohtml
@@ -2,7 +2,12 @@
 
     {{- /*gotype: github.com/TUM-Dev/gocast/web.EditCourseData*/ -}}
     {{$course := .IndexData.TUMLiveContext.Course}}
-    <span class="text-sm text-5 pl-2">Options</span>
+    <div class="flex flex-row">
+        <span class="text-sm text-5 pl-2">Options</span>
+        {{if .IndexData.WikiURL}}
+        <help-icon text="Press here for more information in the wiki" @click="window.open('{{.IndexData.WikiURL}}', '_blank');"/>
+        {{end}}
+    </div>
     <div class="col-span-full flex gap-3 px-2 py-2">
         <label x-show="{{if $course.ChatEnabled}}true{{else}}false{{end}}">
             <input type="checkbox" x-model="formData.isChatEnabled"

--- a/web/template/partial/footer.gohtml
+++ b/web/template/partial/footer.gohtml
@@ -1,16 +1,21 @@
 {{define "footer"}}
-<footer id="desktop-footer"
+{{- /*gotype: github.com/TUM-Dev/gocast/web.IndexData*/ -}}
+    <footer id="desktop-footer"
         class="tum-live-footer justify-between space-x-3 items-center hidden md:flex">
     <div class="flex space-x-3">
         <a href="/about">About</a>
         <a href="/privacy">Data Privacy</a>
         <a href="/imprint">Imprint</a>
+        {{if .WikiURL}}
+            <a target="_blank" rel="noopener noreferrer" href="{{.WikiURL}}">Wiki</a>
+        {{end}}
     </div>
-    <a href="https://github.com/TUM-Dev/gocast" class="">gocast@{{.}} <i class="fa-brands fa-github"></i></a>
+    <a href="https://github.com/TUM-Dev/gocast" class="">gocast@{{.VersionTag}} <i class="fa-brands fa-github"></i></a>
 </footer>
 {{end}}
 
 {{define "mobile_footer"}}
+{{- /*gotype: github.com/TUM-Dev/gocast/web.IndexData*/ -}}
     <footer class="tum-live-footer w-full md:hidden">
         <div class="grid divide-y dark:divide-gray-800">
             <a href="/about">About</a>
@@ -18,7 +23,7 @@
             <a href="/imprint">Imprint</a>
         </div>
         <a href="https://github.com/TUM-Dev/gocast" class="block mt-1 text-center">
-            gocast@{{.}} <i class="fa-brands fa-github"></i>
+            gocast@{{.VersionTag}} <i class="fa-brands fa-github"></i>
         </a>
     </footer>
 {{end}}


### PR DESCRIPTION
### Motivation and Context
Added URL to directly get to the wiki from multiple pages (if available in config).
Closes #1355.

### Description
This PR adds a info icon to the create lecture options where you can get directly to the wiki page and every page footer also contains a URL directly to the wiki page.
To see this you have to add a wikiURL into your config where the location is defined.

### Screenshots
Info Icon on the options page:
![image](https://github.com/user-attachments/assets/3d6f3503-ec63-4e11-a966-7b71851e5095)

Wiki URL on the footer:
![image](https://github.com/user-attachments/assets/ab03dfb4-a6c8-411a-bc5c-866301a07786)
