### PR TITLE
Local Selfstreams with Docker Compose

### DIFF
--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -32,5 +32,7 @@ FROM alpine:3.23
 RUN apk add --no-cache tzdata openssl
 WORKDIR /app
 COPY --from=build-env /go/bin/tumlive .
-RUN sed -i 's|ingestbase: rtmp://ingest.tum.live/|ingestbase: rtmp://ingest/|' /etc/TUM-Live/config.yaml
+RUN RUN while IFS= read -r line; do \
+        echo "${line//rtmp:\/\/ingest.tum.live\//rtmp:\/\/ingest/}"; \
+        done < /etc/TUM-Live/config.yaml > /etc/TUM-Live/config.yaml.tmp && mv /etc/TUM-Live/config.yaml.tmp /etc/TUM-Live/config.yaml
 CMD ["sh", "-c", "sleep 3 && ./tumlive"]

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,0 +1,36 @@
+FROM node:25 AS node
+
+WORKDIR /app
+COPY web web
+
+## remove generated files in case the developer build with npm before
+RUN rm -rf web/assets/ts-dist &&\
+    rm -rf web/assets/css-dist
+
+WORKDIR /app/web
+RUN npm i --no-dev
+
+FROM golang:1.26 AS build-env
+
+RUN mkdir /gostuff
+WORKDIR /gostuff
+COPY go.mod go.sum ./
+
+# Get dependencies - will also be cached if we won't change mod/sum
+RUN go mod download
+
+WORKDIR /go/src/app
+COPY . .
+COPY --from=node /app/web/assets ./web/assets
+COPY --from=node /app/web/node_modules ./web/node_modules
+
+# bundle version into binary if specified in build-args, dev otherwise.
+ARG version=dev
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-w -extldflags '-static' -X main.VersionTag=${version}" -o /go/bin/tumlive cmd/tumlive/main.go
+
+FROM alpine:3.23
+RUN apk add --no-cache tzdata openssl
+WORKDIR /app
+COPY --from=build-env /go/bin/tumlive .
+RUN sed -i 's|ingestbase: rtmp://ingest.tum.live/|ingestbase: rtmp://ingest/|' /etc/TUM-Live/config.yaml
+CMD ["sh", "-c", "sleep 3 && ./tumlive"]

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -32,7 +32,7 @@ FROM alpine:3.23
 RUN apk add --no-cache tzdata openssl
 WORKDIR /app
 COPY --from=build-env /go/bin/tumlive .
-RUN RUN while IFS= read -r line; do \
+RUN while IFS= read -r line; do \
         echo "${line//rtmp:\/\/ingest.tum.live\//rtmp:\/\/ingest/}"; \
         done < /etc/TUM-Live/config.yaml > /etc/TUM-Live/config.yaml.tmp && mv /etc/TUM-Live/config.yaml.tmp /etc/TUM-Live/config.yaml
 CMD ["sh", "-c", "sleep 3 && ./tumlive"]

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -32,7 +32,6 @@ FROM alpine:3.23
 RUN apk add --no-cache tzdata openssl
 WORKDIR /app
 COPY --from=build-env /go/bin/tumlive .
-RUN while IFS= read -r line; do \
-        echo "${line//rtmp:\/\/ingest.tum.live\//rtmp:\/\/ingest/}"; \
-        done < /etc/TUM-Live/config.yaml > /etc/TUM-Live/config.yaml.tmp && mv /etc/TUM-Live/config.yaml.tmp /etc/TUM-Live/config.yaml
+COPY config.yaml /etc/TUM-Live/config.yaml
+RUN sed -i 's|ingestbase: rtmp://ingest.tum.live/|ingestbase: rtmp://ingest/|' /etc/TUM-Live/config.yaml
 CMD ["sh", "-c", "sleep 3 && ./tumlive"]

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -77,6 +77,7 @@ services:
       - ./tum-live-starter.sql:/data/application/init.sql
       - mariadb-data:/var/lib/mysql
     restart: always
+    network_mode: host
 # Omitted for local development due to size. Comment out to use voice-service
 #  voice-service:
 #    container_name: tum-live-voice-service

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -60,7 +60,6 @@ services:
       - "8089:8089"
     volumes:
       - vod:/vod
