### PR TITLE
fix: rtmp-proxy-URL

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -103,4 +103,4 @@ meili:
   apiKey: MASTER_KEY
 vodURLTemplate: https://stream.lrz.de/vod/_definst_/mp4:tum/RBG/%s.mp4/playlist.m3u8
 canonicalURL: https://tum.live
-rtmpProxyURL: https://proxy.example.com
+rtmpProxyURL: https://proxy.example.com/live


### PR DESCRIPTION
### Motivation and Context
Fixing rtmp proxy url.

### Steps for Testing
1. login to admin
2. go to token management and create a token
3. you have to see in example url: https://proxy.example.com/live
<img width="1101" height="279" alt="grafik" src="https://github.com/user-attachments/assets/40aa6c8e-f4b4-42b1-a24e-5d9f72b505f1" />
