### PR TITLE
Fix public stream access in API/v2

### DIFF
--- a/apiv2/server/authorization.go
+++ b/apiv2/server/authorization.go
@@ -105,12 +105,8 @@ type StreamRequest interface {
 func (a *API) authorizeUserForStreamCourse(ctx context.Context, req StreamRequest) (*model.User, model.Stream, model.Course, error) {
 	stream := model.Stream{}
 	course := model.Course{}
-	user, err := a.getCurrent(ctx)
-	if err != nil {
-		return nil, stream, course, e.WithStatus(http.StatusUnauthorized, err)
-	}
 
-	stream, err = a.dao.GetStreamByID(ctx, strconv.FormatUint(uint64(req.GetStreamId()), 10))
+	stream, err := a.dao.GetStreamByID(ctx, strconv.FormatUint(uint64(req.GetStreamId()), 10))
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, stream, course, e.WithStatus(http.StatusNotFound, err)
@@ -123,8 +119,13 @@ func (a *API) authorizeUserForStreamCourse(ctx context.Context, req StreamReques
 		return nil, stream, course, e.WithStatus(http.StatusInternalServerError, err)
 	}
 
+	user, _ := a.getCurrent(ctx)
 	if !user.IsEligibleToWatchCourse(course) {
 		return nil, stream, course, e.WithStatus(http.StatusForbidden, errors.New("User is not eligible to access course content"))
+	}
+
+	if stream.Private && (user == nil || !user.IsAdminOfCourse(course)) {
+		return nil, stream, course, e.WithStatus(http.StatusForbidden, errors.New("User is not allowed to access private stream"))
 	}
 
 	return user, stream, course, nil


### PR DESCRIPTION
### Motivation and Context

Previously, to access the stream endpoints of the gRPC API you had to be logged in. Now it allows access to public and hidden streams without requiring authentication.

### Description

Fixed auth check in stream endpoint.

### Steps for Testing
Prerequisites: 1 public/hidden course with non-private stream

1. Open http://localhost:8081/api/v2/streams/{your-stream-id}. This should return 200 OK with the stream's json.
2. Try setting the course to `loggedIn` and repeat.
3. Now you should receive a `User is not eligible to access course content`-error.