### PR TITLE
1291 split view progress bar in wrong position after entering fullscreen mode if the width ratio of two views adjusted

### DIFF
--- a/web/ts/splitview.ts
+++ b/web/ts/splitview.ts
@@ -1,6 +1,8 @@
 import { getPlayers } from "./TUMLiveVjs";
 import Split from "split.js";
 import { cloneEvents } from "./global";
+import videojs, {VideoJsPlayer} from "video.js";
+import PlayerOptions = videojs.PlayerOptions;
 
 const mouseMovingTimeout = 2200;
 
@@ -152,12 +154,21 @@ export class SplitView {
         fullscreenToggle.off("click");
 
         fullscreenToggle.on("click", async () => {
-            if (document.fullscreenElement === null) {
-                await this.splitParent.requestFullscreen();
-            } else {
-                await document.exitFullscreen();
-            }
+            await this.toggleFullscreen();
         });
+
+        (this.players[0] as VideoJsPlayer).options_.userActions.doubleClick = async () => await this.toggleFullscreen();
+        (this.players[1] as VideoJsPlayer).options_.userActions.doubleClick = async () => await this.toggleFullscreen();
+
+        this.splitParent.addEventListener("fullscreenchange", () => this.update(25))
+    }
+
+    private async toggleFullscreen() {
+        if (document.fullscreenElement === null) {
+            await this.splitParent.requestFullscreen();
+        } else {
+            await document.exitFullscreen();
+        }
     }
 
     private setTrackBarModes(k: number, mode: string) {

--- a/web/ts/splitview.ts
+++ b/web/ts/splitview.ts
@@ -39,16 +39,16 @@ export class SplitView {
         this.videoWrapperResizeObs.observe(this.videoWrapper);
         this.detectMouseNotMoving();
 
-        this.players[0].ready(() => {
+        this.players[1].ready(() => {
             this.setTrackBarModes(0, "disabled");
         });
 
-        this.players[1].ready(() => {
+        this.players[0].ready(() => {
             this.setupControlBars();
             this.overwriteFullscreenToggle();
         });
 
-        cloneEvents(this.players[0].el(), this.players[1].el(), ["mousemove", "mouseenter", "mouseleave"]);
+        cloneEvents(this.players[1].el(), this.players[0].el(), ["mousemove", "mouseenter", "mouseleave"]);
 
         // Setup splitview
         // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -109,15 +109,15 @@ export class SplitView {
     }
 
     private setupControlBars() {
-        this.players[0].controlBar.hide();
-        this.players[0].muted(true);
+        this.players[1].controlBar.hide();
+        this.players[1].muted(true);
 
-        this.players[1].el().addEventListener("fullscreenchange", () => {
+        this.players[0].el().addEventListener("fullscreenchange", () => {
             this.isFullscreen = document.fullscreenElement !== null;
             this.updateControlBarSize(this.getSizes());
         });
 
-        const mainControlBarElem = this.players[1].controlBar.el();
+        const mainControlBarElem = this.players[0].controlBar.el();
         mainControlBarElem.style.position = "absolute";
         mainControlBarElem.style.zIndex = "1";
 
@@ -128,29 +128,24 @@ export class SplitView {
         const wrapperSize = this.videoWrapper.getBoundingClientRect().width;
 
         let marginLeft;
-        if (this.isFullscreen) {
-            marginLeft = "0";
-        } else if (sizes[0] === 100) {
-            marginLeft = `${this.gutterWidth / 2 - wrapperSize}px`; //`calc(${this.gutterWidth / 2}px - 100vw)`;
-        } else if (sizes[0] === 0) {
-            marginLeft = `-${this.gutterWidth / 2}px`;
+        if (sizes[0] === 0) {
+            marginLeft = `${this.gutterWidth / 2}px`;
         } else {
-            const leftContainerWidth = (sizes[0] * wrapperSize) / 100;
-            marginLeft = `-${leftContainerWidth}px`;
+            marginLeft = `0px`;
         }
-
-        const mainControlBarElem = this.players[1].controlBar.el();
-        mainControlBarElem.style.marginLeft = marginLeft;
+        const mainControlBarElem = this.players[0].controlBar.el();
         mainControlBarElem.style.width = `${wrapperSize}px`;
+        mainControlBarElem.style.marginLeft = marginLeft;
 
-        const textTrackDisplay = this.players[1].el_.querySelector(".vjs-text-track-display");
+        const textTrackDisplay = this.players[0].el_.querySelector(".vjs-text-track-display");
         if (textTrackDisplay) {
-            textTrackDisplay.style.left = marginLeft;
+            textTrackDisplay.style.width = `${wrapperSize}px`;
+            textTrackDisplay.style.zIndex = "1";
         }
     }
 
     private overwriteFullscreenToggle() {
-        const fullscreenToggle = this.players[1].controlBar.fullscreenToggle;
+        const fullscreenToggle = this.players[0].controlBar.fullscreenToggle;
         fullscreenToggle.off("click");
 
         fullscreenToggle.on("click", async () => {
@@ -159,8 +154,6 @@ export class SplitView {
 
         (this.players[0] as VideoJsPlayer).options_.userActions.doubleClick = async () => await this.toggleFullscreen();
         (this.players[1] as VideoJsPlayer).options_.userActions.doubleClick = async () => await this.toggleFullscreen();
-
-        this.splitParent.addEventListener("fullscreenchange", () => this.update(25))
     }
 
     private async toggleFullscreen() {

--- a/web/ts/splitview.ts
+++ b/web/ts/splitview.ts
@@ -1,7 +1,7 @@
 import { getPlayers } from "./TUMLiveVjs";
 import Split from "split.js";
 import { cloneEvents } from "./global";
-import videojs, {VideoJsPlayer} from "video.js";
+import videojs, { VideoJsPlayer } from "video.js";
 import PlayerOptions = videojs.PlayerOptions;
 
 const mouseMovingTimeout = 2200;


### PR DESCRIPTION
### Motivation and Context
See Issue #1291.

### Description
Adjusting size of players in splitview when in fullscreen mode (or vice versa) doesn't result in the control bar being in the wrong position anymore. This applies to subtitles as well.
Currently, the control bar of the right video player is used as the control bar for both video players, the one on the left is hidden. This results in said weird issues as the control bar has to have (potentially high) negative left margins. As I couldn't figure out what exactly is the issue with updating the left margin, this is fixed by switching roles of the two control bars (left is "global" control bar, right is hidden). This may have side effects! Only side effect known to me is that the subtitle settings menu is now an overlay of the left video player (instead of the right player).

### Steps for Testing
Prerequisites:
- 1 Livestream / VOD (preferably with subtitles)

1. Navigate to a Livestream
2. Play around by adjusting sizes and toggling fullscreen mode. 
3. See no errors.