### PR TITLE
enh: copied-tooltip

### DIFF
--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -137,6 +137,16 @@
     .primary {
         @apply bg-blue-500 text-white hover:bg-blue-600 dark:bg-indigo-600 dark:hover:bg-indigo-800;
     }
+
+    .copy-tooltip {
+        @apply pointer-events-none absolute bottom-full left-1/2 z-20 mb-2 -translate-x-1/2 whitespace-nowrap rounded bg-gray-700 px-3 py-1.5 text-sm font-normal text-white shadow-md dark:bg-gray-500;
+    }
+
+    .copy-tooltip::after {
+        content: "";
+        @apply absolute left-1/2 top-full h-2 w-2 -translate-x-1/2 -translate-y-1/2 rotate-45;
+        background-color: inherit;
+    }
 }
 
 .tl-select {

--- a/web/template/admin/admin_tabs/token.gohtml
+++ b/web/template/admin/admin_tabs/token.gohtml
@@ -1,10 +1,25 @@
-{{define "token"}}
+{{ define "token" }}
 <link rel="stylesheet" href="/static/node_modules/flatpickr/dist/flatpickr.min.css">
 <script src="/static/node_modules/flatpickr/dist/flatpickr.min.js"></script>
 
-<form class="form-container" x-data="{expires: '', scope: 'lecturer', generatedToken:null}"
-      @submit.prevent="admin.createToken(expires, scope).then(r=>r.json()).then(r => generatedToken=r.token)">
-
+<form class="form-container"
+      x-data="{
+          expires: '',
+          scope: 'lecturer',
+          generatedToken: null,
+          copied: null,
+          copyTimeout: null,
+          copyAndShow(value, key) {
+              global.copyToClipboard(value);
+              this.copied = key;
+              clearTimeout(this.copyTimeout);
+              this.copyTimeout = setTimeout(() => {
+                  this.copied = null;
+              }, 1500);
+          }
+      }"
+      @submit.prevent="admin.createToken(expires, scope).then(r => r.json()).then(r => generatedToken = r.token)">
+      
     <h1 class="form-container-title">Token Management</h1>
     <div class="form-container-body grid grid-cols-2 gap-3">
         <table class="table-auto w-full col-span-full">
@@ -18,20 +33,20 @@
             </tr>
             </thead>
             <tbody class="text-3 text-center">
-            {{range .Tokens.Tokens}}
+            {{ range .Tokens.Tokens }}
                 {{- /*gotype: github.com/TUM-Dev/gocast/web.TokensData*/ -}}
-                <tr x-data="{id: {{.Token.Model.ID}}, show:true}" x-show="show">
-                    <td class="p-4 text-left">{{if .UserMail}}{{.UserMail}}{{else}}{{.UserName}} {{.UserLrzID}}{{end}}</td>
-                    <td>{{.Scope}}</td>
-                    <td>{{if .Token.LastUse.Valid}}{{.Token.LastUse.Time.Format "02 Jan 06 15:04:05"}}{{else}}never
-                        used{{end}}</td>
-                    <td>{{if .Token.Expires.Valid}}{{.Token.Expires.Time.Format "02 Jan 06"}}{{else}}no
-                        expiration{{end}}
+                <tr x-data="{id: {{ .Token.Model.ID }}, show:true}" x-show="show">
+                    <td class="p-4 text-left">{{ if .UserMail }}{{ .UserMail }}{{ else }}{{ .UserName }} {{ .UserLrzID }}{{ end }}</td>
+                    <td>{{ .Scope }}</td>
+                    <td>{{ if .Token.LastUse.Valid }}{{ .Token.LastUse.Time.Format "02 Jan 06 15:04:05" }}{{ else }}never
+                        used{{ end }}</td>
+                    <td>{{ if .Token.Expires.Valid }}{{ .Token.Expires.Time.Format "02 Jan 06" }}{{ else }}no
+                        expiration{{ end }}
                     </td>
                     <td><a @click="admin.deleteToken(id).then(r => {if(r.status===200) show=false})"
                            class="btn block">Delete</a></td>
                 </tr>
-            {{end}}
+            {{ end }}
             </tbody>
         </table>
         <label>
@@ -43,7 +58,7 @@
             <option value="lecturer" class="text-4">
                 Scope: lecturer
             </option>
