### PR TITLE
Fix dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 TUMs lecture streaming service, currently serving up to 100 courses every semester with up to 2000 active students.
 
 Features include:
-- Automatic lecture scheduling and access management coupled with [CAMPUSOnline](https://www.tugraz.at/tu-graz/organisationsstruktur/serviceeinrichtungen-und-stabsstellen/campusonline/)
+- Automatic lecture scheduling and access management coupled with [CAMPUSOnline](https://www.campusonline.tugraz.at)
 - Livestreaming from lecture halls
   - Support for Extron SMPs and automatic backup recordings on them.
   - Support for preset management on ip cameras


### PR DESCRIPTION
### Motivation and Context
There was a dead link for campusonline in the first few lines of README.md

### Description
Insert the new link

### Steps for Testing
Confirm, the link is pointing to the official website of the TU Graz by reading it and clicking it
