### PR TITLE
Fix typo in model/course.go

### DIFF
--- a/model/course.go
+++ b/model/course.go
@@ -337,6 +337,7 @@ func (c Course) IsEnrolled() bool {
 // IsPublic returns true if visibility is set to 'public' and false if not
 func (c Course) IsPublic() bool {
 	return c.Visibility == "public"
+}
 
 var courseSlugRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]{1,150}$`)
 


### PR DESCRIPTION
### Motivation and Context

Fix typo introduced in #1615.