-            <option value="admin" class="text-4" x-show="role == 1" x-init="role = {{.Role}}">
+            <option value="admin" class="text-4" x-show="role == 1" x-init="role = {{ .Role }}">
                 Scope: admin
             </option>
         </select>
@@ -54,9 +69,35 @@
     <div x-show="generatedToken !== null" class="rounded-lg p-6 mb-4 text-1">
         <div class="flex items-center justify-between">
         <h3 class="text-lg font-semibold mb-2">Your Generated Token</h3>
-        <code @click="global.copyToClipboard(generatedToken)" class="block p-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer"><span x-text="generatedToken"></span></code>
+        <span class="relative inline-block">
+            <code @click="copyAndShow(generatedToken, 'generated-token-code')"
+                class="block p-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
+                <span x-text="generatedToken"></span>
+            </code>
+
+            <span x-cloak
+                x-show="copied === 'generated-token-code'"
+                role="status"
+                class="copy-tooltip">
+                Copied
+            </span>
+        </span>
         </div>
-        <p class="mb-4">This is your generated token. Please <span @click="global.copyToClipboard(generatedToken)" class="btn primary hover:bg-blue-700 text-white font-bold py-1 px-4 rounded cursor-pointer" x-init="generatedToken=generatedToken">Copy</span> it and store it securely. It will not be shown again.<br>To use this token for self-streaming, follow the instructions below:</p>
+        <p class="mb-4">This is your generated token. Please
+        <span class="relative inline-block">
+            <span @click="copyAndShow(generatedToken, 'generated-token-button')"
+                class="btn primary hover:bg-blue-700 text-white font-bold py-1 px-4 rounded cursor-pointer">
+                Copy
+            </span>
+
+            <span x-cloak
+                x-show="copied === 'generated-token-button'"
+                role="status"
+                class="copy-tooltip">
+                Copied
+            </span>
+        </span>
+        it and store it securely. It will not be shown again.<br>To use this token for self-streaming, follow the instructions below:</p>
         <p class="border-t border-gray-100 dark:border-gray-500 my-4" x-show="scope === 'lecturer'"></span>
         <div class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg" x-show="scope === 'lecturer'">
                 <div class="mb-4">
@@ -75,16 +116,36 @@
                             </ol>
                              <p class="border-t border-gray-200 dark:border-gray-500 my-4"></p>
                             <p class="mb-2">
-                                <strong>Server:</strong> 
-                                <code @click="global.copyToClipboard(`{{.Tokens.RtmpProxyURL}}`)" class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
-                                    {{.Tokens.RtmpProxyURL}}
-                                </code>
+                                <strong>Server:</strong>
+                                <span class="relative inline-block">
+                                    <code @click="copyAndShow(`{{ .Tokens.RtmpProxyURL }}`, 'obs-server')"
+                                        class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
+                                        {{ .Tokens.RtmpProxyURL }}
+                                    </code>
+
+                                    <span x-cloak
+                                        x-show="copied === 'obs-server'"
+                                        role="status"
+                                        class="copy-tooltip">
+                                        Copied
+                                    </span>
+                                </span>
                             </p>
                             <p>
-                                <strong>Stream Key:</strong> 
-                                <code @click="global.copyToClipboard(generatedToken)" class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
-                                    <span x-text="generatedToken"></span>
-                                </code> 
+                                <strong>Stream Key:</strong>
+                                <span class="relative inline-block">
+                                    <code @click="copyAndShow(generatedToken, 'obs-key')"
+                                        class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
+                                        <span x-text="generatedToken"></span>
+                                    </code>
+
+                                    <span x-cloak
+                                        x-show="copied === 'obs-key'"
+                                        role="status"
+                                        class="copy-tooltip">
+                                        Copied
+                                    </span>
+                                </span>
                             </p>
                              <p class="border-t border-gray-200 dark:border-gray-500 mt-4"></p>
                         </div>
@@ -101,15 +162,35 @@
                              <p class="border-t border-gray-200 dark:border-gray-500 my-4"></p>
                             <p class="mb-2">
                                 <strong>Stream URL:</strong> 
