### PR TITLE
1172 lecture week view

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -440,6 +440,11 @@
                                             :class="{'active' : isListView() }">
                                         List View
                                     </button>
+                                    <button type="button" @click="toggleWeekView()"
+                                            class="tum-live-button tum-live-button-tertiary"
+                                            :class="{'active' : isWeekView() }">
+                                        Week View
+                                    </button>
                                 </section>
                             </header>
                             <section>
@@ -448,8 +453,8 @@
                                         <template
                                                 x-for="group in courseStreams.get(sortFn(streamSortMode), filterPred(streamFilterMode))">
                                             <article class="mb-8">
-                                                <header class="mb-2">
-                                                    <h6 class="font-semibold" x-text="group[0].GetMonthName()"></h6>
+                                                <header class="mb-2"x-data="{name : getGroupName(group[0])}">
+                                                    <h6 class="font-semibold" x-text="name"></h6>
                                                 </header>
                                                 <section class="grid gap-3  grid-cols-1"
                                                          :class="isListView() ? 'xl:grid-cols-1 lg:grid-cols-1 md:grid-cols-1 grid-cols-1' : plannedStreams.hasElements()

--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -417,7 +417,7 @@
                                  :class="plannedStreams.hasElements() ? 'col-span-2' : 'col-span-full'">
                             <header>
                                 <h3 class="font-bold">VODs</h3>
-                                <section class="button-area items-center space-y-1">
+                                <section class="button-area space-y-1">
                                     <button type="button" @click="sortNewestFirst()"
                                             class="tum-live-button tum-live-button-tertiary"
                                             :class="{'active' : isNewestFirst() }">

--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -417,7 +417,7 @@
                                  :class="plannedStreams.hasElements() ? 'col-span-2' : 'col-span-full'">
                             <header>
                                 <h3 class="font-bold">VODs</h3>
-                                <section class="space-x-2">
+                                <section class="button-area items-center space-y-1">
                                     <button type="button" @click="sortNewestFirst()"
                                             class="tum-live-button tum-live-button-tertiary"
                                             :class="{'active' : isNewestFirst() }">

--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -453,8 +453,8 @@
                                         <template
                                                 x-for="group in courseStreams.get(sortFn(streamSortMode), filterPred(streamFilterMode))">
                                             <article class="mb-8">
-                                                <header class="mb-2"x-data="{name : getGroupName(group[0])}">
-                                                    <h6 class="font-semibold" x-text="name"></h6>
+                                                <header class="mb-2">
+                                                    <h6 class="font-semibold" x-text="groupNames.get(group[0].ID);"></h6>
                                                 </header>
                                                 <section class="grid gap-3  grid-cols-1"
                                                          :class="isListView() ? 'xl:grid-cols-1 lg:grid-cols-1 md:grid-cols-1 grid-cols-1' : plannedStreams.hasElements()

--- a/web/ts/api/courses.ts
+++ b/web/ts/api/courses.ts
@@ -1,8 +1,8 @@
-import {get} from "../utilities/fetch-wrappers";
-import {Progress} from "./progress";
-import {ToggleableElement} from "../utilities/ToggleableElement";
-import {same_day} from "../utilities/time-utils";
-import {CustomURL} from "../utilities/url";
+import { get } from "../utilities/fetch-wrappers";
+import { Progress } from "./progress";
+import { ToggleableElement } from "../utilities/ToggleableElement";
+import { same_day } from "../utilities/time-utils";
+import { CustomURL } from "../utilities/url";
 
 type DownloadableVOD = {
     readonly FriendlyName: string;
@@ -120,8 +120,8 @@ export class Stream implements Identifiable {
         ][this.StartDate().getMonth()];
     }
 
