### PR TITLE
disable gin request logs for non ok (>=400) status codes in production

### DIFF
--- a/cmd/tumlive/main.go
+++ b/cmd/tumlive/main.go
@@ -200,7 +200,7 @@ func serveHttp(ctx context.Context, manager *runner_manager.Manager, camService 
 	}
 
 	router.Use(gin.LoggerWithFormatter(func(param gin.LogFormatterParams) string {
-		if param.StatusCode >= 400 {
+		if param.StatusCode >= 400 &&  VersionTag == "development" {
 			return fmt.Sprintf("{\"service\": \"GIN\", \"time\": %s, \"status\": %d, \"client\": \"%s\", \"path\": \"%s\", \"agent\": %s}\n",
 				param.TimeStamp.Format(time.DateTime),
 				param.StatusCode,


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- disable gin request logs for non ok (>=400) status codes in production
- issue: https://github.com/TUM-Dev/gocast/issues/1701

### Description
<!-- Describe your changes in detail, what does your code do? How does it do it? -->
- Disable the logs from gin when VersionTag != "development"