-                                <code @click="global.copyToClipboard(`{{.Tokens.RtmpProxyURL}}`)" class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
-                                    {{.Tokens.RtmpProxyURL}}
-                                </code>
+                                <span class="relative inline-block">
+                                    <code @click="copyAndShow(`{{ .Tokens.RtmpProxyURL }}`, 'zoom-server')"
+                                        class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
+                                        {{ .Tokens.RtmpProxyURL }}
+                                    </code>
+
+                                    <span x-cloak
+                                        x-show="copied === 'zoom-server'"
+                                        role="status"
+                                        class="copy-tooltip">
+                                        Copied
+                                    </span>
+                                </span>
                             </p>
                             <p>
                                 <strong>Stream Key:</strong> 
-                                <code @click="global.copyToClipboard(generatedToken)" class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
-                                    <span x-text="generatedToken"></span>
-                                </code> 
+                                <span class="relative inline-block">
+                                    <code @click="copyAndShow(generatedToken, 'zoom-key')"
+                                        class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
+                                        <span x-text="generatedToken"></span>
+                                    </code>
+
+                                    <span x-cloak
+                                        x-show="copied === 'zoom-key'"
+                                        role="status"
+                                        class="copy-tooltip">
+                                        Copied
+                                    </span>
+                                </span>
                             </p>
                              <p class="border-t border-gray-200 dark:border-gray-500 mt-4"></p>
                         </div>
@@ -126,15 +207,35 @@
                              <p class="border-t border-gray-200 dark:border-gray-500 my-4"></p>
                             <p class="mb-2">
                                 <strong>Stream URL:</strong> 
-                                <code @click="global.copyToClipboard(`{{.Tokens.RtmpProxyURL}}`)" class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
-                                    {{.Tokens.RtmpProxyURL}}
-                                </code>
+                                <span class="relative inline-block">
+                                    <code @click="copyAndShow(`{{ .Tokens.RtmpProxyURL }}`, 'teams-server')"
+                                        class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
+                                        {{ .Tokens.RtmpProxyURL }}
+                                    </code>
+
+                                    <span x-cloak
+                                        x-show="copied === 'teams-server'"
+                                        role="status"
+                                        class="copy-tooltip">
+                                        Copied
+                                    </span>
+                                </span>
                             </p>
                             <p>
                                 <strong>Stream Key:</strong> 
-                                <code @click="global.copyToClipboard(generatedToken)" class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
-                                    <span x-text="generatedToken"></span>
-                                </code> 
+                                <span class="relative inline-block">
+                                    <code @click="copyAndShow(generatedToken, 'teams-key')"
+                                        class="p-1 pt-2 rounded-md font-mono text-sm overflow-x-auto bg-gray-200 dark:bg-secondary cursor-pointer">
+                                        <span x-text="generatedToken"></span>
+                                    </code>
+
+                                    <span x-cloak
+                                        x-show="copied === 'teams-key'"
+                                        role="status"
+                                        class="copy-tooltip">
+                                        Copied
+                                    </span>
+                                </span>
                             </p>
                              <p class="border-t border-gray-200 dark:border-gray-500 mt-4"></p>
                         </div>
@@ -142,8 +243,8 @@
                     <p class="text-sm text-5 px-4">You can start streaming from 15 minutes before the lecture starts and up to 15 minutes after the lecture ends - TUMLive automatically finds the lecture you want to stream.</p>
                     <p class="text-sm text-5 px-4">To test your setup, you can start streaming while not in a lecture and a private test stream will be created.</p>
                 </div>
-          <p class="mt-4 italic">For more information, please refer to the <a href="{{.WikiURL}}/docs/beta/usage/self-streaming/" target="_blank" rel="noopener noreferrer" class="text-blue-500 dark:text-blue-400 hover:text-blue-700 underline">self-streaming guide</a>.</p>
+          <p class="mt-4 italic">For more information, please refer to the <a href="{{ .WikiURL }}/docs/beta/usage/self-streaming/" target="_blank" rel="noopener noreferrer" class="text-blue-500 dark:text-blue-400 hover:text-blue-700 underline">self-streaming guide</a>.</p>
         </div>
     </div>
 </form>
-{{end}}
+{{ end }}

--- a/web/template/partial/course/manage/lecture-management-card.gohtml
+++ b/web/template/partial/course/manage/lecture-management-card.gohtml
@@ -58,7 +58,7 @@
                             <span x-cloak
                                 x-show="copied === 'stream-server'"
                                 role="status"
-                                class="copy-tooltip dark:bg-indigo-600">
+                                class="copy-tooltip bg-blue-500 dark:bg-indigo-600">
                                 Copied
                             </span>
                         </span>
