### PR TITLE
Docs: add dev section and selfstream

### DIFF
--- a/docs_v2/docs/development/DevSetup.md
+++ b/docs_v2/docs/development/DevSetup.md
@@ -1,0 +1,104 @@
+# Development Setup
+
+
+You can checkout the [Github repository](https://github.com/TUM-Dev/gocast) to get started. Here is a quick guide to set up everything.
+
+
+## Getting Started
+
+The easiest way of running and testing TUM-Live is by using the provided docker-compose file:
+
+```bash
+docker compose build && docker compose up
+```
+Be advised that the compose file is not indented for production use as it runs everything on one machine.
+
+If you want to get TUM-Live running natively follow these steps:
+
+### Setup Database
+- Follow the steps [here](https://mariadb.com/kb/en/installing-and-using-mariadb-via-docker/) to install mariadb via docker.
+- Then run the docker container using the following command.
+```bash
+docker run --detach \
+  --name mariadb-tumlive \
+  --env MARIADB_USER=root \
+  --env MARIADB_ROOT_PASSWORD=example \
+  --restart always \
+  -p 3306:3306 \
+  --volume "$(pwd)"/tum-live-starter.sql:/init.sql \
+  mariadb:latest --init-file /init.sql
+```
+- Alternatively, install mariadb on its own.
+    - Create the database `tumlive` using [this](https://github.com/joschahenningsen/TUM-Live/files/8505487/tum-live-starter.zip) script.
+    - Or: Use [JetBrains DataGrip](https://www.jetbrains.com/datagrip/) to open the database and then run the script there to automatically set up a demo database.
+- The database contains the users `admin`, `prof1`, `prof2`, `studi1`, `studi2` and `studi3` with the password `password`.
+
+### Setup Meilisearch
+- Follow the steps [here](https://www.meilisearch.com/docs/resources/self_hosting/getting_started/docker) to set up meilisearch via docker.
+- Use `MASTER_KEY` for the `MEILI_MASTER_KEY` environment variable when starting the container. 
+
+### Install go
+
+- Install **go >=1.26** by following the steps [here](https://go.dev/doc/install)
+- Preferably use [JetBrains GoLand](https://youtu.be/vetAfxQxyJE) and open this project as it simplifies this entire process
+- Go to File -> Settings -> Go -> Go Modules and enable go modules integration.
+- Run `npm i` in the `./web` directory to install the required node modules
+- Run `go get ./...` to install the required go modules
+- If you want to customize the configuration (for example mariadb username and password), copy the `config.yaml` file over to `$HOME/.TUM-Live/config.yaml` and make your changes there to prevent accidentally committing them.
+- Start the app by building and running `./cmd/tumlive/tumlive.go`
+- Head over to `http://localhost:8081` in your browser of choice and confirm that the page has loaded without any problems.
+- To keep automatically rebuilding the frontend code during development, run the command `npm run build-dev` in `./web` (and keep it running).
+- Voilà! Happy coding! :sparkles:
+
+### Enable pre-commit hooks
+
+- Make sure you have [staticcheck](https://staticcheck.io/docs/getting-started/)
+  and [pre-commit](https://pre-commit.com/#install) installed. If you have `pip` installed on your machine, you can install them with the following command
+```bash
+go install honnef.co/go/tools/cmd/staticcheck@latest && pip install pre-commit
+```
+- Run`pre-commit install`. It will install the pre-commit hook scripts for this repository.
+
+Now the hook scripts will be triggered for every new commit, which should improve overall code quality.
+You can also run the pre-commit hooks manually for all files by executing `pre-commit run --all-files`. If you get the error message `The unauthenticated git protocol on port 9418 is no longer supported.`, try running the following command
+```bash
+git config --global url."https://github.com/".insteadOf git://github.com/
+```
+
+See [this](https://github.blog/2021-09-01-improving-git-protocol-security-github/) blogpost for more information on this error message.
+### Linting and formatting typescript files
+
+The following scripts are provided:
+
+- `npm run lint`: Runs `eslint` and `prettier` on the code to find stylistic issues.
+- `npm run lint-fix`: Same as above but also fixes the found issues.
+
+If you use GoLand, you can use follow this [guide](https://www.jetbrains.com/help/idea/prettier.html) to integrate
+prettier. There is also a [guide](https://www.jetbrains.com/help/go/eslint.html) for integrating `eslint`. For both configs are provided that should be automatically detected. If you set everything up correctly,
+`prettier` and `eslint` should run everytime you save. Additionally, GoLands formatter will now respect the `prettier`
+style rules.
+
+### Add Database Models:
+
+To create database models and their corresponding daos there is a helper script that can be used to automate this task:
+
+```shell
+go run cmd/modelGen/modelGen.go <NameOfYourModel(UpperCamelCase)>
+```
+
+### Customization
+
+An exemplary configuration can be found in `/branding`.
+
+#### logo, favicon, manifest.json
+
+For customization mount a directory containing the files in the docker container. Make sure to
+specify the location of the directory in the container in the configuration file as `paths > branding`.
+See `/config.yaml` for an exemplary configuration.
+
+#### title, description
+If intended, put a `branding.yaml` file at the same location as `config.yaml`.
+
+## Credit & Licenses
+
+- [Check out our dependencies](https://github.com/joschahenningsen/TUM-Live/network/dependencies)

--- a/docs_v2/docs/development/Selfstream.md
+++ b/docs_v2/docs/development/Selfstream.md
@@ -1,0 +1,101 @@
+---
+title: Selfstream
+---
+
+# Selfstream
+
+We first have to start all services, and then we can set up the stream.
+
+There are two ways to run Selfstream-services:
+
+## Setting up the services:
+
+### 1. **Using Docker**: 
+
+   This is the recommended way to run Selfstream, as it provides an isolated environment and simplifies the setup process. To run Selfstream using Docker, follow these steps:
+
+   ```bash
+   docker compose -f docker-compose-selfstream.yml up --build
+   ```
+
+Now you can follow the instructions in the [Starting the stream](#starting-the-stream) section to start your stream.
+
+---
+
+### 2. **Starting services locally**:
+
+:::warning
+Warning: This method doesn't insure that the services are running with the correct configuration, so it is recommended to see the logs after each service is started.
+:::
+
+If you prefer to run the services locally, you can start each service individually. This method requires more setup and configuration, but it allows for more flexibility in development. To start the services locally, follow these steps:
+
+:::info
+You have to change the `externalAuthenticationURL` in the `ingest/mediamtx.yml` file by uncommenting the the line and changing the URL to `http://localhost:8081/api/selfstream/onPublish`. This is required for the `meidamtx` server to authenticate the stream correctly.
+:::
+
+   - Start the db and meilisearch first. We use hybrid approach to run db and meilisearch in docker. You can run the following command to start them:
+
+     ```bash
+     docker start meilisearch mariadb-tumlive
+     ```
+
+   - Start the backend. run this command in the `root`
+
+     ```bash
+     go run ./cmd/tumlive
+     ```
+
+- Start the frontend:
+
+  ```bash
+  # in the web/ directory
+  
+  npm install
+  npm run buil-dev
+  ```
+
+- Start the runner. Configure the path accordingly: You can set the `STORAGE_PATH` and `SEGMENT_PATH` environment variables to point to the correct locations if you don't want to use default ones:
+
+  ```bash
+  # in the root
+     
+  STORAGE_PATH=/home/<path-to-cache-location>/storage/mass SEGMENT_PATH=/home/<path-to-cache-location>/dev/storage/live go run runner/cmd/runner/main.go
+  ```
+
+- Start the worker:
+
+  ```bash
+  # in the root
+     
+  go run ./worker/edge
+  ```
+- Start the `meidamtx` server:
+
+   ```bash
+   # in the root
+    
+   mediamtx ./ingest/mediamtx.yml
+   ```
+
+---
+
+## Starting the stream
+
+After setting up the services you can follow these instructions to start your stream. We recommend using OBS as it has been tested and also used to showcase here:
+
+1. Login to an admin account (`admin`, `prof1` or `prof2`).
+    
+    In the admin section confirm that the runner is `active` 
+
+2. In the admin section you can either create a new course or use one of the existing ones to create a new lecture. Just fill the required fields and click the create button.
+
+3. After creating the lecture you can click the `show keys` button to see the `URL` and `key`. Copy them into the streaming software of your choice.
+4. Change the `tum.ingest.live/` to `localhost/`.
+5. Start streaming, and you should see the stream in the admin section after a few seconds. You can also check the `meidamtx` logs to see if the stream is being ingested correctly.
+
+
+
+
+
+

--- a/docs_v2/docs/development/Selfstream.md
+++ b/docs_v2/docs/development/Selfstream.md
@@ -31,14 +31,16 @@ Warning: This method doesn't insure that the services are running with the corre
 If you prefer to run the services locally, you can start each service individually. This method requires more setup and configuration, but it allows for more flexibility in development. To start the services locally, follow these steps:
 
 :::info
-You have to change the `externalAuthenticationURL` in the `ingest/mediamtx.yml` file by uncommenting the the line and changing the URL to `http://localhost:8081/api/selfstream/onPublish`. This is required for the `meidamtx` server to authenticate the stream correctly.
+You have to change the `externalAuthenticationURL` in the `ingest/mediamtx.yml` file by uncommenting the the line and changing the URL to `http://localhost:8081/api/selfstream/onPublish`. This is required for the `mediamtx` server to authenticate the stream correctly.
 :::
 
    - Start the db and meilisearch first. We use hybrid approach to run db and meilisearch in docker. You can run the following command to start them:
-
-     ```bash
-     docker start meilisearch mariadb-tumlive
-     ```
+       ```bash
+       docker start meilisearch mariadb-tumlive
+       ```
+        :::info 
+        If you don't have them set up, please follow the instructions in the [DevSetup](./DevSetup.md#setup-database) guide to set them up.
+        ::: 
 
    - Start the backend. run this command in the `root`
 
@@ -52,7 +54,7 @@ You have to change the `externalAuthenticationURL` in the `ingest/mediamtx.yml` 
   # in the web/ directory
   
   npm install
-  npm run buil-dev
+  npm run build-dev
   ```
 
 - Start the runner. Configure the path accordingly: You can set the `STORAGE_PATH` and `SEGMENT_PATH` environment variables to point to the correct locations if you don't want to use default ones:
@@ -70,7 +72,7 @@ You have to change the `externalAuthenticationURL` in the `ingest/mediamtx.yml` 
      
   go run ./worker/edge
   ```
-- Start the `meidamtx` server:
+- Start the `mediamtx` server:
 
    ```bash
    # in the root

--- a/docs_v2/docs/development/Selfstream.md
+++ b/docs_v2/docs/development/Selfstream.md
@@ -94,7 +94,7 @@ After setting up the services you can follow these instructions to start your st
 
 3. After creating the lecture you can click the `show keys` button to see the `URL` and `key`. Copy them into the streaming software of your choice.
 4. Change the `tum.ingest.live/` to `localhost/`.
-5. Start streaming, and you should see the stream in the admin section after a few seconds. You can also check the `meidamtx` logs to see if the stream is being ingested correctly.
+5. Start streaming, and you should see the stream in the admin section after a few seconds. You can also check the `mediamtx` logs to see if the stream is being ingested correctly.
 
 
 

--- a/docs_v2/docs/development/Upload.md
+++ b/docs_v2/docs/development/Upload.md
@@ -1,0 +1,22 @@
+# Uploading a video
+
+To upload a video, you can use the `docker-compose-selfstreawm.yml` file to start all the services required for the upload process.
+
+## Starting the services
+
+1. in vod-service.go change the port to 8080: err := http.ListenAndServe(":8080", nil)
+2. Run the following command to start the services:
+
+```bash
+docker compose -f docker-compose-selfstream.yml up --build
+```
+
+## Uploading the video
+
+1. Open the frontend in your browser at `http://localhost:8081` and navigate to a lecture or create a new one.
+2. Choose the Upload option and select continue. You have to give it a name and select the date and time of the lecture.
+3. After that, you can select the video file you want to upload and start the uploading process. 
+
+:::info
+Check the logs as you are uploading the video
+:::

--- a/docs_v2/docs/development/_category_.json
+++ b/docs_v2/docs/development/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Development",
+  "position": 5,
+  "link": {
+    "type": "generated-index",
+    "description": "Set up your development environment and learn how to contribute to the project."
+  }
+}

--- a/docs_v2/docs/development/index.md
+++ b/docs_v2/docs/development/index.md
@@ -1,0 +1,7 @@
+---
+title: Development
+---
+
+# Development
+
+This section provides information on how to set up the development environment and contribute to the project.


### PR DESCRIPTION
### Motivation and Context
A new section dedicated for development and contributing to the project. Like from setting up the project, running services and more.

Closes #1653

### Description
Added a development section and a selfstream page for setting up everything locally and running the services using docker or local. 

### Steps for Testing
Prerequisites:
- npm


1. Navigate to docs_v2 folder
2. run `npm install` and then `npm run start`

### Screenshots
<img width="1919" height="912" alt="stream page" src="https://github.com/user-attachments/assets/8b04c017-65d8-4386-81f0-1086b57fed4b" />

