### PR TITLE
Fix incorrect target for user notifications

### DIFF
--- a/model/notification.go
+++ b/model/notification.go
@@ -23,10 +23,9 @@ const (
 // Notification is a message (e.g. a feature alert) that is displayed to users
 type Notification struct {
 	Model
-
 	Title  *string            `json:"title,omitempty"`
 	Body   string             `json:"-" gorm:"not null"`
-	Target NotificationTarget `json:"-" gorm:"not null; default:1"`
+	Target NotificationTarget `json:"target" gorm:"not null; default:1"`
 
 	// SanitizedBody is the body of the notification, converted from markdown to HTML
 	SanitizedBody string `json:"body" gorm:"-"`

--- a/web/ts/notification-management.ts
+++ b/web/ts/notification-management.ts
@@ -7,7 +7,11 @@ export function createNotification(body: string, target: number, title: string |
         headers: {
             "Content-Type": "application/json",
         },
-        body: JSON.stringify(notification),
+        body: JSON.stringify({
+            title: notification.title,
+            body: notification.body,
+            target: Number(notification.target),
+        }),
     })
         .then((r) => r.json())
         .then((r) => {


### PR DESCRIPTION
### Motivation and Context
See issue #1298.

### Description
Included `target` field to notification model's JSON. 

### Steps for Testing
Prerequisites:
- 1 admin, 1 student
- Optionally also 1 lecturer or loggedIn user

1. Log in as an admin
2. Open the notifications panel (http://localhost:8081/admin/notifications) and create a few new notifications with a specific target
3. Log out and log in again using a different user to see the correct notifications (e.g., now a student-user should only see notifications with targets: `Students` and `All Users`)

### ~~Screenshots~~