@@ -72,7 +72,7 @@
                             <span x-cloak
                                 x-show="copied === 'stream-key'"
                                 role="status"
-                                class="copy-tooltip dark:bg-indigo-600">
+                                class="copy-tooltip bg-blue-500 dark:bg-indigo-600">
                                 Copied
                             </span>
                         </span>

--- a/web/template/partial/course/manage/lecture-management-card.gohtml
+++ b/web/template/partial/course/manage/lecture-management-card.gohtml
@@ -23,7 +23,18 @@
                     <a :href="`/w/${lectureData.courseSlug}/${lectureData.lectureId}`"><span
                                 x-text="lectureData.startDateFormatted"></span> <i class="fas fa-external-link"></i></a>
                 </div>
-                <div class="text-3 font-sans ml-6" x-data="{ showKeys: false }">
+                <div class="text-3 font-sans ml-6"
+                    x-data="{
+                        showKeys: false,
+                        copied: null,
+                        copyTimeout: null,
+                        copyAndShow(value, key) {
+                            global.copyToClipboard(value)
+                            this.copied = key
+                            clearTimeout(this.copyTimeout)
+                            this.copyTimeout = setTimeout(() => this.copied = null, 1500)
+                        }
+                    }">
                     <span x-text="lectureData.startTimeFormatted"></span>
                     -
                     <span x-text="lectureData.endTimeFormatted"></span>
@@ -40,13 +51,31 @@
                         </span>
                         <span class="font-semibold">Stream Server:</span>
                         <span x-text="'{{$ingestBase}}{{$course.Slug}}-'+ lectureData.lectureId +'?secret=' + lectureData.streamKey"></span>
-                        <i class="fas fa-clipboard hover:text-purple-500"
-                           @click="() => global.copyToClipboard('{{$ingestBase}}{{$course.Slug}}-'+ lectureData.lectureId +'?secret=' + lectureData.streamKey)"></i>
+                        <span class="relative inline-block">
+                            <i class="fas fa-clipboard hover:text-purple-500 cursor-pointer"
+                            @click="copyAndShow('{{$ingestBase}}{{$course.Slug}}-' + lectureData.lectureId + '?secret=' + lectureData.streamKey, 'stream-server')"></i>
+
+                            <span x-cloak
+                                x-show="copied === 'stream-server'"
+                                role="status"
+                                class="copy-tooltip dark:bg-indigo-600">
+                                Copied
+                            </span>
+                        </span>
                         <br>
                         <span class="font-semibold">Stream Key:</span>
                         <span x-text="lectureData.courseSlug + '-' + lectureData.lectureId"></span>
-                        <i class="fas fa-clipboard hover:text-purple-500"
-                           @click="() => global.copyToClipboard(lectureData.courseSlug + '-' + lectureData.lectureId)"></i>
+                        <span class="relative inline-block">
+                            <i class="fas fa-clipboard hover:text-purple-500 cursor-pointer"
+                            @click="copyAndShow(lectureData.courseSlug + '-' + lectureData.lectureId, 'stream-key')"></i>
+
+                            <span x-cloak
+                                x-show="copied === 'stream-key'"
+                                role="status"
+                                class="copy-tooltip dark:bg-indigo-600">
+                                Copied
+                            </span>
+                        </span>
                         <br>
                         {{if ne $user.Role 1}}
                             <span>Want to stream from a lecture hall instead? Please reach out to the RBG.</span>


### PR DESCRIPTION
### Motivation and Context
Having a "copied" tooltip makes a better and cleaner UI.

### Description
Adding a tooltip to confirm that keys or other things got copied.

### Steps for Testing
1. login as admin
2. In admin panel, go to token management and create a new token.
3. Click on the URL and or the key and the tooltip should appear.
4. Also as you make a new stream and copy the rtmp URL and key it should appear.

NOTE: after 1.5 seconds it should disappear.

### Screenshots
<img width="565" height="293" alt="image" src="https://github.com/user-attachments/assets/0a65e607-bd27-4f59-9026-559abb658850" />
<img width="719" height="658" alt="image" src="https://github.com/user-attachments/assets/d613d70e-2b9a-457a-a760-2f7a96ef446b" />
<img width="523" height="93" alt="image" src="https://github.com/user-attachments/assets/bbfeba46-a88b-4866-8df9-98998897e93a" />