-    network_mode: host
   db:
     container_name: mariadb_container
     image: mariadb

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -86,3 +86,4 @@ volumes:
   vod:
   mariadb-data:
   runner_data:
+  mass:

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -25,7 +25,7 @@ services:
       #- vod-service    # Omitted for local development due to size. Comment out to use voice-service
     build:
       context: runner/
-      dockerfile: runner/Dockerfile-local
+      dockerfile: Dockerfile
     platform: linux/amd64
     environment:
       - STORAGE_PATH=/storage/mass
@@ -33,6 +33,14 @@ services:
     volumes:
       - runner_data:/storage/live
       - vod:/storage/mass
+    network_mode: host
+  ingest:
+    container_name: tum-live-ingest
+      #- vod-service    # Omitted for local development due to size. Comment out to use voice-service
+    build:
+      context: ingest/
+      dockerfile: Dockerfile-local
+    platform: linux/amd64
     network_mode: host
   edge:
     container_name: tum-live-edge

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -6,8 +6,10 @@ services:
   tum-live:
     container_name: tum-live
     depends_on:
-      - db
-      - meili-internal
+      db:
+        condition: service_started
+      meili-internal:
+        condition: service_healthy
     build:
       context: .
       dockerfile: Dockerfile-local
@@ -27,8 +29,8 @@ services:
       test: [ "CMD-SHELL", "nc -z localhost 8081 || exit 1" ]
       interval: 5s
       timeout: 3s
-      retries: 5
-      start_period: 5s # Gibt dem Dienst Zeit zum Booten
+      retries: 15
+      start_period: 60s # Gibt dem Dienst Zeit zum Booten
   runner:
     container_name: tum-live-runner
     depends_on:
@@ -87,7 +89,36 @@ services:
       - ./tum-live-starter.sql:/data/application/init.sql
       - mariadb-data:/var/lib/mysql
     restart: always
-
+  worker:
+    container_name: tum-live-worker
+    depends_on:
+      runner:
+        condition: service_started
+      #- vod-service    # Omitted for local development due to size. Comment out to use voice-service
+    build: worker
+    platform: linux/amd64
+    environment:
+      - Token=abc
+      - Host=worker
+      - MainBase=tum-live
+      - VodURLTemplate=http://localhost:8089/vod/%s.mp4/playlist.m3u8
+      - LrzUploadUrl=http://vod-service:8080
+      - DEBUG-MODE=true
+    volumes:
+      - recordings:/recordings
+      - mass:/mass
+  vod-service:
+    container_name: tum-live-vod-service
+    depends_on:
+      runner:
+        condition: service_started
+    build:
+        context: vod-service
+        dockerfile: Dockerfile-local
+    environment:
+      - OUTPUT_DIR=/vod
+    volumes:
+      - vod:/vod
   meili-internal:        # Service-Name geändert
     image: getmeili/meilisearch:latest
     # KEIN container_name! (Docker generiert einen eindeutigen Namen)
@@ -99,6 +130,12 @@ services:
       - MEILI_NO_ANALYTICS=true
     volumes:
       - meili_gocast_data:/meili_data # Eigener Volume-Name
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -q --spider http://127.0.0.1:7700/health || exit 1" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
 # Omitted for local development due to size. Comment out to use voice-service
 #  voice-service:
 #    container_name: tum-live-voice-service
@@ -117,3 +154,4 @@ volumes:
   runner_data:
   mass:
   meili_gocast_data:
+  recordings:

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -32,7 +32,7 @@ services:
       - SEGMENT_PATH=/storage/live
       - REALHOST=runner
       - "EDGE_SERVER=http://localhost:8089"
-      - "GOCAST_SERVER=http://tum-live:8081"
+      - "GOCAST_SERVER=tum-live:50056"
     volumes:
       - runner_data:/storage/live
       - vod:/storage/mass

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -32,6 +32,7 @@ services:
       - SEGMENT_PATH=/storage/live
       - REALHOST=runner
       - "EDGE_SERVER=http://localhost:8089"
+      - "GOCAST_SERVER=http://tum-live:8081"
     volumes:
       - runner_data:/storage/live
       - vod:/storage/mass

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -7,6 +7,7 @@ services:
     container_name: tum-live
     depends_on:
       - db
