### PR TITLE
fix: Workaround for video.js button focus issue with Space/Enter hotkeys

### DIFF
--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -246,7 +246,23 @@ export const initPlayer = function (
         settings.addOverlayIcon();
     });
     // handle hotkeys from anywhere on the page
-    document.addEventListener("keydown", (event) => player.handleKeyDown(event));
+    document.addEventListener(
+        "keydown",
+        (event) => {
+            // If Space is pressed while a control bar button is focused,
+            // blur the button to stop it from being clicked
+            // See https://github.com/videojs/video.js/issues/2669
+            if (
+                (event.key === " " || event.key === "Spacebar") &&
+                document.activeElement instanceof HTMLElement &&
+                document.activeElement.closest(".vjs-control-bar")
+            ) {
+                document.activeElement.blur();
+            }
+            player.handleKeyDown(event);
+        },
+        true,
+    );
     players.push(player);
 };
 

--- a/web/ts/TUMLiveVjs.ts
+++ b/web/ts/TUMLiveVjs.ts
@@ -229,7 +229,7 @@ export const initPlayer = function (
                 const skipBackwardIndex = controlBar.children().indexOf(skipBackward);
                 if (skipBackwardIndex !== -1) {
                     controlBar.removeChild(playToggle);
-                    controlBar.addChild(playToggle, {}, skipBackwardIndex + 1);
+                    controlBar.addChild(playToggle, {}, skipBackwardIndex);
                 }
             }
         }


### PR DESCRIPTION
### Motivation and Context
When watching a VOD and clicking on any control bar button (e.g., fullscreen), the button remains focused. Pressing Space to pause the video instead triggers a click on the focused button, causing unintended behavior (e.g., exiting fullscreen instead of pausing).
This is a known video.js bug: https://github.com/videojs/video.js/issues/2669

### Description
This PR implements a workaround for the video.js button focus issue. A document-level keydown event listener using the capture phase intercepts Space key presses before they reach the button's native handlers. When Space is pressed while a control bar button (.vjs-control-bar) is focused, the button is blurred via blur(), allowing the hotkey handler to process the key event normally.

### Steps for Testing
1. Log in
2.Navigate to a VOD stream
3.Click on the fullscreen button in the video player control bar
4.Observe the fullscreen button has a visible focus ring
5.Press the Space key
6.✅ Video should pause/play instead of toggling fullscreen

