### PR TITLE
1404 allow deselecting chosen file during video upload

### DIFF
--- a/web/template/partial/course/manage/create-lecture-form-slides/lecture-media-slide.gohtml
+++ b/web/template/partial/course/manage/create-lecture-form-slides/lecture-media-slide.gohtml
@@ -2,25 +2,33 @@
     <div class="mb-4">
         <label x-show="formData.premiere || formData.vodup && !loading">
             <span class="text-sm text-5">Combined Video (mp4, if possible h264)</span>
-            <input type="button" class="btn mt-2" value="Deselect Files" x-on:click="updateFiles('COMB', []);document.getElementById('fileSelection').value = '';">
-            <input id="fileSelection" type="file" accept="video/mp4" class="btn tl-choose-file w-full mt-2 mx-2"
-                   x-on:change="updateFiles('COMB', Object.values($event.target.files));">
+            <label class="flex">
+                <input id="fileSelection1" type="file" accept="video/mp4" class="btn tl-choose-file mt-2 mx-2 w-full"
+                       x-on:change="updateFiles('COMB', Object.values($event.target.files));">
+                <button type="button" title="Deselect File" class="fa fa-trash mt-2 mx-2" @click="updateFiles('COMB', []);document.getElementById('fileSelection1').value = '';"></button>
+            </label>
         </label>
     </div>
 
     <div class="mb-4">
         <label x-show="formData.premiere || formData.vodup && !loading">
             <span class="text-sm text-5">Presentation Video (mp4, if possible h264)</span>
-            <input type="file" accept="video/mp4" class="btn tl-choose-file w-full mt-2 mx-2"
-                   x-on:change="updateFiles('PRES', Object.values($event.target.files))">
+            <label class="flex">
+                <input id="fileSelection2" type="file" accept="video/mp4" class="btn tl-choose-file mt-2 mx-2 w-full"
+                       x-on:change="updateFiles('PRES', Object.values($event.target.files));">
+                <button type="button" title="Deselect File" class="fa fa-trash mt-2 mx-2" @click="updateFiles('PRES', []);document.getElementById('fileSelection2').value = '';"></button>
+            </label>
         </label>
     </div>
 
     <div>
         <label x-show="formData.premiere || formData.vodup && !loading">
             <span class="text-sm text-5">Camera Video (mp4, if possible h264)</span>
-            <input type="file" accept="video/mp4" class="btn tl-choose-file w-full mt-2 mx-2"
-                   x-on:change="updateFiles('CAM', Object.values($event.target.files))">
+            <label class="flex">
+                <input id="fileSelection3" type="file" accept="video/mp4" class="btn tl-choose-file mt-2 mx-2 w-full"
+                       x-on:change="updateFiles('CAM', Object.values($event.target.files));">
+                <button type="button" title="Deselect File" class="fa fa-trash mt-2 mx-2" @click="updateFiles('CAM', []);document.getElementById('fileSelection3').value = '';"></button>
+            </label>
         </label>
     </div>
 {{end}}

--- a/web/template/partial/course/manage/create-lecture-form-slides/lecture-media-slide.gohtml
+++ b/web/template/partial/course/manage/create-lecture-form-slides/lecture-media-slide.gohtml
@@ -3,9 +3,9 @@
         <label x-show="formData.premiere || formData.vodup && !loading">
             <span class="text-sm text-5">Combined Video (mp4, if possible h264)</span>
             <label class="flex">
-                <input id="fileSelection1" type="file" accept="video/mp4" class="btn tl-choose-file mt-2 mx-2 w-full"
+                <input x-ref="fileSelection1" type="file" accept="video/mp4" class="btn tl-choose-file mt-2 mx-2 w-full"
                        x-on:change="updateFiles('COMB', Object.values($event.target.files));">
-                <button type="button" title="Deselect File" class="fa fa-trash mt-2 mx-2" @click="updateFiles('COMB', []);document.getElementById('fileSelection1').value = '';"></button>
+                <button type="button" title="Deselect File" class="fa fa-trash mt-2 mx-2" @click="updateFiles('COMB', []);$refs.fileSelection1.value = '';"></button>
             </label>
         </label>
     </div>
@@ -14,9 +14,9 @@
         <label x-show="formData.premiere || formData.vodup && !loading">
             <span class="text-sm text-5">Presentation Video (mp4, if possible h264)</span>
             <label class="flex">
-                <input id="fileSelection2" type="file" accept="video/mp4" class="btn tl-choose-file mt-2 mx-2 w-full"
+                <input x-ref="fileSelection2" type="file" accept="video/mp4" class="btn tl-choose-file mt-2 mx-2 w-full"
                        x-on:change="updateFiles('PRES', Object.values($event.target.files));">
-                <button type="button" title="Deselect File" class="fa fa-trash mt-2 mx-2" @click="updateFiles('PRES', []);document.getElementById('fileSelection2').value = '';"></button>
+                <button type="button" title="Deselect File" class="fa fa-trash mt-2 mx-2" @click="updateFiles('PRES', []);$refs.fileSelection2.value = '';"></button>
             </label>
         </label>
     </div>
@@ -25,9 +25,9 @@
         <label x-show="formData.premiere || formData.vodup && !loading">
             <span class="text-sm text-5">Camera Video (mp4, if possible h264)</span>
             <label class="flex">
-                <input id="fileSelection3" type="file" accept="video/mp4" class="btn tl-choose-file mt-2 mx-2 w-full"
+                <input x-ref="fileSelection3" type="file" accept="video/mp4" class="btn tl-choose-file mt-2 mx-2 w-full"
                        x-on:change="updateFiles('CAM', Object.values($event.target.files));">
-                <button type="button" title="Deselect File" class="fa fa-trash mt-2 mx-2" @click="updateFiles('CAM', []);document.getElementById('fileSelection3').value = '';"></button>
+                <button type="button" title="Deselect File" class="fa fa-trash mt-2 mx-2" @click="updateFiles('CAM', []);$refs.fileSelection3.value = '';"></button>
             </label>
         </label>
     </div>

--- a/web/template/partial/course/manage/create-lecture-form-slides/lecture-media-slide.gohtml
+++ b/web/template/partial/course/manage/create-lecture-form-slides/lecture-media-slide.gohtml
@@ -2,8 +2,9 @@
     <div class="mb-4">
         <label x-show="formData.premiere || formData.vodup && !loading">
             <span class="text-sm text-5">Combined Video (mp4, if possible h264)</span>
-            <input type="file" accept="video/mp4" class="btn tl-choose-file w-full mt-2 mx-2"
-                   x-on:change="updateFiles('COMB', Object.values($event.target.files))">
+            <input type="button" class="btn mt-2" value="Deselect Files" x-on:click="updateFiles('COMB', []);document.getElementById('fileSelection').value = '';">
+            <input id="fileSelection" type="file" accept="video/mp4" class="btn tl-choose-file w-full mt-2 mx-2"
+                   x-on:change="updateFiles('COMB', Object.values($event.target.files));">
         </label>
     </div>
 


### PR DESCRIPTION
### Motivation and Context
See #1404.

### Description
This PR adds buttons that remove every currently selected file from the respective file selection.

### Steps for Testing
Prerequisites:
- 1 Admin
- 1 Course

1. Log in
2. Navigate to course admin page
3. Click on Video Upload, continue, select any date, continue again.
4. See new "trashcan" buttons and test functionality by selecting and deselecting files.

### Screenshots
![Screenshot from 2024-11-21 16-59-02](https://github.com/user-attachments/assets/d9c660bf-a03f-4994-b581-4573d0d8e70d)

