### PR TITLE
fix(web): blinking text on page (re)load

### DIFF
--- a/web/template/home.gohtml
+++ b/web/template/home.gohtml
@@ -814,7 +814,7 @@
                             </template>
                         </article>
                     </template>
-                    <template x-if="!hasLivestreams() && !recently.hasElements() && userCourses.length == 0 && liveToday.length == 0 && !hasLivestreams()">
+                    <template x-if="loaded && !hasLivestreams() && !recently.hasElements() && userCourses.length == 0 && liveToday.length == 0">
                         <span class="font-semibold m-auto dark:text-white">
                             No streams, VODs or courses to show in this semester.
                         </span>

--- a/web/ts/components/main.ts
+++ b/web/ts/components/main.ts
@@ -14,6 +14,8 @@ export function mainContext(year: number, term: string) {
         liveToday: [] as Course[],
         recently: new AutoPaginator<Course>([], 10, (c: Course) => c.LastRecording.FetchThumbnail()),
 
+        loaded: false,
+
         /**
          * AlpineJS init function which is called automatically in addition to 'x-init'
          */
@@ -52,6 +54,7 @@ export function mainContext(year: number, term: string) {
                     this.recently.reset().preload();
                 })
                 .finally(() => {
+                    this.loaded = true;
                     console.log("🌑 init recently", this.recently);
                     console.log("🌑 init live today", this.liveToday);
                 });


### PR DESCRIPTION
### Motivation and Context

Fixes #1591

### Description

Adds a "loaded" variable to main.ts which is set to true after courses have successfully reloaded.

### Steps for Testing

Quickly reload the home page, the text should not blink any more as mentioned in  #1591
