### PR TITLE
Only show volume overlay when volume has actually changed

### DIFF
--- a/web/ts/hotkeys.ts
+++ b/web/ts/hotkeys.ts
@@ -50,7 +50,6 @@ const handleSeek = (forward: boolean) => (player, event) => {
 const handleVolume = (up: boolean, step = 0.05) =>
     function (player) {
         const oldVolume = player.volume();
-        console.log(oldVolume);
         player.volume(clamp(player.volume() + (up ? step : -step), 0, 1));
         player.muted(false);
         // only show icon overlay when volume has actually changed

--- a/web/ts/hotkeys.ts
+++ b/web/ts/hotkeys.ts
@@ -49,8 +49,14 @@ const handleSeek = (forward: boolean) => (player, event) => {
 
 const handleVolume = (up: boolean, step = 0.05) =>
     function (player) {
+        const oldVolume = player.volume();
+        console.log(oldVolume);
         player.volume(clamp(player.volume() + (up ? step : -step), 0, 1));
         player.muted(false);
+        // only show icon overlay when volume has actually changed
+        if ((up && oldVolume < 1.) || (!up && oldVolume > 0)) {
+            return volumeIcon(up);
+        }
     };
 
 const volumeIcon = (up: boolean) => (player) =>
@@ -141,12 +147,10 @@ export const defaultOptions = {
         volumeUp: {
             match: ["ArrowUp", "Up"],
             handle: handleVolume(true),
-            icon: volumeIcon(true),
         },
         volumeDown: {
             match: ["ArrowDown", "Down"],
             handle: handleVolume(false),
-            icon: volumeIcon(false),
         },
         increasePlaybackRate: {
             match: [">"],

--- a/web/ts/hotkeys.ts
+++ b/web/ts/hotkeys.ts
@@ -53,7 +53,7 @@ const handleVolume = (up: boolean, step = 0.05) =>
         player.volume(clamp(player.volume() + (up ? step : -step), 0, 1));
         player.muted(false);
         // only show icon overlay when volume has actually changed
-        if ((up && oldVolume < 1.) || (!up && oldVolume > 0)) {
+        if ((up && oldVolume < 1) || (!up && oldVolume > 0)) {
             return volumeIcon(up);
         }
     };


### PR DESCRIPTION
### Motivation and Context
#1295. While this is not a perfect solution, it is an improvement to the status quo.

### Description
Checks if volume has actually changed and shows/doesn't show icon overlay accordingly.

### Steps for Testing
Prerequisites:
- 1 Stream/VOD

1. Navigate to the video and check if the overlays stop showing once full/no volume is reached.