### PR TITLE
Remove duplicate repository link

### DIFF
--- a/web/template/partial/info-dropdown.gohtml
+++ b/web/template/partial/info-dropdown.gohtml
@@ -34,10 +34,6 @@
                     <h6 class="text-3 font-bold text-sm">Contribute</h6>
                 </div>
                 <div class="grid gap-2 pl-7">
-                    <a class="flex text-sm font-light text-5" href="https://github.com/TUM-Dev/gocast"
-                       aria-label="GitHub">
-                        <i class="vjs-icon-github my-auto"></i>-Repository
-                    </a>
                     <a class="flex text-sm font-light text-5" href="https://github.com/TUM-Dev/gocast/issues/new?assignees=&labels=&template=bug_report.md&title="
                        aria-label="Bug report">
                         Bug report


### PR DESCRIPTION
### Motivation and Context
We have the link to repo like 3 times on the website. Its a bit overkill.