### PR TITLE
added placeholder when semester page is empty

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -814,6 +814,11 @@
                             </template>
                         </article>
                     </template>
+                    <template x-if="!hasLivestreams() && !recently.hasElements() && userCourses.length == 0 && liveToday.length == 0 && !hasLivestreams()">
+                        <span class="font-semibold m-auto dark:text-white">
+                            No streams, VODs or courses to show in this semester.
+                        </span>
+                    </template>
                 </span>
             </article>
         </template>


### PR DESCRIPTION
### Motivation and Context
Closes #1561 

### Description
Show a placeholder text when there are no live or upcoming streams, recent VODs or courses for a semester.

### Steps for Testing
Prerequisites:
- add the 2025S semester by adding a new course

1. Before logging in, you should see the new text, as the 2025S should be selected by default
2. If you log in with the same user that added the course, you should see the course, but not the placeholder text

### Screenshots
![image](https://github.com/user-attachments/assets/59fb5ec2-2b79-4067-9a26-a6cc68d49dd5)

