### PR TITLE
Fix failing foreign key constraint in test course creation

### DIFF
--- a/dao/streams.go
+++ b/dao/streams.go
@@ -407,10 +407,11 @@ func (d streamsDao) CreateOrGetTestStreamAndCourse(user *model.User) (model.Stre
 // Helper method to fetch test course for current user.
 func (d streamsDao) CreateOrGetTestCourse(user *model.User) (model.Course, error) {
 	var course model.Course
-	userName := user.GetPreferredName()
-
-	if userName != "" {
-		userName += "'s "
+	var userName string
+	if user.LastName != nil {
+		userName = user.Name + " " + *user.LastName + "'s "
+	} else {
+		userName = user.Name + "'s "
 	}
 
 	// Hash the user ID to create a unique slug withouth exposing the user ID
@@ -419,6 +420,7 @@ func (d streamsDao) CreateOrGetTestCourse(user *model.User) (model.Course, error
 	hashedUserID := hex.EncodeToString(hasher.Sum(nil))
 
 	err := DB.FirstOrCreate(&course, model.Course{
+		UserID:       user.ID,
 		Name:         userName + "Test Course",
 		TeachingTerm: "W",
 		Slug:         "TEST-" + hashedUserID,


### PR DESCRIPTION
### Motivation and Context
The following error occurs when trying to create a test course because the `user_id` does not exist in the `users` table:

```JSON
"error": "Error 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (`tumlive`.`courses`, CONSTRAINT `fk_users_courses` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`))"
```

### Description
- Added required UserID field in test course creation.
- Updated the test course's name to include the user's last name