### PR TITLE
fixed schedule for streams spanning multiple days

### DIFF
--- a/web/ts/schedule.ts
+++ b/web/ts/schedule.ts
@@ -49,6 +49,14 @@ const opts = {
         const eventLocation = e.event.extendedProps.location;
         if (eventLocation !== null && eventLocation !== undefined && eventLocation !== "") {
             e.el.title = e.el.title + " Location: " + eventLocation;
+            // if stream spans multiple days and therefore item doesn't include start and end time, insert custom start to end
+            if (e.el.getElementsByClassName("fc-event-time")[0] === undefined) {
+                const timeElem = document.createElement("div")
+                timeElem.className = "fc-event-time";
+                timeElem.innerHTML = "12:00 - 12:00";
+                const parent = e.el.getElementsByClassName("fc-event-title-container")[0];
+                parent.insertBefore(timeElem, parent.children[0]);
+            }
             const locationElem = document.createElement("i");
             locationElem.innerHTML = "&#183;" + eventLocation;
             e.el.getElementsByClassName("fc-event-time")[0].appendChild(locationElem);

--- a/web/ts/schedule.ts
+++ b/web/ts/schedule.ts
@@ -51,7 +51,7 @@ const opts = {
             e.el.title = e.el.title + " Location: " + eventLocation;
             // if stream spans multiple days and therefore item doesn't include start and end time, insert custom start to end
             if (e.el.getElementsByClassName("fc-event-time")[0] === undefined) {
-                const timeElem = document.createElement("div")
+                const timeElem = document.createElement("div");
                 timeElem.className = "fc-event-time";
                 timeElem.innerHTML = "12:00 - 12:00";
                 const parent = e.el.getElementsByClassName("fc-event-title-container")[0];


### PR DESCRIPTION
### Motivation and Context
See #1484. 

### Description
If a stream spans over multiple days, the corresponding calendar item _between_ the start and end day will not have an inner element containing a start and end time. However, the function that injects the location into the calendar item will do so by appending the new location item to the time item. In the case of streams with duration >2d, the time item does not exist. This PR fixes this by manually injecting a custom time item when it doesn't exist yet.

### Steps for Testing
Prerequisites:
- 1 Admin

1. Add a scheduled stream to the database. It must end at least 2 calendar days after the start time.
2. Log in
3. Navigate to a Admin Schedule
4. See that no error is logged to the console, the left and right day/week navigation keys still work and the calendar item contains 12:00 - 12:00 as the time and a valid location.
