### PR TITLE
fix: Allow umlaut in clourse slugs

### DIFF
--- a/model/course.go
+++ b/model/course.go
@@ -347,7 +347,7 @@ func (c *Course) IsPublic() bool {
 	return c.Visibility == "public"
 }
 
-var courseSlugRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]{1,150}$`)
+var courseSlugRegex = regexp.MustCompile(`^[a-zA-Z0-9äöüÄÖÜ\-_]{1,150}$`)
 
 // BeforeSave returns an error if the course to be inserted is invalid
 func (c *Course) BeforeSave(tx *gorm.DB) (err error) {


### PR DESCRIPTION
### Motivation and Context
Adding Umlaut to the Regexp for the course slug regex.

### Description
Enabling Umlaut as an accepted character to the compliance method, as some courses in the past used them.   