+      - meili-internal
     build:
       context: .
       dockerfile: Dockerfile-local
@@ -20,8 +21,8 @@ services:
       - TZ=Europe/Berlin
     ports:
       - "8081:8081"
-    #extra_hosts:       # Only needed if you use wsl
-    #  - "localhost:host-gateway"
+    extra_hosts:       # Only needed if you use wsl
+      - "localhost:host-gateway"
     healthcheck:
       test: [ "CMD-SHELL", "nc -z localhost 8081 || exit 1" ]
       interval: 5s
@@ -49,8 +50,8 @@ services:
       - vod:/storage/mass
     ports:
       - "52735:52735"
-    #extra_hosts:      # Only needed if you use wsl
-    #  - "ingest.tum.live:host-gateway"
+    extra_hosts:      # Only needed if you use wsl
+      - "ingest.tum.live:host-gateway"
   ingest:
     container_name: tum-live-ingest
       #- vod-service    # Omitted for local development due to size. Comment out to use voice-service
@@ -86,6 +87,18 @@ services:
       - ./tum-live-starter.sql:/data/application/init.sql
       - mariadb-data:/var/lib/mysql
     restart: always
+
+  meili-internal:        # Service-Name geändert
+    image: getmeili/meilisearch:latest
+    # KEIN container_name! (Docker generiert einen eindeutigen Namen)
+    ports:
+      - "7700:7700"     # Extern 7701 nutzen, um Konflikt mit 7700 zu vermeiden
+    environment:
+      - MEILI_HTTP_ADDR=0.0.0.0:7700
+      - MEILI_MASTER_KEY=MASTER_KEY
+      - MEILI_NO_ANALYTICS=true
+    volumes:
+      - meili_gocast_data:/meili_data # Eigener Volume-Name
 # Omitted for local development due to size. Comment out to use voice-service
 #  voice-service:
 #    container_name: tum-live-voice-service
@@ -103,3 +116,4 @@ volumes:
   mariadb-data:
   runner_data:
   mass:
+  meili_gocast_data:

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -25,7 +25,7 @@ services:
       #- vod-service    # Omitted for local development due to size. Comment out to use voice-service
     build:
       context: runner/
-      dockerfile: Dockerfile-local
+      dockerfile: runner/Dockerfile-local
     platform: linux/amd64
     environment:
       - STORAGE_PATH=/storage/mass

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -14,7 +14,7 @@ services:
       - mass:/mass
     restart: always
     environment:
-      - DBHOST=localhost
+      - DBHOST=db
       - TZ=Europe/Berlin
     ports:
       - "8081:8081"

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -7,7 +7,9 @@ services:
     container_name: tum-live
     depends_on:
       - db
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile-local
     volumes:
       - ./config.yaml:/etc/TUM-Live/config.yaml
       - ./branding/branding.yaml:/etc/TUM-Live/branding.yaml

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -16,7 +16,8 @@ services:
     environment:
       - DBHOST=localhost
       - TZ=Europe/Berlin
-    network_mode: host
+    ports:
+      - "8081:8081"
   runner:
     container_name: tum-live-runner
     depends_on:
@@ -29,10 +30,13 @@ services:
     environment:
       - STORAGE_PATH=/storage/mass
       - SEGMENT_PATH=/storage/live
+      - REALHOST=runner
+      - "EDGE_SERVER=http://localhost:8089"
     volumes:
       - runner_data:/storage/live
       - vod:/storage/mass
-    network_mode: host
+    ports:
+      - "52735:52735"
   ingest:
     container_name: tum-live-ingest
       #- vod-service    # Omitted for local development due to size. Comment out to use voice-service
@@ -40,7 +44,8 @@ services:
       context: ingest/
       dockerfile: Dockerfile-local
     platform: linux/amd64
-    network_mode: host
+    ports:
+      - "1935:1935"
   edge:
     container_name: tum-live-edge
     depends_on:
@@ -48,20 +53,10 @@ services:
     build: worker/edge
     environment:
       - VOD_DIR=/vod
-      - MAIN_INSTANCE=http://localhost:8081
+      - MAIN_INSTANCE=http://tum-live:8081
       - ADMIN_TOKEN=123
     ports:
       - "8089:8089"
