### PR TITLE
chore(deps): update golang base image in runner

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/golang:1.21-alpine3.18 as builder
+FROM amd64/golang:1.23-alpine3.22 as builder
 
 WORKDIR /go/src/github.com/TUM-Dev/gocast/runner
 COPY . .


### PR DESCRIPTION
### Motivation

Currently the runner build job is failing because our go.mod file requires Go >= 1.23.0, but the build environment is running Go 1.21.10. This PR fixes the following error in the Runner's Dockerfile:

```
 => ERROR [builder 4/5] RUN GO111MODULE=on go mod download                                                                                                                                                   0.2s
------                                                                                                                                                                                                            
 > [builder 4/5] RUN GO111MODULE=on go mod download:
0.162 go: go.mod requires go >= 1.23.0 (running go 1.21.10; GOTOOLCHAIN=local)
------

 2 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 11)
Dockerfile:6
--------------------
   4 |     COPY . .
   5 |     
   6 | >>> RUN GO111MODULE=on go mod download
   7 |     # bundle version into binary if specified in build-args, dev otherwise.
   8 |     ARG version=dev
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c GO111MODULE=on go mod download" did not complete successfully: exit code: 1
```