### PR TITLE
feat(runner): Implement checkvod action

### DIFF
--- a/pkg/runner_manager/manager.go
+++ b/pkg/runner_manager/manager.go
@@ -69,21 +69,21 @@ func (m *Manager) TriggerDueStreams() error {
 			errs = append(errs, fmt.Errorf("RequestStream COMB: %w", err))
 			continue
 		}
-		log.With("stream", s.ID, "job", resp.JobId, "version", model.COMB).Info("started Stream")
+		log.With("stream", s.ID, "job", resp.GetJobId(), "version", model.COMB).Info("started Stream")
 
 		resp, err = m.requestStreamVersion(ctx, s, client, lh, protobuf.StreamVersion_STREAM_VERSION_PRESENTATION)
 		if err != nil && !errors.Is(err, errNotNoLectureSource) {
 			errs = append(errs, fmt.Errorf("RequestStream PRES: %w", err))
 			continue
 		}
-		log.With("stream", s.ID, "job", resp.JobId, "version", model.PRES).Info("started Stream")
+		log.With("stream", s.ID, "job", resp.GetJobId(), "version", model.PRES).Info("started Stream")
 
 		resp, err = m.requestStreamVersion(ctx, s, client, lh, protobuf.StreamVersion_STREAM_VERSION_CAMERA)
 		if err != nil && !errors.Is(err, errNotNoLectureSource) {
 			errs = append(errs, fmt.Errorf("RequestStream CAM: %w", err))
 			continue
 		}
-		log.With("stream", s.ID, "job", resp.JobId, "version", model.CAM).Info("started Stream")
+		log.With("stream", s.ID, "job", resp.GetJobId(), "version", model.CAM).Info("started Stream")
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("failed to start stream: %v", errs)

--- a/runner/config/config.go
+++ b/runner/config/config.go
@@ -14,7 +14,7 @@ var Config struct {
 	SegmentPath  string `env:"SEGMENT_PATH" envDefault:"storage/live"`
 	GocastServer string `env:"GOCAST_SERVER" envDefault:"localhost:50056"`
 	Hostname     string `env:"REALHOST" envDefault:"localhost"`
-	EdgeServer   string `env:"EDGE_SERVER" envDefault:"http://localhost:50057"`
+	EdgeServer   string `env:"EDGE_SERVER" envDefault:"http://localhost:8089"`
 }
 
 func init() {

--- a/runner/handlers.go
+++ b/runner/handlers.go
@@ -29,6 +29,7 @@ func (r *Runner) RequestStream(ctx context.Context, req *protobuf.StreamRequest)
 		actions.Stream,
 		actions.StreamEnd,
 		actions.MkVOD,
+		actions.CheckVoD,
 	}
 
 	jID := r.RunAction(a, data, r.log.With("stream_id", req.GetStreamId(), "stream_version", req.GetVersion(), "input", req.GetInput()))

--- a/runner/pkg/actions/checkvod.go
+++ b/runner/pkg/actions/checkvod.go
@@ -1,0 +1,61 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"path"
+
+	"github.com/tum-dev/gocast/runner/pkg/ffmpeg"
+	"github.com/tum-dev/gocast/runner/pkg/metrics"
+	"github.com/tum-dev/gocast/runner/protobuf"
+)
+
+// CheckVoD probes both the livestream and the VoD and checks if they are identical.
+func CheckVoD(ctx context.Context, logger *slog.Logger, _ chan *protobuf.Notification, d map[string]any, metrics *metrics.Broker) error {
+	const DurationToleranceSeconds = 10.0
+
+	streamID, ok := d["streamID"].(uint64)
+	if !ok {
+		return AbortingError(fmt.Errorf("no stream id in context"))
+	}
+	streamVersion, ok := d["streamVersion"].(string)
+	if !ok {
+		return AbortingError(fmt.Errorf("no stream version in context"))
+	}
+	recording, ok := d["recordingDir"].(string)
+	if !ok {
+		return AbortingError(fmt.Errorf("no recordingDir in context"))
+	}
+	recording = path.Join(recording, "playlist.m3u8")
+	vod, ok := d["vodPath"].(string)
+	if !ok {
+		return AbortingError(fmt.Errorf("no vodPath in context"))
+	}
+
+	isHealthy := false
+	defer func() {
+		d["vodHealthy"] = isHealthy
+		if !isHealthy {
+			metrics.ConvertingErrors.With(metrics.With().Stream(streamID).StreamVersion(streamVersion).L()).Inc()
+		}
+	}()
+
+	probe, err := ffmpeg.Probe(ctx, recording)
+	if err != nil {
+		return AbortingError(fmt.Errorf("probe livestream: %w", err))
+	}
+	liveDuration := probe.Duration()
+	probe, err = ffmpeg.Probe(ctx, vod)
+	if err != nil {
+		return AbortingError(fmt.Errorf("probe vod: %w", err))
+	}
+	vodDuration := probe.Duration()
+	if math.Abs(liveDuration-vodDuration) > DurationToleranceSeconds {
+		return AbortingError(fmt.Errorf("livestream duration (%f) and recording duration (%f) diverge by more than 10 s", liveDuration, vodDuration))
+	}
+	isHealthy = true
+	logger.With("stream", streamID, "stream_version", streamVersion).Info("CheckVoD successful")
+	return nil
+}