-    volumes:
-      - vod:/vod
-    network_mode: host
-  vod-service:
-    container_name: tum-live-vod-service
-    depends_on:
-      - tum-live
-    build: vod-service
-    environment:
-      - OUTPUT_DIR=/vod
     volumes:
       - vod:/vod
     network_mode: host
@@ -77,7 +72,6 @@ services:
       - ./tum-live-starter.sql:/data/application/init.sql
       - mariadb-data:/var/lib/mysql
     restart: always
-    network_mode: host
 # Omitted for local development due to size. Comment out to use voice-service
 #  voice-service:
 #    container_name: tum-live-voice-service

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -8,8 +8,6 @@ services:
     depends_on:
       - db
     build: .
-    ports:
-      - "8081:8081"
     volumes:
       - ./config.yaml:/etc/TUM-Live/config.yaml
       - ./branding/branding.yaml:/etc/TUM-Live/branding.yaml
@@ -18,6 +16,7 @@ services:
     environment:
       - DBHOST=db
       - TZ=Europe/Berlin
+    network_mode: host
   runner:
     container_name: tum-live-runner
     depends_on:

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -48,7 +48,7 @@ services:
     build: worker/edge
     environment:
       - VOD_DIR=/vod
-      - MAIN_INSTANCE=http://tum-live:8081
+      - MAIN_INSTANCE=http://localhost:8081
       - ADMIN_TOKEN=123
     ports:
       - "8089:8089"

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -1,0 +1,89 @@
+####################################################
+# Not production ready, only for local development #
+####################################################
+
+services:
+  tum-live:
+    container_name: tum-live
+    depends_on:
+      - db
+    build: .
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./config.yaml:/etc/TUM-Live/config.yaml
+      - ./branding/branding.yaml:/etc/TUM-Live/branding.yaml
+      - mass:/mass
+    restart: always
+    environment:
+      - DBHOST=db
+      - TZ=Europe/Berlin
+  runner:
+    container_name: tum-live-runner
+    depends_on:
+      - tum-live
+      #- vod-service    # Omitted for local development due to size. Comment out to use voice-service
+    build:
+      context: runner/
+      dockerfile: Dockerfile-local
+    platform: linux/amd64
+    environment:
+      - STORAGE_PATH=/storage/mass
+      - SEGMENT_PATH=/storage/live
+    volumes:
+      - runner_data:/storage/live
+      - vod:/storage/mass
+    network_mode: host
+  edge:
+    container_name: tum-live-edge
+    depends_on:
+      - tum-live
+    build: worker/edge
+    environment:
+      - VOD_DIR=/vod
+      - MAIN_INSTANCE=http://tum-live:8081
+      - ADMIN_TOKEN=123
+    ports:
+      - "8089:8089"
+    volumes:
+      - vod:/vod
+    network_mode: host
+  vod-service:
+    container_name: tum-live-vod-service
+    depends_on:
+      - tum-live
+    build: vod-service
+    environment:
+      - OUTPUT_DIR=/vod
+    volumes:
+      - vod:/vod
+    network_mode: host
+  db:
+    container_name: mariadb_container
+    image: mariadb
+    environment:
+      MYSQL_ROOT_USER: root
+      MYSQL_ROOT_PASSWORD: example
+      TZ: Europe/Berlin
+    command: --init-file /data/application/init.sql
+    volumes:
+      - ./tum-live-starter.sql:/data/application/init.sql
+      - mariadb-data:/var/lib/mysql
+    restart: always
+# Omitted for local development due to size. Comment out to use voice-service
+#  voice-service:
+#    container_name: tum-live-voice-service
+#    image: ghcr.io/tum-dev/tum-live-voice-service:latest
+#    environment:
+#      - TRANSCRIBER=whisper
+#      - WHISPER_MODEL=tiny
+#      - MAX_WORKERS=10
+#      - DEBUG=1
+#    volumes:
+#      - mass:/mass
+
+volumes:
+  recordings:
+  mass:
+  vod:
+  mariadb-data:

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -14,7 +14,7 @@ services:
       - mass:/mass
     restart: always
     environment:
-      - DBHOST=db
+      - DBHOST=localhost
       - TZ=Europe/Berlin
     network_mode: host
   runner:

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -20,10 +20,19 @@ services:
       - TZ=Europe/Berlin
     ports:
       - "8081:8081"
