### PR TITLE
Show Invitations on Course admin page actually shows invitations

### DIFF
--- a/web/template/partial/course/manage/external-participants.gohtml
+++ b/web/template/partial/course/manage/external-participants.gohtml
@@ -26,7 +26,7 @@
             </p>
         </li>
         <li class="p-4" x-show="expanded">
-            <table class="hidden w-full" id="usersTable">
+            <table class="w-full" id="usersTable">
                 <thead>
                 <tr class="font-semibold">
                     <td>Name</td>


### PR DESCRIPTION
### Motivation and Context
#1010 

### Description
Removed unnecessary hidden attribute. 

### Steps for Testing
Prerequisites:
- 1 Admin

1. Log in
2. Navigate to any course admin page
3. Invite external participant
4. See them show up when clicking on "show invitations"