--- a/runner/pkg/actions/mkvod.go
+++ b/runner/pkg/actions/mkvod.go
@@ -29,7 +29,7 @@ func MkVOD(ctx context.Context, logger *slog.Logger, notify chan *protobuf.Notif
 	}
 	streamVersion, ok := d["streamVersion"].(string)
 	if !ok {
-		return AbortingError(fmt.Errorf("no stream end in context"))
+		return AbortingError(fmt.Errorf("no stream version in context"))
 	}
 	recordingDir, ok := d["recordingDir"].(string)
 	if !ok {
@@ -37,9 +37,7 @@ func MkVOD(ctx context.Context, logger *slog.Logger, notify chan *protobuf.Notif
 	}
 
 	metrics.ConvertingProgresses.With(metrics.With().Stream(streamID).L()).Inc()
-	defer func() {
-		metrics.ConvertingProgresses.With(metrics.With().Stream(streamID).L()).Dec()
-	}()
+	defer metrics.ConvertingProgresses.With(metrics.With().Stream(streamID).L()).Dec()
 
 	vodDir := path.Join(config.Config.StoragePath, fmt.Sprintf("%d", streamID), streamVersion)
 	err := os.MkdirAll(vodDir, os.ModePerm)
@@ -47,21 +45,11 @@ func MkVOD(ctx context.Context, logger *slog.Logger, notify chan *protobuf.Notif
 		return AbortingError(fmt.Errorf("create VOD directory: %w", err))
 	}
 
-	recordingContent, err := os.ReadDir(recordingDir)
+	err = convertStream(ctx, logger, streamID, path.Join(recordingDir, "playlist.m3u8"), vodDir, "playlist.m3u8")
 	if err != nil {
-		return AbortingError(fmt.Errorf("read recordingDir: %w", err))
+		return AbortingError(fmt.Errorf("convert stream: %w", err))
 	}
-
-	for _, entry := range recordingContent {
-		if entry.IsDir() {
-			logger.Warn("found dir in recordingDir, skipping", "name", entry.Name())
-			continue
-		}
-		if entry.Name() == "playlist.m3u8" {
-			err = convertStream(ctx, logger, streamID, path.Join(recordingDir, entry.Name()), vodDir, entry.Name())
-			continue
-		}
-	}
+	d["vodPath"] = path.Join(vodDir, "playlist.m3u8")
 
 	vodUrl, err := url.JoinPath(config.Config.EdgeServer, "vod", fmt.Sprintf("%d", streamID), streamVersion, "playlist.m3u8")
 	if err != nil {
@@ -81,7 +69,7 @@ func MkVOD(ctx context.Context, logger *slog.Logger, notify chan *protobuf.Notif
 
 func convertStream(ctx context.Context, logger *slog.Logger, streamID uint64, streamPath, vodDir string, playlistName string) error {
 	input := "-i " + streamPath
-	options := "-c copy -f hls -hls_time 20 -hls_playlist_type event -hls_flags append_list -hls_segment_filename " + path.Join(vodDir, "%05d.ts") + " " + path.Join(vodDir, playlistName)
+	options := "-c copy -f hls -hls_time 20 -hls_playlist_type vod -hls_flags append_list -hls_segment_filename " + path.Join(vodDir, "%05d.ts") + " " + path.Join(vodDir, playlistName)
 
 	args := strings.Split(input, " ")
 	args = append(args, strings.Split(options, " ")...)
@@ -104,11 +92,9 @@ func convertStream(ctx context.Context, logger *slog.Logger, streamID uint64, st
 	go logCmdPipe(logger, stdo, []any{"stream", streamID, "logStream", "stdout"})
 	err = command.Run()
 	if err != nil {
-		logger.Error("ffmpeg command failed", "error", err)
-	} else {
-		logger.Info("ffmpeg converting completed successfully", "stream_id", streamID)
+		return fmt.Errorf("ffmpeg failed: %w", err)
 	}
-	return err
+	return nil
 }
 
 // vodFromEventPlst modifies an HLS playlist from EVENT to VOD

--- a/runner/pkg/ffmpeg/ffmpeg.go
+++ b/runner/pkg/ffmpeg/ffmpeg.go
@@ -1,0 +1,52 @@
+package ffmpeg
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/tidwall/gjson"
+)
+
+// Duration returns the duration of the first stream in an FFProbeResult or 0
+func (r *FFProbeResult) Duration() float64 {
+	return gjson.Get(r.raw, "format.duration").Float()
+}
+
+// Codec returns the codec (e.g. h264) of an audio or video stream in an FFProbeResult or ""
+func (r *FFProbeResult) Codec(codecType string) string {
+	nStreams := gjson.Get(r.raw, "streams.#").Int()
+	for i := 0; i < int(nStreams); i++ {
+		if gjson.Get(r.raw, fmt.Sprintf("streams.%d.codec_type", i)).String() == codecType {
+			return gjson.Get(r.raw, fmt.Sprintf("streams.%d.codec_name", i)).String()
+		}
+	}
+	return ""
+}
+
+// Level returns the level of a FFProbeResult if in h264 or ""
+func (r *FFProbeResult) Level() string {
+	return gjson.Get(r.raw, "streams.0.level").String()
+}
+
+// Container returns the container(e.g. mp4, mkv, ...) of a FFProbeResult or ""
+func (r *FFProbeResult) Container() string {
+	return gjson.Get(r.raw, "format.format_name").String()
+}
+
+// FFProbeResult holds the results of a ffprobe execution
+type FFProbeResult struct {
+	raw string
+}
+
+// Probe ffprobes the given file
+func Probe(ctx context.Context, file string) (*FFProbeResult, error) {
+	out, err := exec.CommandContext(ctx, "ffprobe",
+		"-v", "quiet",
+		"-print_format", "json",
+		"-show_format", "-show_streams", file).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("execute ffprobe: %w", err)
+	}
+	return &FFProbeResult{raw: string(out)}, err
+}

--- a/runner/pkg/metrics/broker.go
+++ b/runner/pkg/metrics/broker.go
@@ -17,6 +17,7 @@ type Broker struct {
 	Streams              *prometheus.GaugeVec
 	StreamErrors         *prometheus.CounterVec
 	ConvertingProgresses *prometheus.GaugeVec
+	ConvertingErrors     *prometheus.CounterVec
 }
 
 // Option represents a functional option for configuring a Broker.
@@ -54,6 +55,12 @@ func NewBroker(options ...Option) *Broker {
 			Name:      "n_converting",
 			Help:      "Number of streams currently being converted",
 		}, []string{"stream_id"}),
+		ConvertingErrors: promauto.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "runner",
+			Subsystem: "converting",
+			Name:      "n_converting_errs",
+			Help:      "Number of failures during conversion",
+		}, []string{"stream_id", "stream_version"}),
 	}
 	for _, option := range options {
 		option(b)
@@ -96,5 +103,11 @@ func (b LabelBuilder) Stream(streamID uint64) LabelBuilder {
 // Source adds a "source" label to LabelBuilder.
 func (b LabelBuilder) Source(source string) LabelBuilder {
 	b["source"] = source
+	return b
+}
+
+// StreamVersion adds a "stream_version" label to LabelBuilder.
+func (b LabelBuilder) StreamVersion(version string) LabelBuilder {
+	b["stream_version"] = version
 	return b
 }


### PR DESCRIPTION
### Motivation and Context

Closes #1646

The intention behind this action is to verify a vod created by the `MKVod` action, fire a metric if it is unhealthy and add the health status to the jobs data for descisions about the cleanup approach in a subsequent action (unimplemented).
