### PR TITLE
feat(player): reposition play button between skip controls

### DIFF
--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -220,6 +220,15 @@ export const initPlayer = function (
             streamUrl: streamUrl,
             startIn: streamStartIn,
         };
+        // Move playToggle in between the skip buttons
+        const controlBar = player.getChild("controlBar");
+        const playToggle = controlBar.getChild("playToggle");
+        controlBar.removeChild(playToggle);
+        const skipBackward = controlBar.getChild("skipBackward");
+        const skipBackwardIndex = controlBar.children().indexOf(skipBackward);
+        controlBar.addChild(playToggle, {}, skipBackwardIndex + 1);
+
+        // Apply player settings
         settings.initTrackbars(streamID);
         settings.initAirPlay();
         settings.setVolume();

--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -222,12 +222,17 @@ export const initPlayer = function (
         };
         // Move playToggle in between the skip buttons
         const controlBar = player.getChild("controlBar");
-        const playToggle = controlBar.getChild("playToggle");
-        controlBar.removeChild(playToggle);
-        const skipBackward = controlBar.getChild("skipBackward");
-        const skipBackwardIndex = controlBar.children().indexOf(skipBackward);
-        controlBar.addChild(playToggle, {}, skipBackwardIndex + 1);
-
+        if (controlBar) {
+            const playToggle = controlBar.getChild("playToggle");
+            const skipBackward = controlBar.getChild("skipBackward");
+            if (playToggle && skipBackward) {
+                const skipBackwardIndex = controlBar.children().indexOf(skipBackward);
+                if (skipBackwardIndex !== -1) {
+                    controlBar.removeChild(playToggle);
+                    controlBar.addChild(playToggle, {}, skipBackwardIndex + 1);
+                }
+            }
+        }
         // Apply player settings
         settings.initTrackbars(streamID);
         settings.initAirPlay();


### PR DESCRIPTION
### Motivation and Context

Changes in videojs changed the order of the play button and skip controls.

Fixes #1721 

### Description
This PR reverts changes in videojs by repositioning the play button between the skip button again.

### Steps for Testing
Prerequisites:
- 1 Livestream

1. Log in
2. Navigate to a Livestream
3. Start the Livestream
4. Ensure that the play button is between the skip controls

### Screenshots
<img width="804" height="455" alt="image" src="https://github.com/user-attachments/assets/f71f5993-af9d-4aaf-bb37-c5c9dce83881" />