### PR TITLE
fixed playback speeds when user is nil

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -99,9 +99,6 @@ func (s PlaybackSpeedSettings) GetEnabled() (res []float32) {
 }
 
 func (u *User) GetEnabledPlaybackSpeeds() (res []float32) {
-	if u == nil {
-		return []float32{1}
-	}
 	// Possibly, this could be collapsed into a single line, but readibility suffers.
 	res = append(res, u.GetPlaybackSpeeds().GetEnabled()...)
 	res = append(res, u.GetCustomSpeeds()...)


### PR DESCRIPTION
### Motivation and Context
See #1395.

### Description
Removed unnecessary check. Methods called in `GetEnabledPlaybackSpeeds()` can handle user defaulting to nil.

### Steps for Testing

1. Watch any public vod/stream when NOT logged in and change the playback speed.
