### PR TITLE
restricted shown playback speeds to <= 2.0 if on safari

### DIFF
--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -156,7 +156,7 @@ export const initPlayer = function (
     const player = videojs(id, {
         liveui: true,
         fluid: fluid,
-        playbackRates: playbackSpeeds,
+        playbackRates: playbackSpeeds.filter((rate) => rate <= 2 || !videojs.browser.IS_SAFARI),
         html5: {
             reloadSourceOnError: true,
             vhs: {

--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -156,6 +156,7 @@ export const initPlayer = function (
     const player = videojs(id, {
         liveui: true,
         fluid: fluid,
+        // restrict clickable playbackRates to <= 2.0 if on Safari, because higher rates cause weird behaviour (see issue #1222)
         playbackRates: playbackSpeeds.filter((rate) => rate <= 2 || !videojs.browser.IS_SAFARI),
         html5: {
             reloadSourceOnError: true,


### PR DESCRIPTION
### Motivation and Context
#1222.

### Description
Restricts shown playback speeds to <= 2.0 if on Safari.

