### PR TITLE
fixed recent vods/streams course links not working

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -666,7 +666,7 @@
                                         <div class="px-2">
                                             <a class="course text-sm"
                                                :href="livestream.Course.URL()"
-                                               @click.prevent="showCourse(livestream.Course.Slug)"
+                                               @click.prevent="showCourse(livestream.Course.Slug, livestream.Course.Year, livestream.Course.TeachingTerm)"
                                                x-text="livestream.Course.Name">
                                             </a>
                                             <template x-if="livestream.Stream.HasName()">
@@ -786,7 +786,7 @@
                                         </a>
                                         <div class="px-1">
                                             <a class="course text-xs"
-                                               x-text="course.Name" @click.prevent="showCourse(course.Slug)"
+                                               x-text="course.Name" @click.prevent="showCourse(course.Slug, course.Year, course.TeachingTerm)"
                                                :href="course.URL()"
                                                :class="course.LastRecording.HasName() ? 'text-xs' : 'text-sm'"></a>
                                             <template x-if="course.LastRecording.HasName()">


### PR DESCRIPTION
### Motivation and Context
Currently, when the start page is in a new semester and streams or vods of the last semester show up as recent stream/vod, the attached course link does not work and just redirects to the start page again.

### Description
It passes the year and the semester to the existing function that handles changing to the course page so that it knows, which semester the course is in. Currently, the function just gets the course slug and assumes that the course is in the current semester.

### Steps for Testing
Prerequisites:
- 1 User
- 1 vod/stream of a course that is in a more recent semester than any other course.
- 1 vod/stream of a course that is in an older semester 

1. Navigate to the homepage.
2. See both vods/streams show up in "Recent Vods/Streams"
3. Click on the links referring to the respective courses
4. Admire the respective course pages, regardless of the semester of the course