+    #extra_hosts:       # Only needed if you use wsl
+    #  - "localhost:host-gateway"
+    healthcheck:
+      test: [ "CMD-SHELL", "nc -z localhost 8081 || exit 1" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s # Gibt dem Dienst Zeit zum Booten
   runner:
     container_name: tum-live-runner
     depends_on:
-      - tum-live
+      tum-live:
+        condition: service_healthy
       #- vod-service    # Omitted for local development due to size. Comment out to use voice-service
     build:
       context: runner/
@@ -40,6 +49,8 @@ services:
       - vod:/storage/mass
     ports:
       - "52735:52735"
+    #extra_hosts:      # Only needed if you use wsl
+    #  - "ingest.tum.live:host-gateway"
   ingest:
     container_name: tum-live-ingest
       #- vod-service    # Omitted for local development due to size. Comment out to use voice-service
@@ -52,7 +63,8 @@ services:
   edge:
     container_name: tum-live-edge
     depends_on:
-      - tum-live
+      tum-live:
+        condition: service_healthy
     build: worker/edge
     environment:
       - VOD_DIR=/vod

--- a/docker-compose-selfstream.yml
+++ b/docker-compose-selfstream.yml
@@ -83,7 +83,6 @@ services:
 #      - mass:/mass
 
 volumes:
-  recordings:
-  mass:
   vod:
   mariadb-data:
+  runner_data:

--- a/ingest/Dockerfile-local
+++ b/ingest/Dockerfile-local
@@ -5,7 +5,7 @@ FROM alpine:3.23
 ADD entrypoint.sh /entrypoint.sh
 ADD mediamtx.yml /mediamtx.yml
 RUN chmod +x /entrypoint.sh
-RUN sed -i 's|externalAuthenticationURL: https://tum.live/api/selfstream/onPublish|externalAuthenticationURL: http://localhost:8081/api/selfstream/onPublish|' /mediamtx.yml
+RUN sed -i 's|externalAuthenticationURL: https://tum.live/api/selfstream/onPublish|externalAuthenticationURL: http://tum-live:8081/api/selfstream/onPublish|' /mediamtx.yml
 
 RUN apk add --no-cache \
   ffmpeg \

--- a/ingest/Dockerfile-local
+++ b/ingest/Dockerfile-local
@@ -1,0 +1,17 @@
+FROM bluenviron/mediamtx:1.17.1 as mediamtx
+
+
+FROM alpine:3.23
+ADD entrypoint.sh /entrypoint.sh
+ADD mediamtx.yml /mediamtx.yml
+RUN chmod +x /entrypoint.sh
+RUN sed -i 's|externalAuthenticationURL: https://tum.live/api/selfstream/onPublish|externalAuthenticationURL: http://localhost:8081/api/selfstream/onPublish|' /mediamtx.yml
+
+RUN apk add --no-cache \
+  ffmpeg \
+  tzdata
+
+COPY --from=mediamtx /mediamtx /mediamtx
+RUN chmod +x /mediamtx
+
+CMD ["/entrypoint.sh"]

--- a/ingest/Dockerfile-local
+++ b/ingest/Dockerfile-local
@@ -1,6 +1,5 @@
 FROM bluenviron/mediamtx:1.17.1 as mediamtx
 
-
 FROM alpine:3.23
 ADD entrypoint.sh /entrypoint.sh
 ADD mediamtx.yml /mediamtx.yml

--- a/vod-service/Dockerfile-local
+++ b/vod-service/Dockerfile-local
@@ -1,0 +1,15 @@
+FROM golang:1.26 as builder
+
+WORKDIR /app
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /vod-service cmd/vod-service/main.go
+
+FROM alpine:3.23
+
+RUN apk add ffmpeg
+COPY --from=builder /vod-service /vod-service
+
+EXPOSE 8080
+
+CMD ["/vod-service"]


### PR DESCRIPTION
### Motivation and Context
Adding a docker compose option for running the selfstream. 

### Description
Added a docker compose file to run all services 

### Steps for Testing

1. Go to root directory
2. run the command `docker compose -f docker-compose-selfstream.yml up --build`.
3. In TUM-Live localhost:8081 make a new course and a new lecture. 
4. Copy the URL and the key in the streaming software and start the stream.

