### PR TITLE
enforced return after abortwithstatus

### DIFF
--- a/web/index.go
+++ b/web/index.go
@@ -178,6 +178,7 @@ func (d *IndexData) LoadLivestreams(c *gin.Context, daoWrapper dao.DaoWrapper) {
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		logger.Error("could not get current live streams", "err", err)
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"message": "Could not load current livestream from database."})
+		return
 	}
 
 	tumLiveContext := d.TUMLiveContext

--- a/web/saml.go
+++ b/web/saml.go
@@ -132,6 +132,7 @@ func configSaml(r *gin.Engine, daoWrapper dao.DaoWrapper) {
 			if len(s) == 0 || s[0] == "" {
 				logger.Error("Can't extract mwn id", "LRZ-ID", lrzID, "firstName", firstName, "lastName", lastName, "mwnID", matrNr)
 				c.AbortWithStatus(http.StatusInternalServerError)
+				return
 			}
 			matrNr = s[0]
 		}
@@ -145,6 +146,7 @@ func configSaml(r *gin.Engine, daoWrapper dao.DaoWrapper) {
 		if err != nil {
 			logger.Error("Could not upsert user", "err", err)
 			c.AbortWithStatus(http.StatusInternalServerError)
+			return
 		}
 		HandleValidLogin(c, &tools.SessionData{Userid: user.ID, SamlSubjectID: &subjectID})
 	})


### PR DESCRIPTION
### Motivation and Context
Not returning after `AbortWithStatus()` may be unwanted behavior.