### PR TITLE
Fix path to sql file used in docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 ####################################################
 # Not production ready, only for local development #
 ####################################################
-version: "3.8"
 
 services:
   tum-live:
@@ -68,7 +67,7 @@ services:
       TZ: Europe/Berlin
     command: --init-file /data/application/init.sql
     volumes:
-      - ./init.sql:/data/application/init.sql
+      - ./docs/static/tum-live-starter.sql:/data/application/init.sql
       - mariadb-data:/var/lib/mysql
     restart: always
 # Omitted for local development due to size. Comment out to use voice-service


### PR DESCRIPTION
### Motivation and Context
The DB Docker service did not function properly locally.

### Description
I fixed the sql volume path and removed the obsolete version field in the docker compose