-    public GetWeekNumber(dateOfFirstWeek : Date) : number {
-        return Math.floor(((this.StartDate().getTime() - dateOfFirstWeek.getTime())) / MS_IN_DAY / 7) + 1;
+    public GetWeekNumber(dateOfFirstWeek: Date): number {
+        return Math.floor((this.StartDate().getTime() - dateOfFirstWeek.getTime()) / MS_IN_DAY / 7) + 1;
     }
 
     private static TimeOf(d: string): string {

--- a/web/ts/api/courses.ts
+++ b/web/ts/api/courses.ts
@@ -125,14 +125,6 @@ export class Stream implements Identifiable {
         return Math.floor(((this.StartDate().getTime() - dateOfFirstWeek.getTime())) / MS_IN_DAY / 7) + 1;
     }
 
-    public GetGroupName(mode : GroupMode, dateOfFirstWeek : Date) : string {
-        if (mode === GroupMode.Month) {
-            return this.GetMonthName();
-        } else if (mode === GroupMode.Week) {
-            return "Week " + this.GetWeekNumber(dateOfFirstWeek).toString();
-        }
-    }
-
     private static TimeOf(d: string): string {
         return new Date(d).toLocaleTimeString("default", { hour: "2-digit", minute: "2-digit" });
     }

--- a/web/ts/api/courses.ts
+++ b/web/ts/api/courses.ts
@@ -1,13 +1,16 @@
-import { get } from "../utilities/fetch-wrappers";
-import { Progress } from "./progress";
-import { ToggleableElement } from "../utilities/ToggleableElement";
-import { same_day } from "../utilities/time-utils";
-import { CustomURL } from "../utilities/url";
+import {get} from "../utilities/fetch-wrappers";
+import {Progress} from "./progress";
+import {ToggleableElement} from "../utilities/ToggleableElement";
+import {same_day} from "../utilities/time-utils";
+import {CustomURL} from "../utilities/url";
+import {GroupMode} from "../components/course";
 
 type DownloadableVOD = {
     readonly FriendlyName: string;
     readonly DownloadURL: string;
 };
+
+const MS_IN_DAY = 1000 * 60 * 60 * 24;
 
 export class Stream implements Identifiable {
     readonly ID: number;
@@ -116,6 +119,18 @@ export class Stream implements Identifiable {
             "November",
             "December",
         ][this.StartDate().getMonth()];
+    }
+
+    public GetWeekNumber(dateOfFirstWeek : Date) : number {
+        return Math.floor(((this.StartDate().getTime() - dateOfFirstWeek.getTime())) / MS_IN_DAY / 7) + 1;
+    }
+
+    public GetGroupName(mode : GroupMode, dateOfFirstWeek : Date) : string {
+        if (mode === GroupMode.Month) {
+            return this.GetMonthName();
+        } else if (mode === GroupMode.Week) {
+            return "Week " + this.GetWeekNumber(dateOfFirstWeek).toString();
+        }
     }
 
     private static TimeOf(d: string): string {

--- a/web/ts/api/courses.ts
+++ b/web/ts/api/courses.ts
@@ -3,7 +3,6 @@ import {Progress} from "./progress";
 import {ToggleableElement} from "../utilities/ToggleableElement";
 import {same_day} from "../utilities/time-utils";
 import {CustomURL} from "../utilities/url";
-import {GroupMode} from "../components/course";
 
 type DownloadableVOD = {
     readonly FriendlyName: string;

--- a/web/ts/components/course.ts
+++ b/web/ts/components/course.ts
@@ -50,6 +50,7 @@ export function courseContext(slug: string, year: number, term: string, userId: 
 
         dateOfFirstWeek: new Date(),
         weekCountWithoutEmptyWeeks: new Map<number, number>(),
+        groupNames: new Map<number, string>(),
 
 
         /**
@@ -158,6 +159,16 @@ export function courseContext(slug: string, year: number, term: string, userId: 
                 this.courseStreams.set(this.course.Recordings, (s: Stream) => s.StartDate().getMonth());
             } else {
                 this.courseStreams.set(this.course.Recordings, (s: Stream) => this.getTrueWeek(s.GetWeekNumber(this.dateOfFirstWeek)));
+            }
+
+            // update group names
+            let groups = this.courseStreams.get(this.sortFn(this.streamSortMode), this.filterPred(this.streamFilterMode));
+            this.groupNames.clear();
+            for (let i = 0; i < groups.length; i++) {
+                let s1 = groups[i][0];
+                this.groupNames.set(s1.ID, this.getGroupName(s1));
+                let s2 = groups[i][groups[i].length - 1];
+                this.groupNames.set(s2.ID, this.getGroupName(s2));
             }
         },
 

--- a/web/ts/components/course.ts
+++ b/web/ts/components/course.ts
@@ -52,7 +52,6 @@ export function courseContext(slug: string, year: number, term: string, userId: 
         weekCountWithoutEmptyWeeks: new Map<number, number>(),
         groupNames: new Map<number, string>(),
 
-
         /**
          * AlpineJS init function which is called automatically in addition to 'x-init'
          */
@@ -80,10 +79,10 @@ export function courseContext(slug: string, year: number, term: string, userId: 
                     this.plannedStreams.set(this.course.Planned.reverse()).reset();
                     this.upcomingStreams.set(this.course.Upcoming).reset();
                     this.loadProgresses(this.course.Recordings.map((s: Stream) => s.ID)).then((progresses) => {
-                        this.course.Recordings.forEach((s: Stream, i) => (s.Progress = progresses[i]));
-                    })
-                    .then(() => this.initializeWeekMap())
-                    .then(() => this.applyGroupView());
+                            this.course.Recordings.forEach((s: Stream, i) => (s.Progress = progresses[i]));
+                        })
+                        .then(() => this.initializeWeekMap())
+                        .then(() => this.applyGroupView());
                     console.log("🌑 init course", this.course);
                 });
         },
@@ -158,16 +157,21 @@ export function courseContext(slug: string, year: number, term: string, userId: 
             if (this.groupMode === GroupMode.Month) {
                 this.courseStreams.set(this.course.Recordings, (s: Stream) => s.StartDate().getMonth());
             } else {
-                this.courseStreams.set(this.course.Recordings, (s: Stream) => this.getTrueWeek(s.GetWeekNumber(this.dateOfFirstWeek)));
+                this.courseStreams.set(this.course.Recordings, (s: Stream) =>
+                    this.getTrueWeek(s.GetWeekNumber(this.dateOfFirstWeek))
+                );
             }
 
             // update group names
-            let groups = this.courseStreams.get(this.sortFn(this.streamSortMode), this.filterPred(this.streamFilterMode));
+            const groups = this.courseStreams.get(
+                this.sortFn(this.streamSortMode),
+                this.filterPred(this.streamFilterMode)
+            );
             this.groupNames.clear();
             for (let i = 0; i < groups.length; i++) {
-                let s1 = groups[i][0];
+                const s1 = groups[i][0];
                 this.groupNames.set(s1.ID, this.getGroupName(s1));
-                let s2 = groups[i][groups[i].length - 1];
+                const s2 = groups[i][groups[i].length - 1];
                 this.groupNames.set(s2.ID, this.getGroupName(s2));
             }
         },
@@ -177,10 +181,12 @@ export function courseContext(slug: string, year: number, term: string, userId: 
          */
         initializeWeekMap() {
             let latestWeek = 1;
-            this.course.Recordings.sort(this.sortFn(StreamSortMode.OldestFirst)).forEach((s : Stream, i : number) => {
+            this.course.Recordings.sort(this.sortFn(StreamSortMode.OldestFirst)).forEach((s: Stream, i: number) => {
                 if (i === 0) {
                     this.dateOfFirstWeek = s.StartDate();
-                    this.dateOfFirstWeek = new Date(this.dateOfFirstWeek.getTime() - this.dateOfFirstWeek.getDay() * 1000 * 60 * 60 * 24);
+                    this.dateOfFirstWeek = new Date(
+                        this.dateOfFirstWeek.getTime() - this.dateOfFirstWeek.getDay() * 1000 * 60 * 60 * 24
+                    );
                     this.dateOfFirstWeek.setHours(0, 1); // avoids errors e.g. in case week1 has vod on Monday at 10am, week2 at 8am
                 }
                 const week = s.GetWeekNumber(this.dateOfFirstWeek);
@@ -190,11 +196,11 @@ export function courseContext(slug: string, year: number, term: string, userId: 
             });
         },
 
-        getTrueWeek(n : number): number {
+        getTrueWeek(n: number): number {
             return this.weekCountWithoutEmptyWeeks.get(n);
         },
 
-        getGroupName(s : Stream) : string {
+        getGroupName(s: Stream) : string {
             if (this.groupMode === GroupMode.Month) {
                 return s.GetMonthName();
             } else {

--- a/web/ts/components/course.ts
+++ b/web/ts/components/course.ts
@@ -24,6 +24,11 @@ export enum ViewMode {
     List,
 }
 
+export enum GroupMode {
+    Month,
+    Week,
+}
+
 export function courseContext(slug: string, year: number, term: string, userId: number): AlpineComponent {
     return {
         userId: userId as number,
@@ -41,6 +46,11 @@ export function courseContext(slug: string, year: number, term: string, userId: 
         streamSortMode: +getFromStorage("streamSortMode") ?? StreamSortMode.NewestFirst,
         streamFilterMode: +getFromStorage("streamFilterMode") ?? StreamFilterMode.ShowWatched,
         viewMode: (+getFromStorage("viewMode") ?? ViewMode.Grid) as number,
+        groupMode: (+getFromStorage("groupMode") ?? GroupMode.Month) as number,
+
+        dateOfFirstWeek: new Date(),
+        weekCountWithoutEmptyWeeks: new Map<number, number>(),
+
 
         /**
          * AlpineJS init function which is called automatically in addition to 'x-init'
@@ -70,8 +80,9 @@ export function courseContext(slug: string, year: number, term: string, userId: 
                     this.upcomingStreams.set(this.course.Upcoming).reset();
                     this.loadProgresses(this.course.Recordings.map((s: Stream) => s.ID)).then((progresses) => {
                         this.course.Recordings.forEach((s: Stream, i) => (s.Progress = progresses[i]));
-                        this.courseStreams.set(this.course.Recordings, (s: Stream) => s.StartDate().getMonth());
-                    });
+                    })
+                    .then(() => this.initializeWeekMap())
+                    .then(() => this.applyGroupView());
                     console.log("🌑 init course", this.course);
                 });
         },
@@ -130,6 +141,54 @@ export function courseContext(slug: string, year: number, term: string, userId: 
 
         isListView() {
             return this.viewMode == ViewMode.List;
+        },
+
+        toggleWeekView() {
+            this.groupMode = this.groupMode === GroupMode.Month ? GroupMode.Week : GroupMode.Month;
+            setInStorage("groupMode", this.groupMode.toString());
+            this.applyGroupView();
+        },
+
+        isWeekView() {
+            return this.groupMode == GroupMode.Week;
+        },
+
+        applyGroupView() {
+            if (this.groupMode === GroupMode.Month) {
+                this.courseStreams.set(this.course.Recordings, (s: Stream) => s.StartDate().getMonth());
+            } else {
+                this.courseStreams.set(this.course.Recordings, (s: Stream) => this.getTrueWeek(s.GetWeekNumber(this.dateOfFirstWeek)));
+            }
+        },
+
+        /**
+         * Maps the difference in Weeks between any lecture and the first lecture to the true week count ignoring weeks without lectures (e.g. Christmas Break)
+         */
+        initializeWeekMap() {
+            let latestWeek = 1;
+            this.course.Recordings.sort(this.sortFn(StreamSortMode.OldestFirst)).forEach((s : Stream, i : number) => {
+                if (i === 0) {
+                    this.dateOfFirstWeek = s.StartDate();
+                    this.dateOfFirstWeek = new Date(this.dateOfFirstWeek.getTime() - this.dateOfFirstWeek.getDay() * 1000 * 60 * 60 * 24);
+                    this.dateOfFirstWeek.setHours(0, 1); // avoids errors e.g. in case week1 has vod on Monday at 10am, week2 at 8am
+                }
+                const week = s.GetWeekNumber(this.dateOfFirstWeek);
+                if (!this.weekCountWithoutEmptyWeeks.has(week)) {
+                    this.weekCountWithoutEmptyWeeks.set(week, latestWeek++);
+                }
+            });
+        },
+
+        getTrueWeek(n : number): number {
+            return this.weekCountWithoutEmptyWeeks.get(n);
+        },
+
+        getGroupName(s : Stream) : string {
+            if (this.groupMode === GroupMode.Month) {
+                return s.GetMonthName();
+            } else {
+                return "Week " + this.getTrueWeek(s.GetWeekNumber(this.dateOfFirstWeek)).toString();
+            }
         },
 
         /**

--- a/web/ts/components/course.ts
+++ b/web/ts/components/course.ts
@@ -78,7 +78,8 @@ export function courseContext(slug: string, year: number, term: string, userId: 
                     this.loadPinned();
                     this.plannedStreams.set(this.course.Planned.reverse()).reset();
                     this.upcomingStreams.set(this.course.Upcoming).reset();
-                    this.loadProgresses(this.course.Recordings.map((s: Stream) => s.ID)).then((progresses) => {
+                    this.loadProgresses(this.course.Recordings.map((s: Stream) => s.ID))
+                        .then((progresses) => {
                             this.course.Recordings.forEach((s: Stream, i) => (s.Progress = progresses[i]));
                         })
                         .then(() => this.initializeWeekMap())
@@ -158,14 +159,14 @@ export function courseContext(slug: string, year: number, term: string, userId: 
                 this.courseStreams.set(this.course.Recordings, (s: Stream) => s.StartDate().getMonth());
             } else {
                 this.courseStreams.set(this.course.Recordings, (s: Stream) =>
-                    this.getTrueWeek(s.GetWeekNumber(this.dateOfFirstWeek))
+                    this.getTrueWeek(s.GetWeekNumber(this.dateOfFirstWeek)),
                 );
             }
 
             // update group names
             const groups = this.courseStreams.get(
                 this.sortFn(this.streamSortMode),
-                this.filterPred(this.streamFilterMode)
+                this.filterPred(this.streamFilterMode),
             );
             this.groupNames.clear();
             for (let i = 0; i < groups.length; i++) {
@@ -185,7 +186,7 @@ export function courseContext(slug: string, year: number, term: string, userId: 
                 if (i === 0) {
                     this.dateOfFirstWeek = s.StartDate();
                     this.dateOfFirstWeek = new Date(
-                        this.dateOfFirstWeek.getTime() - this.dateOfFirstWeek.getDay() * 1000 * 60 * 60 * 24
+                        this.dateOfFirstWeek.getTime() - this.dateOfFirstWeek.getDay() * 1000 * 60 * 60 * 24,
                     );
                     this.dateOfFirstWeek.setHours(0, 1); // avoids errors e.g. in case week1 has vod on Monday at 10am, week2 at 8am
                 }
@@ -200,7 +201,7 @@ export function courseContext(slug: string, year: number, term: string, userId: 
             return this.weekCountWithoutEmptyWeeks.get(n);
         },
 
-        getGroupName(s: Stream) : string {
+        getGroupName(s: Stream): string {
             if (this.groupMode === GroupMode.Month) {
                 return s.GetMonthName();
             } else {


### PR DESCRIPTION
### Motivation and Context
See #1172.

### Description
Introduces a new button to toggle to Week View. Computes the week count as the number of weeks that have passed since the first lecture (+1 so that it starts at 1). Ignores weeks without any lecture (e.g. Christmas Break).

### Steps for Testing
Prerequisites:
- 1 Course
- 1 User

1. Navigate to course page
2. Click on Week View
3. Make sure that behavior doesn't change when using any of the other buttons in any order. 

### Screenshots
![Screenshot from 2024-11-21 09-40-29](https://github.com/user-attachments/assets/ce296481-53c1-4688-9afa-12b82b1df482)

