### PR TITLE
Replace visibility checks with dedicated methods

### DIFF
--- a/api/courses.go
+++ b/api/courses.go
@@ -147,17 +147,17 @@ func (r coursesRoutes) getLive(c *gin.Context) {
 		courseForLiveStream, _ := r.GetCourseById(context.Background(), stream.CourseID)
 
 		// only show streams for logged-in users if they are logged in
-		if courseForLiveStream.Visibility == "loggedin" && tumLiveContext.User == nil {
+		if courseForLiveStream.IsLoggedIn() && tumLiveContext.User == nil {
 			continue
 		}
 		// only show "enrolled" streams to users which are enrolled or admins
-		if courseForLiveStream.Visibility == "enrolled" {
+		if courseForLiveStream.IsEnrolled() {
 			if !tumLiveContext.User.IsAllowedToWatchPrivateCourse(courseForLiveStream) {
 				continue
 			}
 		}
 		// Only show hidden streams to course admins
-		if courseForLiveStream.Visibility == "hidden" && (tumLiveContext.User == nil || !tumLiveContext.User.IsAdminOfCourse(courseForLiveStream)) {
+		if courseForLiveStream.IsHidden() && (tumLiveContext.User == nil || !tumLiveContext.User.IsAdminOfCourse(courseForLiveStream)) {
 			continue
 		}
 		// Only show private streams to course admins

--- a/api/download.go
+++ b/api/download.go
@@ -87,12 +87,12 @@ func (r downloadRoutes) download(c *gin.Context) {
 			_ = c.Error(dlErr)
 			return
 		}
-		if course.Visibility == "loggedin" || course.Visibility == "enrolled" {
+		if course.IsLoggedIn() || course.IsEnrolled() {
 			if tumLiveContext.User == nil {
 				_ = c.Error(dlErr)
 				return
 			}
-			if course.Visibility == "enrolled" {
+			if course.IsEnrolled() {
 				if !tumLiveContext.User.IsEligibleToWatchCourse(course) {
 					_ = c.Error(dlErr)
 					return

--- a/apiv2/server/course.go
+++ b/apiv2/server/course.go
@@ -31,17 +31,17 @@ func (a *API) GetLiveCourses(ctx context.Context, req *emptypb.Empty) (*protobuf
 		courseForLiveStream, _ := a.dao.GetCourseById(context.Background(), stream.CourseID)
 
 		// only show streams for logged-in users if they are logged in
-		if courseForLiveStream.Visibility == "loggedin" && user == nil {
+		if courseForLiveStream.IsLoggedIn() && user == nil {
 			continue
 		}
 		// only show "enrolled" streams to users which are enrolled or admins
-		if courseForLiveStream.Visibility == "enrolled" {
+		if courseForLiveStream.IsEnrolled() {
 			if !user.IsAllowedToWatchPrivateCourse(courseForLiveStream) {
 				continue
 			}
 		}
 		// Only show hidden streams to course admins
-		if courseForLiveStream.Visibility == "hidden" && (user == nil || !user.IsAdminOfCourse(courseForLiveStream)) {
+		if courseForLiveStream.IsHidden() && (user == nil || !user.IsAdminOfCourse(courseForLiveStream)) {
 			continue
 		}
 		// Only show private streams to course admins

--- a/model/course.go
+++ b/model/course.go
@@ -331,3 +331,8 @@ func (c Course) IsLoggedIn() bool {
 func (c Course) IsEnrolled() bool {
 	return c.Visibility == "enrolled"
 }
+
+// IsPublic returns true if visibility is set to 'public' and false if not
+func (c Course) IsPublic() bool {
+	return c.Visibility == "public"
+}

--- a/model/user.go
+++ b/model/user.go
@@ -285,9 +285,9 @@ func (u *User) IsAllowedToWatchPrivateCourse(course Course) bool {
 // IsEligibleToWatchCourse checks if the user is allowed to access the course
 func (u *User) IsEligibleToWatchCourse(course Course) bool {
 	if u == nil {
-		return course.Visibility == "public" || course.Visibility == "hidden"
+		return course.IsPublic() || course.IsHidden()
 	}
-	if course.Visibility == "public" || course.Visibility == "hidden" || course.Visibility == "loggedin" {
+	if course.IsPublic() || course.IsHidden() || course.IsLoggedIn() {
 		return true
 	}
 	for _, invCourse := range u.Courses {
@@ -300,7 +300,7 @@ func (u *User) IsEligibleToWatchCourse(course Course) bool {
 
 // IsEligibleToSearchForCourse is a stricter version of IsEligibleToWatchCourse; in case of hidden course, it returns true only when the user is an admin of the course
 func (u *User) IsEligibleToSearchForCourse(course Course) bool {
-	return u.IsEligibleToWatchCourse(course) && course.Visibility != "hidden" || u.IsAdminOfCourse(course)
+	return u.IsEligibleToWatchCourse(course) && !course.IsHidden() || u.IsAdminOfCourse(course)
 }
 
 func (u *User) CoursesForSemester(year int, term string, context context.Context) []Course {

--- a/tools/middlewares.go
+++ b/tools/middlewares.go
@@ -160,14 +160,15 @@ func InitCourse(wrapper dao.DaoWrapper) gin.HandlerFunc {
 			return
 		}
 		// check if course is accessible by user:
-		if course.IsPublic() || course.IsHidden() || (tumLiveContext.User != nil && tumLiveContext.User.IsEligibleToWatchCourse(course)) {
+		switch {
+		case course.IsPublic(), course.IsHidden(), tumLiveContext.User != nil && tumLiveContext.User.IsEligibleToWatchCourse(course):
 			tumLiveContext.Course = &course
 			c.Set("TUMLiveContext", tumLiveContext)
-		} else if tumLiveContext.User == nil {
+		case tumLiveContext.User == nil:
 			c.Redirect(http.StatusFound, "/login?return="+url.QueryEscape(c.Request.RequestURI))
 			c.Abort()
 			return
-		} else {
+		default:
 			c.Status(http.StatusForbidden)
 			RenderErrorPage(c, http.StatusForbidden, ForbiddenCourseAccess)
 		}

--- a/tools/middlewares.go
+++ b/tools/middlewares.go
@@ -160,7 +160,7 @@ func InitCourse(wrapper dao.DaoWrapper) gin.HandlerFunc {
 			return
 		}
 		// check if course is accessible by user:
-		if course.Visibility == "public" || course.Visibility == "hidden" || (tumLiveContext.User != nil && tumLiveContext.User.IsEligibleToWatchCourse(course)) {
+		if course.IsPublic() || course.IsHidden() || (tumLiveContext.User != nil && tumLiveContext.User.IsEligibleToWatchCourse(course)) {
 			tumLiveContext.Course = &course
 			c.Set("TUMLiveContext", tumLiveContext)
 		} else if tumLiveContext.User == nil {
@@ -217,7 +217,7 @@ func InitStream(wrapper dao.DaoWrapper) gin.HandlerFunc {
 			c.Abort()
 			return
 		}
-		if course.Visibility != "public" && course.Visibility != "hidden" {
+		if !course.IsPublic() && !course.IsHidden() {
 			if tumLiveContext.User == nil {
 				c.Redirect(http.StatusFound, "/login?return="+url.QueryEscape(c.Request.RequestURI))
 				c.Abort()
@@ -277,7 +277,7 @@ func InitStreamRealtime() realtime.SubscriptionMiddleware {
 		if stream.Private && (tumLiveContext.User == nil || !tumLiveContext.User.IsAdminOfCourse(course)) {
 			return realtime.NewError(http.StatusForbidden, "forbidden to see course")
 		}
-		if course.Visibility != "public" && course.Visibility != "hidden" {
+		if !course.IsPublic() && !course.IsHidden() {
 			if tumLiveContext.User == nil {
 				return realtime.NewError(http.StatusForbidden, "course only visible for logged in users")
 			} else if tumLiveContext.User == nil || !tumLiveContext.User.IsEligibleToWatchCourse(course) {

--- a/web/index.go
+++ b/web/index.go
@@ -189,17 +189,17 @@ func (d *IndexData) LoadLivestreams(c *gin.Context, daoWrapper dao.DaoWrapper) {
 		courseForLiveStream, _ := daoWrapper.GetCourseById(context.Background(), stream.CourseID)
 
 		// only show streams for logged in users if they are logged in
-		if courseForLiveStream.Visibility == "loggedin" && tumLiveContext.User == nil {
+		if courseForLiveStream.IsLoggedIn() && tumLiveContext.User == nil {
 			continue
 		}
 		// only show "enrolled" streams to users which are enrolled or admins
-		if courseForLiveStream.Visibility == "enrolled" {
+		if courseForLiveStream.IsEnrolled() {
 			if !tumLiveContext.User.IsAllowedToWatchPrivateCourse(courseForLiveStream) {
 				continue
 			}
 		}
 		// Only show hidden streams to admins
-		if courseForLiveStream.Visibility == "hidden" && (tumLiveContext.User == nil || tumLiveContext.User.Role != model.AdminType) {
+		if courseForLiveStream.IsHidden() && (tumLiveContext.User == nil || tumLiveContext.User.Role != model.AdminType) {
 			continue
 		}
 		var lectureHall *model.LectureHall


### PR DESCRIPTION
### Motivation and Context

- Replaced all instances of `.Visibility` with their respective methods: `.isPublic()`, `.isHidden()`, `.isEnrolled()`, `.isLoggedIn()`.