### PR TITLE
fix(api): sanitation of course and lecture hall fields

### DIFF
--- a/model/course.go
+++ b/model/course.go
@@ -2,8 +2,10 @@ package model
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"gorm.io/gorm"
@@ -330,4 +332,14 @@ func (c Course) IsLoggedIn() bool {
 // IsEnrolled returns true if visibility is set to 'enrolled' and false if not
 func (c Course) IsEnrolled() bool {
 	return c.Visibility == "enrolled"
+}
+
+var courseSlugRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]{1,150}$`)
+
+// BeforeSave returns an error if the course to be inserted is invalid
+func (c *Course) BeforeSave(tx *gorm.DB) (err error) {
+	if !courseSlugRegex.MatchString(c.Slug) {
+		return errors.New("invalid course slug")
+	}
+	return nil
 }

--- a/model/course_test.go
+++ b/model/course_test.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBeforeSave(t *testing.T) {
+	course := &Course{}
+	cases := []struct {
+		slug    string
+		wantErr bool
+	}{
+		{"", true},
+		{strings.Repeat("a", 300), true},
+		{"test123", false},
+		{"test_123", false},
+		{"!test", true},
+		{"\" && rm -rf /", true},
+	}
+	for _, tc := range cases {
+		course.Slug = tc.slug
+		err := course.BeforeSave(nil)
+		if err == nil && tc.wantErr {
+			t.Errorf("BeforeCreate(%q) = nil, want error", tc.slug)
+		} else if err != nil && !tc.wantErr {
+			t.Errorf("BeforeCreate(%q) = %v, want nil", tc.slug, err)
+		}
+	}
+}

--- a/model/lecture_hall.go
+++ b/model/lecture_hall.go
@@ -1,6 +1,12 @@
 package model
 
-import "gorm.io/gorm"
+import (
+	"fmt"
+	"net/netip"
+	"net/url"
+
+	"gorm.io/gorm"
+)
 
 type LectureHall struct {
 	gorm.Model
@@ -64,4 +70,30 @@ func (l *LectureHall) ToDTO() *LectureHallDTO {
 		Name:        l.Name,
 		ExternalURL: l.ExternalURL,
 	}
+}
+
+// BeforeSave returns an error if either source is invalid.
+func (l *LectureHall) BeforeSave(*gorm.DB) error {
+	_, err := netip.ParseAddr(l.CameraIP)
+	if err != nil {
+		return fmt.Errorf("invalid camera IP address: %s", l.CameraIP)
+	}
+	u, err := url.Parse(l.CombIP)
+	if err != nil {
+		return fmt.Errorf("invalid comb URL: %s", u)
+	}
+	l.CombIP = u.String() // save parsed (and urlencoded) URL to database
+
+	u, err = url.Parse(l.CamIP)
+	if err != nil {
+		return fmt.Errorf("invalid cam URL: %s", u)
+	}
+	l.CamIP = u.String()
+
+	u, err = url.Parse(l.PresIP)
+	if err != nil {
+		return fmt.Errorf("invalid pres URL: %s", u)
+	}
+	l.PresIP = u.String()
+	return nil
 }

--- a/model/lecture_hall_test.go
+++ b/model/lecture_hall_test.go
@@ -1,0 +1,1 @@
+package model

--- a/model/lecture_hall_test.go
+++ b/model/lecture_hall_test.go
@@ -1,1 +1,57 @@
 package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBeforeSaveLectureHall(t *testing.T) {
+	cases := []struct {
+		l        LectureHall
+		expected LectureHall
+		wantErr  bool
+	}{
+		{
+			l: LectureHall{
+				CameraIP: "not an ip",
+			},
+			wantErr: true,
+		},
+		{
+			l: LectureHall{
+				CameraIP: "127.0.0.almostanip",
+			},
+			expected: LectureHall{
+				CameraIP: "",
+			},
+			wantErr: true,
+		},
+		{
+			l: LectureHall{
+				CameraIP: "127.0.0.1",
+				CamIP:    "somehost/malicious\" && stuff",
+			},
+			expected: LectureHall{
+				CameraIP: "127.0.0.1",
+				CamIP:    "somehost/malicious%22%20&&%20stuff",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("BeforeSave(%+v)", tc.l), func(t *testing.T) {
+			err := tc.l.BeforeSave(nil)
+			if err != nil && !tc.wantErr {
+				t.Errorf("BeforeCreateLectureHall(%+v): got error %v, want no error", tc.l, err)
+			} else if err == nil && tc.wantErr {
+				t.Errorf("BeforeCreateLectureHall(%+v): got no error, want error", tc.l)
+			}
+			if err == nil {
+				assert.Equal(t, tc.expected, tc.l)
+			}
+		})
+	}
+}

--- a/web/template/admin/admin_tabs/create-course.gohtml
+++ b/web/template/admin/admin_tabs/create-course.gohtml
@@ -49,7 +49,7 @@
                                required
                                placeholder="eidi"
                                :class="slug === '' ? 'border-red-500 focus:border-red-500' : ''"
-                               @input="slug = slug.replace(/[^A-Za-z0-9\-_.+()~]/g, '')"/>
+                               @input="slug = slug.replace(/[^A-Za-z0-9\-_]/g, '')"/>
                     </div>
                     {{template "semester-selection"}}
                 </form>


### PR DESCRIPTION
This fixes a security issue, where a malicious lecturer or admin, or attacker who gained their access
can create a course with a slug that is injected into commands, a worker runs.

Executing just `ffmpeg` in the worker has been considered, but the worker currently relies on the shells
capability to redirect its stdout to a file.

Thanks to @oiidmnk and @lcarilla for reporting the issue!

In similar fashion to https://github.com/TUM-Dev/gocast/commit/b995a237b2246e5809e8715e21e2ed0f59882081, we want to sanitize these values because they are used
to execute commands in the worker and can be abused by admins or lecturers to run arbitrary commands