### PR TITLE
added mark as private to scheduled and livestreams as dropdown option.

### DIFF
--- a/web/template/partial/course/manage/lecture-management-card.gohtml
+++ b/web/template/partial/course/manage/lecture-management-card.gohtml
@@ -197,7 +197,7 @@
                             <button x-text="lectureData.private?'Make public': 'Make private'"
                                     class="block w-full px-4 py-2 text-left text-sm"
                                     @click="toggleVisibility(); closeMoreDropdown()"
-                                    x-show="lectureData.isRecording"
+                                    x-show="lectureData.isRecording || lectureData.isLiveNow || !lectureData.isPast && !lectureData.isLiveNow && !lectureData.isRecording"
                                     :class="lectureData.private?'text-gray-400 dark:hover:text-gray-500 hover:text-gray-300':'text-red-400 dark:hover:text-red-500 hover:text-red-300'">
                                 Make private
                             </button>

--- a/web/template/partial/course/manage/lecture-management-card.gohtml
+++ b/web/template/partial/course/manage/lecture-management-card.gohtml
@@ -197,7 +197,7 @@
                             <button x-text="lectureData.private?'Make public': 'Make private'"
                                     class="block w-full px-4 py-2 text-left text-sm"
                                     @click="toggleVisibility(); closeMoreDropdown()"
-                                    x-show="lectureData.isRecording || lectureData.isLiveNow || !lectureData.isPast && !lectureData.isLiveNow && !lectureData.isRecording"
+                                    x-show="lectureData.isRecording || lectureData.isLiveNow || !lectureData.isPast"
                                     :class="lectureData.private?'text-gray-400 dark:hover:text-gray-500 hover:text-gray-300':'text-red-400 dark:hover:text-red-500 hover:text-red-300'">
                                 Make private
                             </button>


### PR DESCRIPTION
### Motivation and Context
fixes issue #1341
### Description
I added the option "mark as private "that was forgotten for livestreams and scheduled lectures for admins. 

### Steps for Testing
<!-- Please describe in detail how a reviewer can test your changes. -->
Prerequisites:
- 1 Admin
- 1 Lecture: livestream or scheduled lecture
- 1 Student 

1. Log in as Admin
2. Navigate to Admin Panel 
3. Choose Lecture to mark as private  
4. Mark as private 
5. log in as a student 
6. check that the student can no longer see the private stream or private scheduled lecture 

