### PR TITLE
Fixed bad readability issue of ```Include Timestamp```

### DIFF
--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -66,6 +66,11 @@
         @apply text-gray-700 dark:text-gray-300;
     }
 
+    /*low contrast text*/
+    .important-text-4 {
+        @apply text-gray-700 dark:text-gray-300 !important;
+    }
+
     /*full contrast text*/
     .text-5 {
         @apply text-gray-600 dark:text-gray-400;

--- a/web/template/watch.gohtml
+++ b/web/template/watch.gohtml
@@ -63,7 +63,7 @@
                          class="flex justify-start items-center pt-2">
                         <input id="include-timestamp" type="checkbox" class="h-8 hover:cursor-pointer"
                                x-model="share.includeTimestamp" @change="share.setURL(false)">
-                        <label for="include-timestamp" class="font-light text-4 text-xs ml-2">Include Timestamp</label>
+                        <label for="include-timestamp" class="font-light text-xs ml-2 important-text-4">Include Timestamp</label>
                         <input x-cloak x-show="share.includeTimestamp" class="tl-input h-8 w-20 text-xs ml-2"
                                type="text" x-model="share.timestamp" @input="share.setURL(false);">
                     </div>


### PR DESCRIPTION
### Motivation and Context
This PR fixes Issue #1167 

### Description
There is now a new class called important-text-4 which adds the !important flag to the text color.
Can be used to override text colors of other selectors, use with caution!.

### Steps for Testing
1. Navigate to any VoD
2. Press the ```Share``` Button
3. Select ```Include Timestamp```
