### PR TITLE
fix: combined view redirect

### DIFF
--- a/web/template/partial/stream/actions.gohtml
+++ b/web/template/partial/stream/actions.gohtml
@@ -61,7 +61,7 @@
                         {{if $stream.PlaylistUrl}}
                             <a class="text-left flex justify-start items-center w-full text-3 px-4 py-2 hover:cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600"
                                title="Combined view"
-                               @click="watch.switchView('/w/{{$course.Slug}}/{{$stream.Model.ID}}')">
+                               @click="watch.switchView('/w/{{$course.Slug}}/{{$stream.Model.ID}}/COMB')">
                                 <i class="text-lg fas fa-object-group text-4 hover:text-1 w-8"></i>
                                 <span class="font-light text-sm">Combined view</span>
                             </a>


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some VODs don't have a pure presentation stream. When switching to the combined view (`COMB`) however, the user is instantly redirected to the presentation view again -> without manually changing the URL the user can't access the combined view.

https://github.com/user-attachments/assets/e7fc245d-7b24-42de-ae7d-5f3782f223c5

### Description
Add the `/COMB` path explicitly to prevent redirect back to faulty stream

### Steps for Testing
Prerequisites:
- 1 VOD without presentation such as: https://tum.live/w/WiSe25_26_CE_NetSec/66507/PRES

1. Log in
2. Open such a VOD
3. Try to change stream to "Combined view"

### Screenshots
No UI change - see video above
