### PR TITLE
disabled cgo in build for VOD Service

### DIFF
--- a/vod-service/Dockerfile
+++ b/vod-service/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN go build -o /vod-service cmd/vod-service/main.go
+RUN CGO_ENABLED=0 go build -o /vod-service cmd/vod-service/main.go
 
 FROM alpine:3.24
 


### PR DESCRIPTION
### Motivation and Context
fixing the vod service docker build problem
